### PR TITLE
`eclipse-temurin:21-jre-alpine` for `account-service`, `trade-processor` and `trade-service`

### DIFF
--- a/account-service/Dockerfile
+++ b/account-service/Dockerfile
@@ -1,13 +1,10 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/java/.devcontainer/base.Dockerfile
-
-# [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11, 17, 11-bullseye, 17-bullseye, 11-buster, 17-buster
-ARG VARIANT="21"
-FROM mcr.microsoft.com/vscode/devcontainers/java:1-${VARIANT}
-
-WORKDIR /account-service
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk AS build-stage
+WORKDIR /app
 COPY . .
-
-EXPOSE 18088
-
 RUN ./gradlew build
-ENTRYPOINT ./gradlew bootRun
+
+FROM eclipse-temurin:21-jre-alpine
+RUN mkdir /app
+COPY --from=build-stage /app/build/libs/*.jar /app/account-service.jar
+EXPOSE 18088
+ENTRYPOINT ["java","-jar","/app/account-service.jar"]

--- a/trade-processor/Dockerfile
+++ b/trade-processor/Dockerfile
@@ -1,20 +1,10 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/java/.devcontainer/base.Dockerfile
-
-# [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11, 17, 11-bullseye, 17-bullseye, 11-buster, 17-buster
-ARG VARIANT="21"
-FROM mcr.microsoft.com/vscode/devcontainers/java:1-${VARIANT}
-
-WORKDIR /trade-processor
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk AS build-stage
+WORKDIR /app
 COPY . .
-
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
-
-EXPOSE 18091
-
 RUN ./gradlew build
-ENTRYPOINT ./gradlew bootRun
+
+FROM eclipse-temurin:21-jre-alpine
+RUN mkdir /app
+COPY --from=build-stage /app/build/libs/*.jar /app/trade-processor.jar
+EXPOSE 18091
+ENTRYPOINT ["java","-jar","/app/trade-processor.jar"]

--- a/trade-service/Dockerfile
+++ b/trade-service/Dockerfile
@@ -1,13 +1,10 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/java/.devcontainer/base.Dockerfile
-
-# [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11, 17, 11-bullseye, 17-bullseye, 11-buster, 17-buster
-ARG VARIANT="21"
-FROM mcr.microsoft.com/vscode/devcontainers/java:1-${VARIANT}
-
-WORKDIR /trade-service
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk AS build-stage
+WORKDIR /app
 COPY . .
-
-EXPOSE 18092
-
 RUN ./gradlew build
-ENTRYPOINT ./gradlew bootRun
+
+FROM eclipse-temurin:21-jre-alpine
+RUN mkdir /app
+COPY --from=build-stage /app/build/libs/*.jar /app/trade-service.jar
+EXPOSE 18092
+ENTRYPOINT ["java","-jar","/app/trade-service.jar"]


### PR DESCRIPTION
`eclipse-temurin:21-jre-alpine` for `account-service`, `trade-processor` and `trade-service` like done here https://github.com/finos/traderX/pull/259 for `position-service` already.