### PR TITLE
Ingress - nginx:alpine-slim

### DIFF
--- a/ingress/Dockerfile
+++ b/ingress/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM nginx:alpine-slim
 
 EXPOSE 8080
 ARG NGINX_HOST="localhost"


### PR DESCRIPTION
Before:
```
REPOSITORY              TAG       IMAGE ID       CREATED          SIZE
ingress                 latest    fbc70e10c3fd   13 minutes ago   192MB
```

After:
```
ingress                 latest    4a9a0b759eab   7 minutes ago    17.3MB
```

Saving 174.7MB on disk for the `ingress` service. It will save space and time when running `docker compose up`.