### PR TITLE
PeopleService (.NET): decrease container size and improve security posture

### DIFF
--- a/people-service/Dockerfile
+++ b/people-service/Dockerfile
@@ -1,22 +1,20 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/dotnet/.devcontainer/base.Dockerfile
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-noble AS build
+ARG TARGETARCH
+WORKDIR /source
+COPY PeopleService.WebApi/PeopleService.WebApi.csproj PeopleService.WebApi/
+COPY PeopleService.Core/PeopleService.Core.csproj PeopleService.Core/
+RUN dotnet restore PeopleService.WebApi/PeopleService.WebApi.csproj -a $TARGETARCH
+COPY PeopleService.WebApi/ PeopleService.WebApi/
+COPY PeopleService.Core/ PeopleService.Core/
 
-# [Choice] .NET version: 8.0 /8.0-bookworm, 8.0-jammy, 7.0 /7.0-bookworm, 7.0-bullseye, 7.0-jammy, 6.0 /6.0-bookworm, 6.0-bullseye, 6.0-jammy, 6.0-focal
-ARG VARIANT="8.0"
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:${VARIANT}
+FROM build AS publish
+WORKDIR /source/PeopleService.WebApi
+RUN dotnet publish PeopleService.WebApi.csproj -p:PublishSingleFile=true -a $TARGETARCH --self-contained true -c release -o /app
 
-WORKDIR /people-service
-COPY . .
-
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled
+WORKDIR /app
+COPY --from=publish /app .
 EXPOSE 18089
-
-# [Choice] Node.js version: none, lts/*, 18, 16, 14
-ARG NODE_VERSION="18"
-RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
-
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
-ENTRYPOINT cd PeopleService.WebApi && dotnet run
+ENV ASPNETCORE_HTTP_PORTS=18089
+ENV ASPNETCORE_ENVIRONMENT=Development
+ENTRYPOINT ["./PeopleService.WebApi"]

--- a/people-service/README.md
+++ b/people-service/README.md
@@ -26,4 +26,4 @@ Visit the forwarded port `/swagger` to open the SwaggerUI.
 
 Example URL:
 
-`/People/GetPerson?LoginId=user01`
+`/People/GetPerson?LogonId=user01`


### PR DESCRIPTION
For the PeopleService (.NET) container: decrease container size and improve security posture: from `1.53GB` to `111MB`  uncompressed on disk (-1.4GB saved) --> saving time to build and run the container (locally and on Kubernetes).

Towards helping for this https://github.com/finos/traderX/issues/231.

On a security standpoint, by using the multi-stage build approach and having a `distroless` base image (`noble-chiseled`), this is also reducing the number of packages included in the container: with Syft, from 4,064 packages to 10 packages:
```
NAME             VERSION                  TYPE   
base-files       13ubuntu10.1             deb     
ca-certificates  20240203                 deb     
gcc-14           14.2.0-4ubuntu2~24.04    deb     
gcc-14-base      14.2.0-4ubuntu2~24.04    deb     
libc6            2.39-0ubuntu8.3          deb     
libgcc-s1        14.2.0-4ubuntu2~24.04    deb     
libssl3t64       3.0.13-0ubuntu3.4        deb     
libstdc++6       14.2.0-4ubuntu2~24.04    deb     
openssl          3.0.13-0ubuntu3.4        deb     
zlib1g           1:1.3.dfsg-3.1ubuntu2.1  deb
```

Which is consequently reducing the number of CVEs too, with Trivy, from 1051 to 3:
```
peopleservice:before (debian 12.8):
Total: 1051 (UNKNOWN: 25, LOW: 364, MEDIUM: 567, HIGH: 92, CRITICAL: 3)

peopleservice:after (ubuntu 24.04):
Total: 3 (UNKNOWN: 0, LOW: 3, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

Tested locally with this new Dockerfile:
```bash
cd people-service
docker build -t peopleservice:after .
docker run -d -p 8080:18089 peopleservice:after
curl http://localhost:8080/People/GetPerson?LogonId=user01
```
Getting a successful response:
```
{"logonId":"user01","fullName":"Alice Johnson","email":"alice.johnson@example.com","employeeId":"E0001","department":"HR","photoUrl":"https://example.com/pthotos/user01.jpg"}
```