### PR TITLE
Optimize `position-service` (Java) Dockerfile

### DIFF
--- a/position-service/Dockerfile
+++ b/position-service/Dockerfile
@@ -1,19 +1,10 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/java/.devcontainer/base.Dockerfile
-
-# [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11, 17, 11-bullseye, 17-bullseye, 11-buster, 17-buster
-ARG VARIANT="21"
-FROM mcr.microsoft.com/vscode/devcontainers/java:1-${VARIANT} AS build-stage
-
-# Copy code
-WORKDIR /position-service
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk AS build-stage
+WORKDIR /app
 COPY . .
-
-# Build code
 RUN ./gradlew build
 
-FROM mcr.microsoft.com/openjdk/jdk:${VARIANT}-ubuntu
+FROM eclipse-temurin:21-jre-alpine
 RUN mkdir /app
-COPY --from=build-stage /position-service/build/libs/*.jar /app/position-service.jar
+COPY --from=build-stage /app/build/libs/*.jar /app/position-service.jar
 EXPOSE 18090
-# ENTRYPOINT ./gradlew bootRun
 ENTRYPOINT ["java","-jar","/app/position-service.jar"]


### PR DESCRIPTION
Optimize `position-service` (Java) Dockerfile.

Continuity of https://github.com/finos/traderX/pull/232, towards helping for this https://github.com/finos/traderX/issues/231.

Note: this is moving from `openjdk` to `eclipse-temurin` as [the recommended approach](https://whichjdk.com/).

**263MB** have been saved with the uncompressed container image on disk:
```
REPOSITORY                               TAG        SIZE
position-service                         after      257MB
position-service                         before     521MB
```

On a security standpoint, by using `eclipse-temurin:21-jre-alpine` base image, this is also reducing the number of packages included in the container: with Syft, from 210 packages to 140 packages (70 packages included in the container image saved).

Which is consequently reducing the number of CVEs too, with Trivy, from 62 to 0:
```
┌────────────────────────────────────────┬────────┬─────────────────┐
│                 Target                 │  Type  │ Vulnerabilities │
├────────────────────────────────────────┼────────┼─────────────────┤
│ position-service:before (ubuntu 22.04) │ ubuntu │       62        │
├────────────────────────────────────────┼────────┼─────────────────┤
│ position-service:after (alpine 3.21.3) │ alpine │       0         │
├────────────────────────────────────────┼────────┼─────────────────┤
```