### PR TITLE
Remove package-lock to resolve issue 303

### DIFF
--- a/web-front-end/angular/Dockerfile.prod
+++ b/web-front-end/angular/Dockerfile.prod
@@ -4,8 +4,8 @@ FROM node:22-alpine as builder
 WORKDIR /app
 
 # Copy package files and install all dependencies
-COPY package.json package-lock.json ./
-RUN npm ci && npm cache clean --force
+COPY package.json ./
+RUN npm install && npm cache clean --force
 
 # Copy source files and build for production
 COPY . .


### PR DESCRIPTION
This fixes https://github.com/finos/traderX/issues/303

This pull request updates the dependency installation process in the `web-front-end/angular/Dockerfile.prod` file. The change simplifies the Docker build process by switching from `npm ci` to `npm install` and only copying `package.json` instead of both `package.json` and `package-lock.json`.

Dependency installation update:

* Changed the Docker build step to copy only `package.json` (instead of both `package.json` and `package-lock.json`) and replaced `npm ci` with `npm install` for installing dependencies. (`web-front-end/angular/Dockerfile.prod`)