### PR TITLE
Upgrade to spring boot 3.3 and fix CVEs breaking the CVE scan

### DIFF
--- a/.github/node-cve-ignore-list.xml
+++ b/.github/node-cve-ignore-list.xml
@@ -1,7 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+<?xml version="1.0"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
     <suppress>
-        <notes>Erroneously reporting CVE-2024-6484 and CVE-2024-6531</notes>
-        <cpe>bootstrap:bootstrap:5.3.3</cpe>
+        <module name="web-front-end/angular">
+            <dependency>
+                <artifact>bootstrap</artifact>
+                <version>5.3.3</version>
+                <cve>CVE-2024-6484</cve>
+                <cve>CVE-2024-6531</cve>
+            </dependency>
+        </module>
     </suppress>
 </suppressions>

--- a/.github/node-cve-ignore-list.xml
+++ b/.github/node-cve-ignore-list.xml
@@ -1,13 +1,12 @@
-<?xml version="1.0"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+
     <suppress>
-        <module name="web-front-end/angular">
-            <dependency>
-                <artifact>bootstrap</artifact>
-                <version>5.3.3</version>
-                <cve>CVE-2024-6484</cve>
-                <cve>CVE-2024-6531</cve>
-            </dependency>
-        </module>
+        <cpe>cpe:/a:bootstrap:bootstrap:5.3.3</cpe>
+        <cve>CVE-2024-6484</cve>
+        <cve>CVE-2024-6531</cve>
     </suppress>
+
 </suppressions>

--- a/.github/node-cve-ignore-list.xml
+++ b/.github/node-cve-ignore-list.xml
@@ -1,3 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes>Erroneously reporting CVE-2024-6484 and CVE-2024-6531</notes>
+        <cpe>bootstrap:bootstrap:5.3.3</cpe>
+    </suppress>
 </suppressions>

--- a/account-service/build.gradle
+++ b/account-service/build.gradle
@@ -7,8 +7,8 @@
 
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '3.3.1'
-  id 'io.spring.dependency-management' version '1.1.5'
+  id 'org.springframework.boot' version '3.3.3'
+  id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'finos.traderx.account-service'
@@ -23,7 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.h2database:h2:2.2.224'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/account-service/src/main/resources/application.properties
+++ b/account-service/src/main/resources/application.properties
@@ -7,6 +7,7 @@ spring.datasource.password=${DATABASE_DBPASS:sa}
 spring.data.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.data.jpa.show-sql=true
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+spring.threads.virtual.enabled=true
 
 # To avoid "Request header is too large" when application is backed by oidc proxy.
 server.max-http-request-header-size=1000000

--- a/position-service/build.gradle
+++ b/position-service/build.gradle
@@ -7,8 +7,8 @@
 
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '3.3.1'
-  id 'io.spring.dependency-management' version '1.1.5'
+  id 'org.springframework.boot' version '3.3.3'
+  id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'finos.traderx.position-service'
@@ -23,7 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.h2database:h2:2.2.224'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/position-service/src/main/resources/application.properties
+++ b/position-service/src/main/resources/application.properties
@@ -7,6 +7,7 @@ spring.datasource.password=${DATABASE_DBPASS:sa}
 spring.data.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.data.jpa.show-sql=true
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+spring.threads.virtual.enabled=true
 
 # To avoid "Request header is too large" when application is backed by oidc proxy.
 server.max-http-request-header-size=1000000

--- a/trade-processor/build.gradle
+++ b/trade-processor/build.gradle
@@ -7,8 +7,8 @@
 
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '3.3.1'
-  id 'io.spring.dependency-management' version '1.1.5'
+  id 'org.springframework.boot' version '3.3.3'
+  id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'finos.traderx.trade-processor'
@@ -23,7 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.h2database:h2:2.2.224'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	
 	implementation('org.json:json:20240303') {
 		because 'previous versions are affected by multiple CVE'

--- a/trade-processor/src/main/resources/application.properties
+++ b/trade-processor/src/main/resources/application.properties
@@ -9,6 +9,7 @@ spring.data.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
 
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+spring.threads.virtual.enabled=true
 
 trade.feed.address=${TRADE_FEED_ADDRESS:http://${TRADE_FEED_HOST:localhost}:18086}
 

--- a/trade-service/build.gradle
+++ b/trade-service/build.gradle
@@ -7,8 +7,8 @@
 
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '3.3.1'
-  id 'io.spring.dependency-management' version '1.1.5'
+  id 'org.springframework.boot' version '3.3.3'
+  id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'finos.traderx.trade-service'
@@ -27,7 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.h2database:h2:2.2.224'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
 	implementation('org.json:json:20240303') {
 		because 'previous versions are affected by multiple CVE'

--- a/trade-service/src/main/resources/application.properties
+++ b/trade-service/src/main/resources/application.properties
@@ -1,4 +1,6 @@
 server.port=${TRADING_SERVICE_PORT:18092}
+spring.threads.virtual.enabled=true
+
 people.service.url=${PEOPLE_SERVICE_URL:http://${PEOPLE_SERVICE_HOST:localhost}:18089}
 account.service.url=${ACCOUNT_SERVICE_URL:http://${ACCOUNT_SERVICE_HOST:localhost}:18088}
 reference.data.service.url=${REFERENCE_DATA_SERVICE_URL:http://${REFERENCE_DATA_HOST:localhost}:18085}


### PR DESCRIPTION

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS Corporate Contributor License Agreement.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.


Fixed JS CVE by suppressing bootstrap, and migrated to spring boot 3.3 to address CVEs on the Spring side
Credit to @TeamModerne on the spring side as changes were made using OpenRewrite recipes for Spring boot upgrade (but the LST was outdated, so these were manually applied)