### PR TITLE
Update security.yml - install specific .NET 9 version

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -70,6 +70,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0'
       - name: Build project with dotnet
         run: dotnet build --configuration Release
         working-directory: ${{ matrix.module-folder }}


### PR DESCRIPTION
Fixing this error: https://github.com/finos/traderX/actions/runs/14065081927/job/39385379612
```
Run dotnet build --configuration Release
MSBuild version 17.8.19+c3ade832a for .NET
  Determining projects to restore...
/usr/lib/dotnet/sdk/8.0.11[4](https://github.com/finos/traderX/actions/runs/14065081927/job/39385379612#step:4:5)/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(166,[5](https://github.com/finos/traderX/actions/runs/14065081927/job/39385379612#step:4:6)): error NETSDK1045: The current .NET SDK does not support targeting .NET 9.0.  Either target .NET 8.0 or lower, or use a version of the .NET SDK that supports .NET 9.0. Download the .NET SDK from https://aka.ms/dotnet/download [/home/runner/work/traderX/traderX/people-service/PeopleService.Core/PeopleService.Core.csproj]
/usr/lib/dotnet/sdk/8.0.114/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(1[6](https://github.com/finos/traderX/actions/runs/14065081927/job/39385379612#step:4:7)6,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 9.0.  Either target .NET 8.0 or lower, or use a version of the .NET SDK that supports .NET 9.0. Download the .NET SDK from https://aka.ms/dotnet/download [/home/runner/work/traderX/traderX/people-service/PeopleService.WebApi/PeopleService.WebApi.csproj]

Build FAILED.
```