### PR TITLE
#103 #104 - Address account service bug and fix swaggerUI to test this

### DIFF
--- a/account-service/build.gradle
+++ b/account-service/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.h2database:h2:2.2.224'
-	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/account-service/src/main/java/finos/traderx/accountservice/model/Account.java
+++ b/account-service/src/main/java/finos/traderx/accountservice/model/Account.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -17,7 +18,9 @@ public class Account implements Serializable {
 
 		@Id
 		@Column(name = "ID")
-		@GeneratedValue(strategy = GenerationType.SEQUENCE)
+		@GeneratedValue(strategy = GenerationType.SEQUENCE, generator="account_generator")
+		@SequenceGenerator(name = "account_generator", sequenceName = "ACCOUNTS_SEQ", allocationSize = 1)
+
 		private int id;
 
 		@Column(length = 50, name = "DisplayName")

--- a/account-service/src/main/resources/application.properties
+++ b/account-service/src/main/resources/application.properties
@@ -1,7 +1,4 @@
 server.port=${ACCOUNT_SERVICE_PORT:18088}
-springdoc.api-docs.path=/api-docs
-springdoc.swagger-ui.enabled=true
-springdoc.swagger-ui.disable-swagger-default-url=true
 
 spring.datasource.url=jdbc:h2:tcp://${DATABASE_TCP_HOST:localhost}:${DATABASE_TCP_PORT:18082}/${DATABASE_NAME:traderx};CASE_INSENSITIVE_IDENTIFIERS=TRUE
 spring.datasource.driverClassName=org.h2.Driver

--- a/database/initialSchema.sql
+++ b/database/initialSchema.sql
@@ -20,6 +20,7 @@ CREATE TABLE Trades ( ID Varchar (50) Primary Key, AccountID INTEGER, Created TI
 
 Alter Table Trades Add Foreign Key (AccountID) references Accounts(ID); 
 
+CREATE SEQUENCE ACCOUNTS_SEQ start with 65000 INCREMENT BY 1;
 
 --- SAMPLE DATA ---
 

--- a/position-service/build.gradle
+++ b/position-service/build.gradle
@@ -7,7 +7,7 @@
 
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '3.2.2'
+  id 'org.springframework.boot' version '3.2.0'
   id 'io.spring.dependency-management' version '1.1.4'
 }
 
@@ -30,7 +30,7 @@ dependencies {
   
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.h2database:h2:2.2.224'
-	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/position-service/build.gradle
+++ b/position-service/build.gradle
@@ -7,7 +7,7 @@
 
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '3.2.0'
+  id 'org.springframework.boot' version '3.2.2'
   id 'io.spring.dependency-management' version '1.1.4'
 }
 

--- a/position-service/src/main/resources/application.properties
+++ b/position-service/src/main/resources/application.properties
@@ -1,7 +1,4 @@
 server.port=${POSITION_SERVICE_PORT:18090}
-springdoc.api-docs.path=/api-docs
-springdoc.swagger-ui.enabled=true
-springdoc.swagger-ui.disable-swagger-default-url=true
 
 spring.datasource.url=jdbc:h2:tcp://${DATABASE_TCP_HOST:localhost}:${DATABASE_TCP_PORT:18082}/${DATABASE_NAME:traderx};CASE_INSENSITIVE_IDENTIFIERS=TRUE
 spring.datasource.driverClassName=org.h2.Driver

--- a/trade-processor/build.gradle
+++ b/trade-processor/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 	
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.h2database:h2:2.2.224'
-	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	
 	implementation('org.json:json:20231013') {
 		because 'previous versions are affected by multiple CVE'
@@ -38,8 +38,6 @@ dependencies {
 	implementation ('io.socket:socket.io-client:2.1.0'){
 		exclude group: 'org.json', module: 'json'
 	}
-   	implementation 'io.swagger.core.v3:swagger-core:2.2.20'
-	implementation 'org.yaml:snakeyaml:2.2'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/trade-processor/src/main/resources/application.properties
+++ b/trade-processor/src/main/resources/application.properties
@@ -1,6 +1,4 @@
-springdoc.api-docs.path=/api-docs
-springdoc.swagger-ui.enabled=true
-springdoc.swagger-ui.disable-swagger-default-url=true
+server.port=${TRADE_PROCESSOR_SERVICE_PORT:18091}
 
 spring.datasource.url=jdbc:h2:tcp://${DATABASE_TCP_HOST:localhost}:${DATABASE_TCP_PORT:18082}/${DATABASE_NAME:traderx};CASE_INSENSITIVE_IDENTIFIERS=TRUE
 spring.datasource.driverClassName=org.h2.Driver
@@ -12,7 +10,6 @@ spring.jpa.hibernate.ddl-auto=update
 
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 
-server.port=${TRADE_PROCESSOR_SERVICE_PORT:18091}
 trade.feed.address=${TRADE_FEED_ADDRESS:http://${TRADE_FEED_HOST:localhost}:18086}
 
 # To avoid "Request header is too large" when application is backed by oidc proxy.

--- a/trade-service/build.gradle
+++ b/trade-service/build.gradle
@@ -30,8 +30,7 @@ dependencies {
 	
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.h2database:h2:2.2.224'
-	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
-
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
 	implementation('org.json:json:20231013') {
 		because 'previous versions are affected by multiple CVE'
@@ -39,9 +38,6 @@ dependencies {
 	implementation ('io.socket:socket.io-client:2.1.0') {
 		exclude group: 'org.json', module: 'json'
 	}
-
-	implementation 'io.swagger.core.v3:swagger-core:2.2.20'
-	implementation 'io.swagger.core.v3:swagger-annotations:2.2.20'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/trade-service/src/main/resources/application.properties
+++ b/trade-service/src/main/resources/application.properties
@@ -5,10 +5,6 @@ reference.data.service.url=${REFERENCE_DATA_SERVICE_URL:http://${REFERENCE_DATA_
 
 trade.feed.address=${TRADE_FEED_ADDRESS:http://${TRADE_FEED_HOST:localhost}:18086}
 
-springdoc.api-docs.path=/api-docs
-springdoc.swagger-ui.enabled=true
-springdoc.swagger-ui.disable-swagger-default-url=true
-
 # To avoid "Request header is too large" when application is backed by oidc proxy.
 server.max-http-header-size=1000000
 


### PR DESCRIPTION
#103  - Create account was missing a sequence and therefore IDs were not being generated.  Basic sequence was added to support this

#104  - SwaggerUI regression from spring boot upgrade - has now been fixed. This was needed to test the REST services - in particular create-account service, in order to fix it.


THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS Corporate Contributor License Agreement.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.

