### PR TITLE
Add CycloneDX SBOM generation across all services

### DIFF
--- a/account-service/build.gradle
+++ b/account-service/build.gradle
@@ -9,6 +9,20 @@ plugins {
   id 'java'
   id 'org.springframework.boot' version '3.5.7'
   id 'io.spring.dependency-management' version '1.1.7'
+  id 'org.cyclonedx.bom' version '1.10.0'
+}
+
+cyclonedxBom {
+    includeConfigs = ["runtimeClasspath"]
+    skipConfigs = ["testCompileClasspath", "testRuntimeClasspath"]
+    projectType = "application"
+    schemaVersion = "1.5"
+    destination = file("build/reports")
+    outputName = "sbom"
+    outputFormat = "all"
+    includeBomSerialNumber = true
+    includeLicenseText = false
+    componentVersion = version
 }
 
 group = 'finos.traderx.account-service'

--- a/people-service/.config/dotnet-tools.json
+++ b/people-service/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "cyclonedx": {
+      "version": "2.9.1",
+      "commands": [
+        "dotnet-CycloneDX"
+      ]
+    }
+  }
+}

--- a/people-service/generate-sbom.sh
+++ b/people-service/generate-sbom.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+echo "Installing CycloneDX dotnet tool..."
+dotnet tool restore
+
+echo "Generating SBOM for PeopleService..."
+mkdir -p build/reports
+dotnet CycloneDX PeopleService.sln -o build/reports -f sbom -j -x
+
+echo "SBOM generated successfully at build/reports/sbom.json"

--- a/position-service/build.gradle
+++ b/position-service/build.gradle
@@ -9,6 +9,20 @@ plugins {
   id 'java'
   id 'org.springframework.boot' version '3.5.7'
   id 'io.spring.dependency-management' version '1.1.7'
+  id 'org.cyclonedx.bom' version '1.10.0'
+}
+
+cyclonedxBom {
+    includeConfigs = ["runtimeClasspath"]
+    skipConfigs = ["testCompileClasspath", "testRuntimeClasspath"]
+    projectType = "application"
+    schemaVersion = "1.5"
+    destination = file("build/reports")
+    outputName = "sbom"
+    outputFormat = "all"
+    includeBomSerialNumber = true
+    includeLicenseText = false
+    componentVersion = version
 }
 
 group = 'finos.traderx.position-service'

--- a/reference-data/package.json
+++ b/reference-data/package.json
@@ -17,7 +17,9 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "sbom": "cyclonedx-npm --output-file build/reports/sbom.json --output-format JSON",
+    "sbom:xml": "cyclonedx-npm --output-file build/reports/sbom.xml --output-format XML"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.12",
@@ -31,6 +33,7 @@
     "rxjs": "^7.8.2"
   },
   "devDependencies": {
+    "@cyclonedx/cyclonedx-npm": "^1.19.3",
     "@nestjs/cli": "^11.0.5",
     "@nestjs/schematics": "^11.0.2",
     "@nestjs/testing": "^11.0.12",

--- a/trade-feed/package.json
+++ b/trade-feed/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node index.js"
+    "start": "node index.js",
+    "sbom": "cyclonedx-npm --output-file build/reports/sbom.json --output-format JSON",
+    "sbom:xml": "cyclonedx-npm --output-file build/reports/sbom.xml --output-format XML"
   },
   "author": "",
   "license": "ISC",
@@ -15,5 +17,8 @@
     "npm-check-updates": "^17.1.16",
     "socket.io": "^4.8.1",
     "winston": "^3.17.0"
+  },
+  "devDependencies": {
+    "@cyclonedx/cyclonedx-npm": "^1.19.3"
   }
 }

--- a/trade-processor/build.gradle
+++ b/trade-processor/build.gradle
@@ -9,6 +9,20 @@ plugins {
   id 'java'
   id 'org.springframework.boot' version '3.5.7'
   id 'io.spring.dependency-management' version '1.1.7'
+  id 'org.cyclonedx.bom' version '1.10.0'
+}
+
+cyclonedxBom {
+    includeConfigs = ["runtimeClasspath"]
+    skipConfigs = ["testCompileClasspath", "testRuntimeClasspath"]
+    projectType = "application"
+    schemaVersion = "1.5"
+    destination = file("build/reports")
+    outputName = "sbom"
+    outputFormat = "all"
+    includeBomSerialNumber = true
+    includeLicenseText = false
+    componentVersion = version
 }
 
 group = 'finos.traderx.trade-processor'

--- a/trade-service/build.gradle
+++ b/trade-service/build.gradle
@@ -9,6 +9,20 @@ plugins {
   id 'java'
   id 'org.springframework.boot' version '3.5.7'
   id 'io.spring.dependency-management' version '1.1.7'
+  id 'org.cyclonedx.bom' version '1.10.0'
+}
+
+cyclonedxBom {
+    includeConfigs = ["runtimeClasspath"]
+    skipConfigs = ["testCompileClasspath", "testRuntimeClasspath"]
+    projectType = "application"
+    schemaVersion = "1.5"
+    destination = file("build/reports")
+    outputName = "sbom"
+    outputFormat = "all"
+    includeBomSerialNumber = true
+    includeLicenseText = false
+    componentVersion = version
 }
 
 group = 'finos.traderx.trade-service'

--- a/web-front-end/angular/package.json
+++ b/web-front-end/angular/package.json
@@ -9,7 +9,9 @@
     "build": "cross-env NG_CLI_ANALYTICS=ci ng build --base-href=. --configuration production --output-path=./dist --aot --output-hashing=all",
     "buildlocal": "cross-env NG_CLI_ANALYTICS=ci ng build --base-href=. --configuration local --output-path=./dist --aot --output-hashing=all",
     "test": "ng test --code-coverage --watch=true",
-    "test:ci": "ng test --code-coverage --watch=false --browsers=ChromeHeadlessNoSandbox"
+    "test:ci": "ng test --code-coverage --watch=false --browsers=ChromeHeadlessNoSandbox",
+    "sbom": "cyclonedx-npm --output-file build/reports/sbom.json --output-format JSON",
+    "sbom:xml": "cyclonedx-npm --output-file build/reports/sbom.xml --output-format XML"
   },
   "private": true,
   "license": "Apache-2.0",
@@ -32,6 +34,7 @@
     "zone.js": "^0.14.10"
   },
   "devDependencies": {
+    "@cyclonedx/cyclonedx-npm": "^1.19.3",
     "@angular-devkit/build-angular": "^18.2.12",
     "@angular/cli": "^18.2.12",
     "@angular/compiler-cli": "^18.2.12",

--- a/web-front-end/react/package.json
+++ b/web-front-end/react/package.json
@@ -22,7 +22,9 @@
     "start": "PORT=${WEB_SERVICE_REACT_PORT:-18094} react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "sbom": "cyclonedx-npm --output-file build/reports/sbom.json --output-format JSON",
+    "sbom:xml": "cyclonedx-npm --output-file build/reports/sbom.xml --output-format XML"
   },
   "eslintConfig": {
     "extends": [
@@ -43,6 +45,7 @@
     ]
   },
   "devDependencies": {
+    "@cyclonedx/cyclonedx-npm": "^1.19.3",
     "@emotion/react": "^11.10.8",
     "@emotion/styled": "^11.10.8",
     "@heswell/salt-lab": "^1.0.0-alpha.2",


### PR DESCRIPTION
- Add CycloneDX Gradle plugin to Java services (account-service, trade-service, position-service, trade-processor)
- Add CycloneDX dotnet tool configuration for .NET service (people-service)
- Add @cyclonedx/cyclonedx-npm to Node.js services (trade-feed, reference-data)
- Add SBOM generation scripts to web-front-end (Angular and React)

This enables automated Software Bill of Materials (SBOM) generation during the build process, supporting EO 14028 compliance and secure-by-design principles.