### PR TITLE
Issue #338: formalize runtime build/start lifecycle and NFR gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ bash pipeline/generate-state.sh 001-baseline-uncontainerized-parity
 Start/stop/status:
 
 ```bash
+CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh --build-only
 CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh
 
 ./scripts/status-base-uncontainerized-generated.sh

--- a/catalog/base-uncontainerized-processes.csv
+++ b/catalog/base-uncontainerized-processes.csv
@@ -1,10 +1,10 @@
-order,process_id,workdir,start_cmd,port,health_hint
-1,database,database,./gradlew build && ./run.sh,18082,tcp://localhost:18082
-2,reference-data,reference-data,[ -d node_modules ] || npm install; npm run start,18085,http://localhost:18085/stocks
-3,trade-feed,trade-feed,[ -d node_modules ] || npm install; npm run start,18086,http://localhost:18086/
-4,people-service,people-service/PeopleService.WebApi,dotnet run,18089,http://localhost:18089/swagger
-5,account-service,account-service,./gradlew bootRun,18088,http://localhost:18088/account/
-6,position-service,position-service,./gradlew bootRun,18090,http://localhost:18090/positions/22214
-7,trade-processor,trade-processor,./gradlew bootRun,18091,http://localhost:18091/health
-8,trade-service,trade-service,./gradlew bootRun,18092,http://localhost:18092/v3/api-docs
-9,web-front-end-angular,web-front-end/angular,[ -d node_modules ] || npm install; npm run start,18093,http://localhost:18093/
+order,process_id,workdir,start_cmd,port,health_hint,build_cmd
+1,database,database,./run.sh,18082,tcp://localhost:18082,./gradlew build -x test
+2,reference-data,reference-data,npm run start,18085,http://localhost:18085/stocks,[ -d node_modules ] || npm install
+3,trade-feed,trade-feed,npm run start,18086,http://localhost:18086/,[ -d node_modules ] || npm install
+4,people-service,people-service/PeopleService.WebApi,ASPNETCORE_ENVIRONMENT=Development dotnet ./bin/Debug/net9.0/PeopleService.WebApi.dll,18089,http://localhost:18089/swagger,dotnet build
+5,account-service,account-service,java -jar $(ls build/libs/*.jar | grep -v plain | head -1),18088,http://localhost:18088/account/,./gradlew build -x test
+6,position-service,position-service,java -jar $(ls build/libs/*.jar | grep -v plain | head -1),18090,http://localhost:18090/positions/22214,./gradlew build -x test
+7,trade-processor,trade-processor,java -jar $(ls build/libs/*.jar | grep -v plain | head -1),18091,http://localhost:18091/health,./gradlew build -x test
+8,trade-service,trade-service,java -jar $(ls build/libs/*.jar | grep -v plain | head -1),18092,http://localhost:18092/v3/api-docs,./gradlew build -x test
+9,web-front-end-angular,web-front-end/angular,node serve-angular-dist.js,18093,http://localhost:18093/,[ -d node_modules ] || npm install; [ -d dist ] || npm run build

--- a/docs/spec-kit/api-explorer.md
+++ b/docs/spec-kit/api-explorer.md
@@ -26,7 +26,24 @@ Generate and start a state runtime:
 
 ```bash
 bash pipeline/generate-state.sh <state-id>
+```
+
+For process-based states (`001`, `002`, `003`):
+
+```bash
+./scripts/start-base-uncontainerized-generated.sh --build-only
+./scripts/start-base-uncontainerized-generated.sh
+# or for state 002/003:
+# ./scripts/start-state-002-edge-proxy-generated.sh --build-only
+# ./scripts/start-state-002-edge-proxy-generated.sh
+```
+
+For containerized/Kubernetes states (`004+`):
+
+```bash
 ./scripts/start-state-<state-id>-generated.sh
+# optional restart without rebuild
+./scripts/start-state-<state-id>-generated.sh --skip-build
 ```
 
 Then open:

--- a/docs/spec-kit/generated-state-branches.md
+++ b/docs/spec-kit/generated-state-branches.md
@@ -76,7 +76,8 @@ Default branch target for baseline:
 State `002-edge-proxy-uncontainerized` now uses:
 
 - generation: `bash pipeline/generate-state.sh 002-edge-proxy-uncontainerized`
-- runtime: `./scripts/start-state-002-edge-proxy-generated.sh`
+- runtime (first run/build): `./scripts/start-state-002-edge-proxy-generated.sh --build-only`
+- runtime (start after build): `./scripts/start-state-002-edge-proxy-generated.sh`
 - publish branch: `code/generated-state-002-edge-proxy-uncontainerized`
 
 Publish branch snapshot:
@@ -88,7 +89,8 @@ bash pipeline/publish-generated-state-branch.sh 002-edge-proxy-uncontainerized -
 State `004-containerized-compose-runtime` now uses:
 
 - generation: `bash pipeline/generate-state.sh 004-containerized-compose-runtime`
-- runtime: `./scripts/start-state-004-containerized-generated.sh` (NGINX ingress on `http://localhost:8080`)
+- runtime (default build + start): `./scripts/start-state-004-containerized-generated.sh` (NGINX ingress on `http://localhost:8080`)
+- runtime (restart without image rebuild): `./scripts/start-state-004-containerized-generated.sh --skip-build`
 - publish branch: `code/generated-state-004-containerized-compose-runtime`
 
 Publish branch snapshot:

--- a/docs/spec-kit/run-generated-overlays.md
+++ b/docs/spec-kit/run-generated-overlays.md
@@ -20,13 +20,15 @@ Generation now installs local runtime scripts into:
 ## Start Full Overlay Stack
 
 ```bash
+CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh --build-only
 CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh
 ```
 
 Optional if dependencies are already cached:
 
 ```bash
-TRADERSPEC_SKIP_NETWORK_CHECK=1 CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh
+TRADERSPEC_SKIP_NETWORK_CHECK=1 CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh --build-only
+CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh
 ```
 
 ## Dry Run
@@ -61,6 +63,7 @@ Generate and start:
 
 ```bash
 bash pipeline/generate-state.sh 002-edge-proxy-uncontainerized
+./scripts/start-state-002-edge-proxy-generated.sh --build-only
 ./scripts/start-state-002-edge-proxy-generated.sh
 ```
 
@@ -83,6 +86,7 @@ Generate and start:
 ```bash
 bash pipeline/generate-state.sh 004-containerized-compose-runtime
 ./scripts/start-state-004-containerized-generated.sh
+./scripts/start-state-004-containerized-generated.sh --skip-build
 ```
 
 Ingress/UI endpoint: `http://localhost:8080`

--- a/docs/spec-kit/spec-kit-generation-guide.md
+++ b/docs/spec-kit/spec-kit-generation-guide.md
@@ -71,16 +71,20 @@ Run examples:
 
 ```bash
 # 001 (uncontainerized)
+CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh --build-only
 CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh
 
 # 003 (compose)
 ./scripts/start-state-004-containerized-generated.sh
+./scripts/start-state-004-containerized-generated.sh --skip-build
 
 # 006 (compose + observability)
 ./scripts/start-state-007-observability-lgtm-compose-generated.sh
+./scripts/start-state-007-observability-lgtm-compose-generated.sh --skip-build
 
 # 009 (kubernetes)
 ./scripts/start-state-010-kubernetes-runtime-generated.sh --provider kind
+./scripts/start-state-010-kubernetes-runtime-generated.sh --provider kind --skip-build
 ```
 
 ## Derived-State Implementation Pattern

--- a/docs/spec-kit/spec-kit-workflow.md
+++ b/docs/spec-kit/spec-kit-workflow.md
@@ -227,6 +227,7 @@ Generated outputs:
 Run generated baseline stack:
 
 ```bash
+CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh --build-only
 CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh
 ```
 
@@ -234,6 +235,7 @@ Run generated containerized stack (state `004`):
 
 ```bash
 ./scripts/start-state-004-containerized-generated.sh
+./scripts/start-state-004-containerized-generated.sh --skip-build
 ./scripts/status-state-004-containerized-generated.sh
 ./scripts/test-state-004-containerized.sh
 ./scripts/stop-state-004-containerized-generated.sh

--- a/pipeline/install-generated-runtime-harness.sh
+++ b/pipeline/install-generated-runtime-harness.sh
@@ -215,6 +215,7 @@ write_generated_runbook() {
 Start:
 
 ```bash
+./scripts/start-base-uncontainerized-generated.sh --build-only
 ./scripts/start-base-uncontainerized-generated.sh
 ```
 
@@ -233,6 +234,7 @@ EOF
 Start:
 
 ```bash
+./scripts/start-state-002-edge-proxy-generated.sh --build-only
 ./scripts/start-state-002-edge-proxy-generated.sh
 ```
 
@@ -251,6 +253,7 @@ EOF
 Start:
 
 ```bash
+./scripts/start-state-003-agentic-harness-foundation-generated.sh --build-only
 ./scripts/start-state-003-agentic-harness-foundation-generated.sh
 ```
 
@@ -276,6 +279,7 @@ Start:
 
 ```bash
 ./scripts/start-state-004-containerized-generated.sh
+./scripts/start-state-004-containerized-generated.sh --skip-build
 ```
 
 Status / stop:
@@ -300,6 +304,7 @@ Start:
 
 ```bash
 ./scripts/start-state-005-postgres-database-replacement-generated.sh
+./scripts/start-state-005-postgres-database-replacement-generated.sh --skip-build
 ```
 
 Status / stop:
@@ -324,6 +329,7 @@ Start:
 
 ```bash
 ./scripts/start-state-006-messaging-nats-replacement-generated.sh
+./scripts/start-state-006-messaging-nats-replacement-generated.sh --skip-build
 ```
 
 Status / stop:
@@ -348,6 +354,7 @@ Start:
 
 ```bash
 ./scripts/start-state-007-observability-lgtm-compose-generated.sh
+./scripts/start-state-007-observability-lgtm-compose-generated.sh --skip-build
 ```
 
 Status / stop:
@@ -372,6 +379,7 @@ Start:
 
 ```bash
 ./scripts/start-state-008-pricing-awareness-market-data-generated.sh
+./scripts/start-state-008-pricing-awareness-market-data-generated.sh --skip-build
 ```
 
 Status / stop:
@@ -396,6 +404,7 @@ Start:
 
 ```bash
 ./scripts/start-state-009-order-management-matcher-generated.sh
+./scripts/start-state-009-order-management-matcher-generated.sh --skip-build
 ```
 
 Status / stop:
@@ -420,6 +429,7 @@ Start:
 
 ```bash
 ./scripts/start-state-010-kubernetes-runtime-generated.sh
+./scripts/start-state-010-kubernetes-runtime-generated.sh --skip-build
 ```
 
 Status / stop:
@@ -444,6 +454,7 @@ Start:
 
 ```bash
 ./scripts/start-state-011-tilt-kubernetes-dev-loop-generated.sh
+./scripts/start-state-011-tilt-kubernetes-dev-loop-generated.sh --skip-build
 ```
 
 Status / stop:
@@ -468,6 +479,7 @@ Start:
 
 ```bash
 ./scripts/start-state-012-platform-convergence-c3-generated.sh
+./scripts/start-state-012-platform-convergence-c3-generated.sh --skip-build
 ```
 
 Status / stop:
@@ -492,6 +504,7 @@ Start:
 
 ```bash
 ./scripts/start-state-013-radius-kubernetes-platform-generated.sh
+./scripts/start-state-013-radius-kubernetes-platform-generated.sh --skip-build
 ```
 
 Status / stop:
@@ -516,6 +529,7 @@ Start baseline C3 runtime:
 
 ```bash
 ./scripts/start-state-014-fdc3-intent-interoperability-generated.sh
+./scripts/start-state-014-fdc3-intent-interoperability-generated.sh --skip-build
 ```
 
 Start C3 + Sail sidecar:

--- a/pipeline/install-generated-runtime-harness.sh
+++ b/pipeline/install-generated-runtime-harness.sh
@@ -215,7 +215,10 @@ write_generated_runbook() {
 Start:
 
 ```bash
+# Build/preflight only (no runtime start)
 ./scripts/start-base-uncontainerized-generated.sh --build-only
+
+# Start runtime (will build if needed)
 ./scripts/start-base-uncontainerized-generated.sh
 ```
 
@@ -234,7 +237,10 @@ EOF
 Start:
 
 ```bash
+# Build/preflight only (no runtime start)
 ./scripts/start-state-002-edge-proxy-generated.sh --build-only
+
+# Start runtime (will build if needed)
 ./scripts/start-state-002-edge-proxy-generated.sh
 ```
 
@@ -253,7 +259,10 @@ EOF
 Start:
 
 ```bash
+# Build/preflight only (no runtime start)
 ./scripts/start-state-003-agentic-harness-foundation-generated.sh --build-only
+
+# Start runtime (will build if needed)
 ./scripts/start-state-003-agentic-harness-foundation-generated.sh
 ```
 
@@ -275,10 +284,13 @@ EOF
       cat > "${TARGET_ROOT}/RUN_FROM_GENERATED.md" <<'EOF'
 # Run From Generated (State 004)
 
-Start:
+Start (choose one):
 
 ```bash
+# Full start (build + start)
 ./scripts/start-state-004-containerized-generated.sh
+
+# Fast restart (reuse existing artifacts; skips build)
 ./scripts/start-state-004-containerized-generated.sh --skip-build
 ```
 
@@ -300,10 +312,13 @@ EOF
       cat > "${TARGET_ROOT}/RUN_FROM_GENERATED.md" <<'EOF'
 # Run From Generated (State 005)
 
-Start:
+Start (choose one):
 
 ```bash
+# Full start (build + start)
 ./scripts/start-state-005-postgres-database-replacement-generated.sh
+
+# Fast restart (reuse existing artifacts; skips build)
 ./scripts/start-state-005-postgres-database-replacement-generated.sh --skip-build
 ```
 
@@ -325,10 +340,13 @@ EOF
       cat > "${TARGET_ROOT}/RUN_FROM_GENERATED.md" <<'EOF'
 # Run From Generated (State 006)
 
-Start:
+Start (choose one):
 
 ```bash
+# Full start (build + start)
 ./scripts/start-state-006-messaging-nats-replacement-generated.sh
+
+# Fast restart (reuse existing artifacts; skips build)
 ./scripts/start-state-006-messaging-nats-replacement-generated.sh --skip-build
 ```
 
@@ -350,10 +368,13 @@ EOF
       cat > "${TARGET_ROOT}/RUN_FROM_GENERATED.md" <<'EOF'
 # Run From Generated (State 007)
 
-Start:
+Start (choose one):
 
 ```bash
+# Full start (build + start)
 ./scripts/start-state-007-observability-lgtm-compose-generated.sh
+
+# Fast restart (reuse existing artifacts; skips build)
 ./scripts/start-state-007-observability-lgtm-compose-generated.sh --skip-build
 ```
 
@@ -375,10 +396,13 @@ EOF
       cat > "${TARGET_ROOT}/RUN_FROM_GENERATED.md" <<'EOF'
 # Run From Generated (State 008)
 
-Start:
+Start (choose one):
 
 ```bash
+# Full start (build + start)
 ./scripts/start-state-008-pricing-awareness-market-data-generated.sh
+
+# Fast restart (reuse existing artifacts; skips build)
 ./scripts/start-state-008-pricing-awareness-market-data-generated.sh --skip-build
 ```
 
@@ -400,10 +424,13 @@ EOF
       cat > "${TARGET_ROOT}/RUN_FROM_GENERATED.md" <<'EOF'
 # Run From Generated (State 009)
 
-Start:
+Start (choose one):
 
 ```bash
+# Full start (build + start)
 ./scripts/start-state-009-order-management-matcher-generated.sh
+
+# Fast restart (reuse existing artifacts; skips build)
 ./scripts/start-state-009-order-management-matcher-generated.sh --skip-build
 ```
 
@@ -425,10 +452,13 @@ EOF
       cat > "${TARGET_ROOT}/RUN_FROM_GENERATED.md" <<'EOF'
 # Run From Generated (State 010)
 
-Start:
+Start (choose one):
 
 ```bash
+# Full start (build + start)
 ./scripts/start-state-010-kubernetes-runtime-generated.sh
+
+# Fast restart (reuse existing artifacts; skips build)
 ./scripts/start-state-010-kubernetes-runtime-generated.sh --skip-build
 ```
 
@@ -450,10 +480,13 @@ EOF
       cat > "${TARGET_ROOT}/RUN_FROM_GENERATED.md" <<'EOF'
 # Run From Generated (State 011)
 
-Start:
+Start (choose one):
 
 ```bash
+# Full start (build + start)
 ./scripts/start-state-011-tilt-kubernetes-dev-loop-generated.sh
+
+# Fast restart (reuse existing artifacts; skips build)
 ./scripts/start-state-011-tilt-kubernetes-dev-loop-generated.sh --skip-build
 ```
 
@@ -475,10 +508,13 @@ EOF
       cat > "${TARGET_ROOT}/RUN_FROM_GENERATED.md" <<'EOF'
 # Run From Generated (State 012)
 
-Start:
+Start (choose one):
 
 ```bash
+# Full start (build + start)
 ./scripts/start-state-012-platform-convergence-c3-generated.sh
+
+# Fast restart (reuse existing artifacts; skips build)
 ./scripts/start-state-012-platform-convergence-c3-generated.sh --skip-build
 ```
 
@@ -500,10 +536,13 @@ EOF
       cat > "${TARGET_ROOT}/RUN_FROM_GENERATED.md" <<'EOF'
 # Run From Generated (State 013)
 
-Start:
+Start (choose one):
 
 ```bash
+# Full start (build + start)
 ./scripts/start-state-013-radius-kubernetes-platform-generated.sh
+
+# Fast restart (reuse existing artifacts; skips build)
 ./scripts/start-state-013-radius-kubernetes-platform-generated.sh --skip-build
 ```
 
@@ -525,10 +564,13 @@ EOF
       cat > "${TARGET_ROOT}/RUN_FROM_GENERATED.md" <<'EOF'
 # Run From Generated (State 014)
 
-Start baseline C3 runtime:
+Start baseline C3 runtime (choose one):
 
 ```bash
+# Full start (build + start)
 ./scripts/start-state-014-fdc3-intent-interoperability-generated.sh
+
+# Fast restart (reuse existing artifacts; skips build)
 ./scripts/start-state-014-fdc3-intent-interoperability-generated.sh --skip-build
 ```
 

--- a/pipeline/publish-generated-state-branch.sh
+++ b/pipeline/publish-generated-state-branch.sh
@@ -2277,6 +2277,7 @@ Prerequisites:
 Start:
 
 ```bash
+CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh --build-only
 CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh
 ```
 
@@ -2307,6 +2308,7 @@ Prerequisites:
 Start:
 
 ```bash
+CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-state-002-edge-proxy-generated.sh --build-only
 CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-state-002-edge-proxy-generated.sh
 ```
 
@@ -2338,6 +2340,7 @@ Prerequisites:
 Start:
 
 ```bash
+CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-state-003-agentic-harness-foundation-generated.sh --build-only
 CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-state-003-agentic-harness-foundation-generated.sh
 ```
 
@@ -2371,6 +2374,7 @@ Start:
 
 ```bash
 ./scripts/start-state-004-containerized-generated.sh
+./scripts/start-state-004-containerized-generated.sh --skip-build
 ```
 
 Endpoints:
@@ -2400,6 +2404,7 @@ Start:
 
 ```bash
 ./scripts/start-state-010-kubernetes-runtime-generated.sh
+./scripts/start-state-010-kubernetes-runtime-generated.sh --skip-build
 # optional:
 # ./scripts/start-state-010-kubernetes-runtime-generated.sh --provider minikube --minikube-profile traderx-state-010
 ```
@@ -2433,6 +2438,7 @@ Start baseline runtime (inherited from state 010):
 
 ```bash
 ./scripts/start-state-010-kubernetes-runtime-generated.sh
+./scripts/start-state-010-kubernetes-runtime-generated.sh --skip-build
 ```
 
 Inherited runtime endpoints:
@@ -2469,6 +2475,7 @@ Start baseline runtime (inherited from state 010):
 
 ```bash
 ./scripts/start-state-010-kubernetes-runtime-generated.sh
+./scripts/start-state-010-kubernetes-runtime-generated.sh --skip-build
 ```
 
 Inherited runtime endpoints:
@@ -2504,6 +2511,7 @@ Start convergence runtime:
 
 ```bash
 ./scripts/start-state-012-platform-convergence-c3-generated.sh
+./scripts/start-state-012-platform-convergence-c3-generated.sh --skip-build
 ```
 
 Inherited runtime endpoints:
@@ -2577,6 +2585,7 @@ Start:
 
 ```bash
 ./scripts/start-state-007-observability-lgtm-compose-generated.sh
+./scripts/start-state-007-observability-lgtm-compose-generated.sh --skip-build
 ```
 
 Endpoints:
@@ -2607,6 +2616,7 @@ Start:
 
 ```bash
 ./scripts/start-state-006-messaging-nats-replacement-generated.sh
+./scripts/start-state-006-messaging-nats-replacement-generated.sh --skip-build
 ```
 
 Endpoints:
@@ -2634,6 +2644,7 @@ Start:
 
 ```bash
 ./scripts/start-state-005-postgres-database-replacement-generated.sh
+./scripts/start-state-005-postgres-database-replacement-generated.sh --skip-build
 ```
 
 Endpoints:
@@ -2661,6 +2672,7 @@ Start:
 
 ```bash
 ./scripts/start-state-009-order-management-matcher-generated.sh
+./scripts/start-state-009-order-management-matcher-generated.sh --skip-build
 ```
 
 Endpoints:
@@ -2690,6 +2702,7 @@ Start:
 
 ```bash
 ./scripts/start-state-008-pricing-awareness-market-data-generated.sh
+./scripts/start-state-008-pricing-awareness-market-data-generated.sh --skip-build
 ```
 
 Endpoints:

--- a/pipeline/validate-lifecycle-script-contract.sh
+++ b/pipeline/validate-lifecycle-script-contract.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPTS_DIR="${ROOT}/scripts"
+CATALOG="${ROOT}/catalog/base-uncontainerized-processes.csv"
+
+fail() {
+  echo "[fail] $*"
+  exit 1
+}
+
+require_file() {
+  local path="$1"
+  [[ -f "${path}" ]] || fail "missing file: ${path}"
+}
+
+require_pattern_in_file() {
+  local pattern="$1"
+  local path="$2"
+  if ! rg -q -- "${pattern}" "${path}"; then
+    fail "missing required pattern '${pattern}' in ${path}"
+  fi
+}
+
+require_file "${SCRIPTS_DIR}/start-base-uncontainerized-generated.sh"
+require_file "${SCRIPTS_DIR}/stop-base-uncontainerized-generated.sh"
+require_file "${SCRIPTS_DIR}/test-order-create-pubsub-smoke.sh"
+require_file "${CATALOG}"
+
+# Baseline contract: catalog must expose build_cmd and every process row must define it.
+header="$(head -n 1 "${CATALOG}")"
+[[ "${header}" == *",build_cmd" ]] || fail "${CATALOG} must include build_cmd column"
+
+awk -F, 'NR > 1 { if ($7 == "") { printf("[fail] missing build_cmd for process %s on row %d\n", $2, NR); exit 1 } }' "${CATALOG}"
+
+# Uncontainerized lifecycle scripts must expose explicit build-only mode.
+require_pattern_in_file '--build-only' "${SCRIPTS_DIR}/start-base-uncontainerized-generated.sh"
+
+for state_num in 002 003; do
+  start_script="$(find "${SCRIPTS_DIR}" -maxdepth 1 -type f -name "start-state-${state_num}-*-generated.sh" | sort | head -n 1 || true)"
+  stop_script="$(find "${SCRIPTS_DIR}" -maxdepth 1 -type f -name "stop-state-${state_num}-*-generated.sh" | sort | head -n 1 || true)"
+  smoke_script="$(find "${SCRIPTS_DIR}" -maxdepth 1 -type f -name "test-state-${state_num}-*.sh" | sort | head -n 1 || true)"
+
+  [[ -n "${start_script}" ]] || fail "missing start script for state ${state_num}"
+  [[ -n "${stop_script}" ]] || fail "missing stop script for state ${state_num}"
+  [[ -n "${smoke_script}" ]] || fail "missing readiness script for state ${state_num}"
+
+  require_pattern_in_file '--build-only' "${start_script}"
+done
+
+# Every other generated state must have start/stop/readiness scripts and build/start separation flag.
+for state_num in 004 005 006 007 008 009 010 011 012 013 014; do
+  start_script="$(find "${SCRIPTS_DIR}" -maxdepth 1 -type f -name "start-state-${state_num}-*-generated.sh" | sort | head -n 1 || true)"
+  stop_script="$(find "${SCRIPTS_DIR}" -maxdepth 1 -type f -name "stop-state-${state_num}-*-generated.sh" | sort | head -n 1 || true)"
+  smoke_script="$(find "${SCRIPTS_DIR}" -maxdepth 1 -type f -name "test-state-${state_num}-*.sh" | sort | head -n 1 || true)"
+
+  [[ -n "${start_script}" ]] || fail "missing start script for state ${state_num}"
+  [[ -n "${stop_script}" ]] || fail "missing stop script for state ${state_num}"
+  [[ -n "${smoke_script}" ]] || fail "missing readiness script for state ${state_num}"
+
+  if ! rg -q -- '--build-only|--skip-build' "${start_script}"; then
+    fail "start script must support build/start separation flag (--build-only or --skip-build): ${start_script}"
+  fi
+done
+
+echo "[ok] lifecycle script contract validation passed"

--- a/pipeline/verify-spec-coverage.sh
+++ b/pipeline/verify-spec-coverage.sh
@@ -29,6 +29,7 @@ fi
 
 "${ROOT}/pipeline/validate-regeneration-readiness.sh"
 bash "${ROOT}/pipeline/validate-state-pack-artifacts.sh"
+bash "${ROOT}/pipeline/validate-lifecycle-script-contract.sh"
 bash "${ROOT}/pipeline/validate-convergence-state-model.sh"
 bash "${ROOT}/pipeline/validate-convergence-rationale-deltas.sh"
 bash "${ROOT}/pipeline/validate-ghcr-run-bundle-readmes.sh"

--- a/scripts/start-base-uncontainerized-generated.sh
+++ b/scripts/start-base-uncontainerized-generated.sh
@@ -31,14 +31,18 @@ TRADE_SERVICE_SPECFIRST="${GENERATED_ROOT}/code/components/trade-service-specfir
 WEB_FRONT_END_ANGULAR_SPECFIRST="${GENERATED_ROOT}/code/components/web-front-end-angular-specfirst"
 
 DRY_RUN=0
+BUILD_ONLY=0
 while (( "$#" )); do
   case "$1" in
     --dry-run)
       DRY_RUN=1
       ;;
+    --build-only)
+      BUILD_ONLY=1
+      ;;
     *)
       echo "[error] unknown argument: $1"
-      echo "[hint] supported: --dry-run"
+      echo "[hint] supported: --dry-run --build-only"
       exit 1
       ;;
   esac
@@ -47,6 +51,17 @@ done
 
 source "${REPO_ROOT}/scripts/lib/generated-state-detection.sh"
 traderx_ensure_generated_state "${EXPECTED_STATE}" "${REPO_ROOT}" "${GENERATED_ROOT}"
+
+ensure_component_layout() {
+  local source_dir="$1"
+  local target_dir="$2"
+
+  if [[ -d "${target_dir}" ]]; then
+    return 0
+  fi
+
+  cp -R "${source_dir}" "${target_dir}"
+}
 
 prepare_generated_base_layout() {
   local generated_paths=(
@@ -70,12 +85,6 @@ prepare_generated_base_layout() {
     fi
   done
 
-  # Full wipe of target-generated (preserving .run/ which holds pids/logs/tool-cache).
-  # This guarantees no stale component directories from other states are present,
-  # regardless of which states were generated before this one.
-  if [[ -d "${TARGET}" ]]; then
-    find "${TARGET}" -maxdepth 1 -mindepth 1 ! -name '.run' -exec rm -rf {} +
-  fi
   mkdir -p "${TARGET}" "${TARGET}/web-front-end" "${TARGET}/catalog"
 
   if [[ ! -f "${SPEC_SOURCE}" ]]; then
@@ -84,15 +93,15 @@ prepare_generated_base_layout() {
   fi
   cp "${SPEC_SOURCE}" "${SPEC}"
 
-  cp -R "${REFERENCE_DATA_SPECFIRST}" "${TARGET}/reference-data"
-  cp -R "${DATABASE_SPECFIRST}" "${TARGET}/database"
-  cp -R "${PEOPLE_SERVICE_SPECFIRST}" "${TARGET}/people-service"
-  cp -R "${ACCOUNT_SERVICE_SPECFIRST}" "${TARGET}/account-service"
-  cp -R "${POSITION_SERVICE_SPECFIRST}" "${TARGET}/position-service"
-  cp -R "${TRADE_FEED_SPECFIRST}" "${TARGET}/trade-feed"
-  cp -R "${TRADE_PROCESSOR_SPECFIRST}" "${TARGET}/trade-processor"
-  cp -R "${TRADE_SERVICE_SPECFIRST}" "${TARGET}/trade-service"
-  cp -R "${WEB_FRONT_END_ANGULAR_SPECFIRST}" "${TARGET}/web-front-end/angular"
+  ensure_component_layout "${REFERENCE_DATA_SPECFIRST}" "${TARGET}/reference-data"
+  ensure_component_layout "${DATABASE_SPECFIRST}" "${TARGET}/database"
+  ensure_component_layout "${PEOPLE_SERVICE_SPECFIRST}" "${TARGET}/people-service"
+  ensure_component_layout "${ACCOUNT_SERVICE_SPECFIRST}" "${TARGET}/account-service"
+  ensure_component_layout "${POSITION_SERVICE_SPECFIRST}" "${TARGET}/position-service"
+  ensure_component_layout "${TRADE_FEED_SPECFIRST}" "${TARGET}/trade-feed"
+  ensure_component_layout "${TRADE_PROCESSOR_SPECFIRST}" "${TARGET}/trade-processor"
+  ensure_component_layout "${TRADE_SERVICE_SPECFIRST}" "${TARGET}/trade-service"
+  ensure_component_layout "${WEB_FRONT_END_ANGULAR_SPECFIRST}" "${TARGET}/web-front-end/angular"
 
   echo "[ok] generated base layout prepared in ${TARGET}"
 }
@@ -214,6 +223,106 @@ port_listener_pids() {
   lsof -nP -tiTCP:"${port}" -sTCP:LISTEN 2>/dev/null || true
 }
 
+build_artifact_exists() {
+  local process="$1"
+  local workdir_rel="$2"
+  local build_cmd="$3"
+  local workdir="${TARGET}/${workdir_rel}"
+
+  if [[ -z "${build_cmd}" ]]; then
+    return 0
+  fi
+
+  if [[ "${process}" == "web-front-end-angular" ]]; then
+    [[ -d "${workdir}/node_modules" && -d "${workdir}/dist" ]]
+    return $?
+  fi
+
+  if echo "${build_cmd}" | grep -q 'ng build'; then
+    [[ -d "${workdir}/dist" ]]
+    return $?
+  fi
+
+  if echo "${build_cmd}" | grep -q '\[ -d dist \]'; then
+    [[ -d "${workdir}/dist" ]]
+    return $?
+  fi
+
+  if echo "${build_cmd}" | grep -q 'node_modules'; then
+    [[ -d "${workdir}/node_modules" ]]
+    return $?
+  fi
+
+  if echo "${build_cmd}" | grep -q 'dotnet build'; then
+    compgen -G "${workdir}/bin/Debug/net*/PeopleService.WebApi.dll" >/dev/null
+    return $?
+  fi
+
+  if echo "${build_cmd}" | grep -q 'gradlew'; then
+    if [[ "${process}" == "database" ]]; then
+      [[ -f "${workdir}/build/libs/database-specfirst.jar" ]]
+      return $?
+    fi
+
+    local jar
+    jar="$(ls "${workdir}"/build/libs/*.jar 2>/dev/null | grep -v plain | head -1 || true)"
+    [[ -n "${jar}" ]]
+    return $?
+  fi
+
+  return 1
+}
+
+run_build_process() {
+  local process="$1"
+  local workdir_rel="$2"
+  local build_cmd="$3"
+  local workdir="${TARGET}/${workdir_rel}"
+
+  if [[ -z "${build_cmd}" ]]; then
+    return 0
+  fi
+
+  if [[ ! -d "${workdir}" ]]; then
+    echo "[error] missing workdir for ${process}: ${workdir}"
+    exit 1
+  fi
+
+  if build_artifact_exists "${process}" "${workdir_rel}" "${build_cmd}"; then
+    echo "[build-skip] ${process}: already built"
+    return 0
+  fi
+
+  if ((DRY_RUN == 1)); then
+    echo "[dry-run] [build] ${process}: cd ${workdir} && ${build_cmd}"
+    return 0
+  fi
+
+  echo "[build] ${process}: ${build_cmd}"
+  (cd "${workdir}" && eval "${build_cmd}") || {
+    echo "[error] build failed for ${process}"
+    exit 1
+  }
+}
+
+build_check_or_exit() {
+  local process="$1"
+  local workdir_rel="$2"
+  local build_cmd="$3"
+
+  if [[ -z "${build_cmd}" ]]; then
+    return 0
+  fi
+
+  if build_artifact_exists "${process}" "${workdir_rel}" "${build_cmd}"; then
+    return 0
+  fi
+
+  echo "[error] ${process}: missing build artifacts required by start command."
+  echo "[hint] run ./scripts/start-base-uncontainerized-generated.sh --build-only"
+  exit 1
+}
+
 start_process() {
   local process="$1"
   local workdir_rel="$2"
@@ -274,10 +383,29 @@ if ((DRY_RUN == 0)); then
   preflight_checks
 fi
 
-while IFS=, read -r order process workdir start_cmd port health_hint; do
+if ((BUILD_ONLY == 1)); then
+  echo "[build] building base uncontainerized services (--build-only)"
+  while IFS=, read -r order process workdir start_cmd port health_hint build_cmd; do
+    if [[ "${order}" == "order" ]]; then
+      continue
+    fi
+    run_build_process "${process}" "${workdir}" "${build_cmd}"
+  done < <(tail -n +2 "${SPEC}" | sort -t, -k1,1n)
+
+  if ((DRY_RUN == 1)); then
+    echo "[done] dry run complete"
+  else
+    echo "[done] build phase complete"
+    echo "[hint] run the same script without --build-only to start services"
+  fi
+  exit 0
+fi
+
+while IFS=, read -r order process workdir start_cmd port health_hint build_cmd; do
   if [[ "${order}" == "order" ]]; then
     continue
   fi
+  build_check_or_exit "${process}" "${workdir}" "${build_cmd}"
   start_process "${process}" "${workdir}" "${start_cmd}" "${port}"
 done < <(tail -n +2 "${SPEC}" | sort -t, -k1,1n)
 

--- a/scripts/start-state-002-edge-proxy-generated.sh
+++ b/scripts/start-state-002-edge-proxy-generated.sh
@@ -21,15 +21,19 @@ EDGE_COMPONENT_DIR="${GENERATED_ROOT}/code/components/edge-proxy-specfirst"
 EDGE_TARGET_DIR="${TARGET}/edge-proxy"
 EDGE_PROXY_PORT="${EDGE_PROXY_PORT:-18080}"
 DRY_RUN=0
+BUILD_ONLY=0
 
 while (( "$#" )); do
   case "$1" in
     --dry-run)
       DRY_RUN=1
       ;;
+    --build-only)
+      BUILD_ONLY=1
+      ;;
     *)
       echo "[error] unknown argument: $1"
-      echo "[hint] supported: --dry-run"
+      echo "[hint] supported: --dry-run --build-only"
       exit 1
       ;;
   esac
@@ -42,11 +46,21 @@ done
   exit 1
 }
 
-if (( DRY_RUN == 1 )); then
+if (( DRY_RUN == 1 )) && (( BUILD_ONLY == 1 )); then
+  TRADERX_EXPECTED_STATE_ID="${EXPECTED_STATE}" \
+  TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
+  TRADERX_SOURCE_REPO_ROOT="${SOURCE_REPO_ROOT}" \
+    "${REPO_ROOT}/scripts/start-base-uncontainerized-generated.sh" --dry-run --build-only
+elif (( DRY_RUN == 1 )); then
   TRADERX_EXPECTED_STATE_ID="${EXPECTED_STATE}" \
   TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
   TRADERX_SOURCE_REPO_ROOT="${SOURCE_REPO_ROOT}" \
     "${REPO_ROOT}/scripts/start-base-uncontainerized-generated.sh" --dry-run
+elif (( BUILD_ONLY == 1 )); then
+  TRADERX_EXPECTED_STATE_ID="${EXPECTED_STATE}" \
+  TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
+  TRADERX_SOURCE_REPO_ROOT="${SOURCE_REPO_ROOT}" \
+    "${REPO_ROOT}/scripts/start-base-uncontainerized-generated.sh" --build-only
 else
   TRADERX_EXPECTED_STATE_ID="${EXPECTED_STATE}" \
   TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
@@ -55,8 +69,34 @@ else
 fi
 
 mkdir -p "${RUN_DIR}/logs" "${RUN_DIR}/pids"
-rm -rf "${EDGE_TARGET_DIR}"
-cp -R "${EDGE_COMPONENT_DIR}" "${EDGE_TARGET_DIR}"
+if [[ ! -d "${EDGE_TARGET_DIR}" ]]; then
+  cp -R "${EDGE_COMPONENT_DIR}" "${EDGE_TARGET_DIR}"
+fi
+
+if (( BUILD_ONLY == 1 )); then
+  if [[ -d "${EDGE_TARGET_DIR}/node_modules" ]]; then
+    echo "[build-skip] edge-proxy: already built"
+  elif (( DRY_RUN == 1 )); then
+    echo "[dry-run] [build] edge-proxy: cd ${EDGE_TARGET_DIR} && npm install"
+  else
+    echo "[build] edge-proxy: npm install"
+    (cd "${EDGE_TARGET_DIR}" && npm install)
+  fi
+
+  if (( DRY_RUN == 1 )); then
+    echo "[done] dry run complete for state 002"
+  else
+    echo "[done] build phase complete for state 002"
+    echo "[hint] run without --build-only to start services"
+  fi
+  exit 0
+fi
+
+if [[ ! -d "${EDGE_TARGET_DIR}/node_modules" ]]; then
+  echo "[error] edge-proxy build artifacts missing (node_modules)."
+  echo "[hint] run ./scripts/start-state-002-edge-proxy-generated.sh --build-only"
+  exit 1
+fi
 
 pidfile="${RUN_DIR}/pids/edge-proxy.pid"
 logfile="${RUN_DIR}/logs/edge-proxy.log"
@@ -76,13 +116,13 @@ if nc -z localhost "${EDGE_PROXY_PORT}" >/dev/null 2>&1; then
 fi
 
 if (( DRY_RUN == 1 )); then
-  echo "[dry-run] edge-proxy: cd ${EDGE_TARGET_DIR} && [ -d node_modules ] || npm install; npm run start"
+  echo "[dry-run] edge-proxy: cd ${EDGE_TARGET_DIR} && npm run start"
   echo "[done] dry run complete for state 002"
   exit 0
 fi
 
 echo "[start] edge-proxy"
-nohup /bin/zsh -lc "cd '${EDGE_TARGET_DIR}' && [ -d node_modules ] || npm install; npm run start" >"${logfile}" 2>&1 &
+nohup /bin/zsh -lc "cd '${EDGE_TARGET_DIR}' && npm run start" >"${logfile}" 2>&1 &
 echo "$!" > "${pidfile}"
 
 attempts=60

--- a/scripts/start-state-003-agentic-harness-foundation-generated.sh
+++ b/scripts/start-state-003-agentic-harness-foundation-generated.sh
@@ -21,15 +21,19 @@ EDGE_COMPONENT_DIR="${GENERATED_ROOT}/code/components/edge-proxy-specfirst"
 EDGE_TARGET_DIR="${TARGET}/edge-proxy"
 EDGE_PROXY_PORT="${EDGE_PROXY_PORT:-18080}"
 DRY_RUN=0
+BUILD_ONLY=0
 
 while (( "$#" )); do
   case "$1" in
     --dry-run)
       DRY_RUN=1
       ;;
+    --build-only)
+      BUILD_ONLY=1
+      ;;
     *)
       echo "[error] unknown argument: $1"
-      echo "[hint] supported: --dry-run"
+      echo "[hint] supported: --dry-run --build-only"
       exit 1
       ;;
   esac
@@ -42,11 +46,21 @@ done
   exit 1
 }
 
-if (( DRY_RUN == 1 )); then
+if (( DRY_RUN == 1 )) && (( BUILD_ONLY == 1 )); then
+  TRADERX_EXPECTED_STATE_ID="${EXPECTED_STATE}" \
+  TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
+  TRADERX_SOURCE_REPO_ROOT="${SOURCE_REPO_ROOT}" \
+    "${REPO_ROOT}/scripts/start-base-uncontainerized-generated.sh" --dry-run --build-only
+elif (( DRY_RUN == 1 )); then
   TRADERX_EXPECTED_STATE_ID="${EXPECTED_STATE}" \
   TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
   TRADERX_SOURCE_REPO_ROOT="${SOURCE_REPO_ROOT}" \
     "${REPO_ROOT}/scripts/start-base-uncontainerized-generated.sh" --dry-run
+elif (( BUILD_ONLY == 1 )); then
+  TRADERX_EXPECTED_STATE_ID="${EXPECTED_STATE}" \
+  TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
+  TRADERX_SOURCE_REPO_ROOT="${SOURCE_REPO_ROOT}" \
+    "${REPO_ROOT}/scripts/start-base-uncontainerized-generated.sh" --build-only
 else
   TRADERX_EXPECTED_STATE_ID="${EXPECTED_STATE}" \
   TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
@@ -55,8 +69,34 @@ else
 fi
 
 mkdir -p "${RUN_DIR}/logs" "${RUN_DIR}/pids"
-rm -rf "${EDGE_TARGET_DIR}"
-cp -R "${EDGE_COMPONENT_DIR}" "${EDGE_TARGET_DIR}"
+if [[ ! -d "${EDGE_TARGET_DIR}" ]]; then
+  cp -R "${EDGE_COMPONENT_DIR}" "${EDGE_TARGET_DIR}"
+fi
+
+if (( BUILD_ONLY == 1 )); then
+  if [[ -d "${EDGE_TARGET_DIR}/node_modules" ]]; then
+    echo "[build-skip] edge-proxy: already built"
+  elif (( DRY_RUN == 1 )); then
+    echo "[dry-run] [build] edge-proxy: cd ${EDGE_TARGET_DIR} && npm install"
+  else
+    echo "[build] edge-proxy: npm install"
+    (cd "${EDGE_TARGET_DIR}" && npm install)
+  fi
+
+  if (( DRY_RUN == 1 )); then
+    echo "[done] dry run complete for state 003"
+  else
+    echo "[done] build phase complete for state 003"
+    echo "[hint] run without --build-only to start services"
+  fi
+  exit 0
+fi
+
+if [[ ! -d "${EDGE_TARGET_DIR}/node_modules" ]]; then
+  echo "[error] edge-proxy build artifacts missing (node_modules)."
+  echo "[hint] run ./scripts/start-state-003-agentic-harness-foundation-generated.sh --build-only"
+  exit 1
+fi
 
 pidfile="${RUN_DIR}/pids/edge-proxy.pid"
 logfile="${RUN_DIR}/logs/edge-proxy.log"
@@ -76,13 +116,13 @@ if nc -z localhost "${EDGE_PROXY_PORT}" >/dev/null 2>&1; then
 fi
 
 if (( DRY_RUN == 1 )); then
-  echo "[dry-run] edge-proxy: cd ${EDGE_TARGET_DIR} && [ -d node_modules ] || npm install; npm run start"
+  echo "[dry-run] edge-proxy: cd ${EDGE_TARGET_DIR} && npm run start"
   echo "[done] dry run complete for state 003"
   exit 0
 fi
 
 echo "[start] edge-proxy"
-nohup /bin/zsh -lc "cd '${EDGE_TARGET_DIR}' && [ -d node_modules ] || npm install; npm run start" >"${logfile}" 2>&1 &
+nohup /bin/zsh -lc "cd '${EDGE_TARGET_DIR}' && npm run start" >"${logfile}" 2>&1 &
 echo "$!" > "${pidfile}"
 
 attempts=60

--- a/scripts/start-state-004-containerized-generated.sh
+++ b/scripts/start-state-004-containerized-generated.sh
@@ -17,15 +17,19 @@ COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
 WEB_COMPONENT_DIR="${GENERATED_ROOT}/code/components/web-front-end-angular-specfirst"
 WEB_TARGET_DIR="${GENERATED_ROOT}/code/target-generated/web-front-end/angular"
 DRY_RUN=0
+SKIP_BUILD=0
 
 while (( "$#" )); do
   case "$1" in
     --dry-run)
       DRY_RUN=1
       ;;
+    --skip-build)
+      SKIP_BUILD=1
+      ;;
     *)
       echo "[error] unknown argument: $1"
-      echo "[hint] supported: --dry-run"
+      echo "[hint] supported: --dry-run --skip-build"
       exit 1
       ;;
   esac
@@ -94,12 +98,20 @@ sync_state_aware_web_ui
 }
 
 if (( DRY_RUN == 1 )); then
-  echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --build"
+  if (( SKIP_BUILD == 1 )); then
+    echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --no-build"
+  else
+    echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --build"
+  fi
   echo "[done] dry run complete for state 004"
   exit 0
 fi
 
-docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --build
+if (( SKIP_BUILD == 1 )); then
+  docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --no-build
+else
+  docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --build
+fi
 
 wait_for_http() {
   local name="$1"

--- a/scripts/start-state-005-postgres-database-replacement-generated.sh
+++ b/scripts/start-state-005-postgres-database-replacement-generated.sh
@@ -15,15 +15,19 @@ COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-005}"
 COMPOSE_DIR="${GENERATED_ROOT}/code/target-generated/postgres-database-replacement"
 COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
 DRY_RUN=0
+SKIP_BUILD=0
 
 while (( "$#" )); do
   case "$1" in
     --dry-run)
       DRY_RUN=1
       ;;
+    --skip-build)
+      SKIP_BUILD=1
+      ;;
     *)
       echo "[error] unknown argument: $1"
-      echo "[hint] supported: --dry-run"
+      echo "[hint] supported: --dry-run --skip-build"
       exit 1
       ;;
   esac
@@ -57,12 +61,20 @@ fi
 }
 
 if (( DRY_RUN == 1 )); then
-  echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --build"
+  if (( SKIP_BUILD == 1 )); then
+    echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --no-build"
+  else
+    echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --build"
+  fi
   echo "[done] dry run complete for state 005"
   exit 0
 fi
 
-docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --build
+if (( SKIP_BUILD == 1 )); then
+  docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --no-build
+else
+  docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --build
+fi
 
 wait_for_postgres() {
   local attempts=90

--- a/scripts/start-state-006-messaging-nats-replacement-generated.sh
+++ b/scripts/start-state-006-messaging-nats-replacement-generated.sh
@@ -15,15 +15,19 @@ COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-006}"
 COMPOSE_DIR="${GENERATED_ROOT}/code/target-generated/messaging-nats-replacement"
 COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
 DRY_RUN=0
+SKIP_BUILD=0
 
 while (( "$#" )); do
   case "$1" in
     --dry-run)
       DRY_RUN=1
       ;;
+    --skip-build)
+      SKIP_BUILD=1
+      ;;
     *)
       echo "[error] unknown argument: $1"
-      echo "[hint] supported: --dry-run"
+      echo "[hint] supported: --dry-run --skip-build"
       exit 1
       ;;
   esac
@@ -57,12 +61,20 @@ fi
 }
 
 if (( DRY_RUN == 1 )); then
-  echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --build"
+  if (( SKIP_BUILD == 1 )); then
+    echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --no-build"
+  else
+    echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --build"
+  fi
   echo "[done] dry run complete for state 006"
   exit 0
 fi
 
-docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --build
+if (( SKIP_BUILD == 1 )); then
+  docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --no-build
+else
+  docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --build
+fi
 
 wait_for_postgres() {
   local attempts=90

--- a/scripts/start-state-007-observability-lgtm-compose-generated.sh
+++ b/scripts/start-state-007-observability-lgtm-compose-generated.sh
@@ -16,15 +16,19 @@ GRAFANA_PORT="${GRAFANA_PORT:-3001}"
 COMPOSE_DIR="${GENERATED_ROOT}/code/target-generated/observability-lgtm-compose"
 COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
 DRY_RUN=0
+SKIP_BUILD=0
 
 while (( "$#" )); do
   case "$1" in
     --dry-run)
       DRY_RUN=1
       ;;
+    --skip-build)
+      SKIP_BUILD=1
+      ;;
     *)
       echo "[error] unknown argument: $1"
-      echo "[hint] supported: --dry-run"
+      echo "[hint] supported: --dry-run --skip-build"
       exit 1
       ;;
   esac
@@ -58,12 +62,20 @@ fi
 }
 
 if (( DRY_RUN == 1 )); then
-  echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --build"
+  if (( SKIP_BUILD == 1 )); then
+    echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --no-build"
+  else
+    echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --build"
+  fi
   echo "[done] dry run complete for state 007"
   exit 0
 fi
 
-docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --build
+if (( SKIP_BUILD == 1 )); then
+  docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --no-build
+else
+  docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --build
+fi
 
 wait_for_postgres() {
   local attempts=90

--- a/scripts/start-state-008-pricing-awareness-market-data-generated.sh
+++ b/scripts/start-state-008-pricing-awareness-market-data-generated.sh
@@ -15,15 +15,19 @@ COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-008}"
 COMPOSE_DIR="${GENERATED_ROOT}/code/target-generated/pricing-awareness-market-data"
 COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
 DRY_RUN=0
+SKIP_BUILD=0
 
 while (( "$#" )); do
   case "$1" in
     --dry-run)
       DRY_RUN=1
       ;;
+    --skip-build)
+      SKIP_BUILD=1
+      ;;
     *)
       echo "[error] unknown argument: $1"
-      echo "[hint] supported: --dry-run"
+      echo "[hint] supported: --dry-run --skip-build"
       exit 1
       ;;
   esac
@@ -57,12 +61,20 @@ fi
 }
 
 if (( DRY_RUN == 1 )); then
-  echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --build"
+  if (( SKIP_BUILD == 1 )); then
+    echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --no-build"
+  else
+    echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --build"
+  fi
   echo "[done] dry run complete for state 008"
   exit 0
 fi
 
-docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --build
+if (( SKIP_BUILD == 1 )); then
+  docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --no-build
+else
+  docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --build
+fi
 
 wait_for_postgres() {
   local attempts=90

--- a/scripts/start-state-009-order-management-matcher-generated.sh
+++ b/scripts/start-state-009-order-management-matcher-generated.sh
@@ -16,15 +16,19 @@ GRAFANA_PORT="${GRAFANA_PORT:-3001}"
 COMPOSE_DIR="${GENERATED_ROOT}/code/target-generated/order-management-matcher"
 COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
 DRY_RUN=0
+SKIP_BUILD=0
 
 while (( "$#" )); do
   case "$1" in
     --dry-run)
       DRY_RUN=1
       ;;
+    --skip-build)
+      SKIP_BUILD=1
+      ;;
     *)
       echo "[error] unknown argument: $1"
-      echo "[hint] supported: --dry-run"
+      echo "[hint] supported: --dry-run --skip-build"
       exit 1
       ;;
   esac
@@ -58,12 +62,20 @@ fi
 }
 
 if (( DRY_RUN == 1 )); then
-  echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --build"
+  if (( SKIP_BUILD == 1 )); then
+    echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --no-build"
+  else
+    echo "[dry-run] docker compose -f ${COMPOSE_FILE} --project-name ${COMPOSE_PROJECT_NAME} up -d --build"
+  fi
   echo "[done] dry run complete for state 009"
   exit 0
 fi
 
-docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --build
+if (( SKIP_BUILD == 1 )); then
+  docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --no-build
+else
+  docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --build
+fi
 
 # Grafana only provisions file-based dashboards on startup.
 # Restart once after compose up so updated generated dashboards are always loaded.

--- a/scripts/status-base-uncontainerized-generated.sh
+++ b/scripts/status-base-uncontainerized-generated.sh
@@ -25,7 +25,7 @@ fi
 printf "%-24s %-10s %-8s %-12s\n" "process" "pid" "running" "port-open"
 printf "%-24s %-10s %-8s %-12s\n" "------------------------" "----------" "--------" "------------"
 
-while IFS=, read -r order process workdir start_cmd port health_hint; do
+while IFS=, read -r order process workdir start_cmd port health_hint build_cmd; do
   if [[ "${order}" == "order" ]]; then
     continue
   fi

--- a/scripts/stop-base-uncontainerized-generated.sh
+++ b/scripts/stop-base-uncontainerized-generated.sh
@@ -41,7 +41,7 @@ kill_listener_on_port() {
   done
 }
 
-while IFS=, read -r order process workdir start_cmd port health_hint; do
+while IFS=, read -r order process workdir start_cmd port health_hint build_cmd; do
   if [[ "${order}" == "order" ]]; then
     continue
   fi

--- a/specs/001-baseline-uncontainerized-parity/README.md
+++ b/specs/001-baseline-uncontainerized-parity/README.md
@@ -14,6 +14,17 @@ This is the canonical root Spec Kit feature pack for the TraderX simple base app
 - `conformance/**` - generated per-component conformance packs
 - `tests/smoke/**` - state smoke-test coverage expectations
 
+## Environment Lifecycle Contract
+
+Every uncontainerized generated state must provide and maintain these four scripts:
+
+- `scripts/start-<state>.sh --build-only` - install dependencies and compile artifacts; never starts processes; reruns safely
+- `scripts/start-<state>.sh` - start all services; requires a prior successful build
+- `scripts/stop-<state>.sh` - stop all services; idempotent
+- `scripts/smoke-test-<state>.sh` - end-to-end readiness check against a running environment; read-only; exits `0` only when healthy
+
+The smoke test is the canonical "ready for business" check and must remain runnable independently from the start script.
+
 ## Validation
 
 ```bash

--- a/specs/001-baseline-uncontainerized-parity/quickstart.md
+++ b/specs/001-baseline-uncontainerized-parity/quickstart.md
@@ -18,6 +18,7 @@ bash pipeline/generate-web-front-end-angular-specfirst.sh
 
 ```bash
 ./scripts/stop-base-uncontainerized-generated.sh
+CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh --build-only
 CORS_ALLOWED_ORIGINS=http://localhost:18093 ./scripts/start-base-uncontainerized-generated.sh
 ```
 

--- a/specs/001-baseline-uncontainerized-parity/spec.md
+++ b/specs/001-baseline-uncontainerized-parity/spec.md
@@ -180,6 +180,7 @@ As a developer, I need startup commands to report what state is currently genera
 - **NFR-008 (Responsive Blotters)**: Trade and position blotters MUST preserve readability across viewport sizes via side-by-side wrapping layout with minimum pane width constraints.
 - **NFR-009 (Runtime State Detection)**: State runtime/start scripts MUST detect the currently generated state id before startup and emit explicit guidance for mismatch handling (including clean-rebuild guidance when moving backwards in lineage).
 - **NFR-010 (Optional Auto-Regeneration)**: Runtime/start scripts MUST support an explicit opt-in mode to auto-regenerate the expected state before startup when mismatch is detected.
+- **NFR-011 (Lifecycle Script Contract)**: Generated states MUST expose separated lifecycle commands for build, start, stop, and readiness checks. For uncontainerized states this is `start --build-only`, `start`, `stop`, and `smoke`; for containerized/Kubernetes states `--skip-build` is the accepted build/start separation mode.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/001-baseline-uncontainerized-parity/system/acceptance-criteria.md
+++ b/specs/001-baseline-uncontainerized-parity/system/acceptance-criteria.md
@@ -17,3 +17,4 @@
 - `AC-015` Given account-user mappings are displayed, when people-service lookup succeeds, then full names are shown; on lookup failure, username fallback is shown.
 - `AC-016` Given viewport constraints vary, when trade and position blotters render, then layout wraps while preserving minimum pane width for readability.
 - `AC-017` Given canonical dependency targets are updated, when templates and generated-state branches are validated, then all targeted versions match across releases or the validation gates fail.
+- `AC-018` Given a generated state runtime harness, when lifecycle scripts are validated, then start/stop/readiness scripts exist and build/start separation is explicitly supported (`--build-only` or `--skip-build`).

--- a/specs/001-baseline-uncontainerized-parity/system/requirements-traceability.csv
+++ b/specs/001-baseline-uncontainerized-parity/system/requirements-traceability.csv
@@ -45,3 +45,4 @@ SYS-FR-016,US-011,AC-014,F3,web-front-end-angular,none,scripts/test-web-angular-
 SYS-FR-017,US-012,AC-015,F6,web-front-end-angular,none,scripts/test-web-angular-baseline-ux-contract.sh
 SYS-NFR-008,US-013,AC-016,F2,web-front-end-angular,none,scripts/test-web-angular-baseline-ux-contract.sh
 SYS-NFR-009,US-014,AC-017,STARTUP,trade-service,specs/001-baseline-uncontainerized-parity/contracts/trade-service/openapi.yaml,pipeline/validate-generated-branch-dependency-consistency.sh
+SYS-NFR-010,US-015,AC-018,STARTUP,trade-service,specs/001-baseline-uncontainerized-parity/contracts/trade-service/openapi.yaml,pipeline/validate-lifecycle-script-contract.sh

--- a/specs/001-baseline-uncontainerized-parity/system/system-requirements.md
+++ b/specs/001-baseline-uncontainerized-parity/system/system-requirements.md
@@ -31,3 +31,4 @@
 - `SYS-NFR-007` Spec-first generation SHALL not require hydration from deleted legacy source trees.
 - `SYS-NFR-008` Trade and position blotters SHALL keep responsive readability through side-by-side layout with wrap and minimum pane width constraints.
 - `SYS-NFR-009` Dependency upgrade targets SHALL be declared in canonical repository artifacts and MUST propagate to all generated state releases; generation and validation gates SHALL fail when target versions do not propagate.
+- `SYS-NFR-010` Generated states SHALL enforce a lifecycle script contract with distinct build/start/stop/readiness commands. Uncontainerized states SHALL provide `start --build-only`; containerized/Kubernetes states SHALL provide `--skip-build` or equivalent build/start separation mode.

--- a/specs/001-baseline-uncontainerized-parity/system/user-stories.md
+++ b/specs/001-baseline-uncontainerized-parity/system/user-stories.md
@@ -14,3 +14,4 @@
 - `US-012` As an operations user, I want account-user mappings to display full names resolved from people-service instead of raw usernames.
 - `US-013` As a trader, I want the trade and position blotters to remain readable on varying screen widths via responsive side-by-side wrapping layout.
 - `US-014` As a maintainer, I want dependency target versions declared once and enforced across generated states so upgrades persist across releases without hidden post-generation overrides.
+- `US-015` As an operator, I want every generated state to expose explicit build/start/stop/readiness lifecycle commands so CI and local workflows can separate build from runtime startup.

--- a/specs/002-edge-proxy-uncontainerized/README.md
+++ b/specs/002-edge-proxy-uncontainerized/README.md
@@ -23,3 +23,8 @@ Implemented artifacts:
 - `scripts/start-state-002-edge-proxy-generated.sh`
 - `scripts/test-state-002-edge-proxy.sh`
 - `tests/smoke/README.md`
+
+Runtime lifecycle:
+
+- first run/build: `./scripts/start-state-002-edge-proxy-generated.sh --build-only`
+- start after build: `./scripts/start-state-002-edge-proxy-generated.sh`

--- a/specs/002-edge-proxy-uncontainerized/plan.md
+++ b/specs/002-edge-proxy-uncontainerized/plan.md
@@ -25,5 +25,6 @@
 - `bash pipeline/generate-state.sh 002-edge-proxy-uncontainerized`
 - `bash pipeline/generate-state-002-edge-proxy-uncontainerized.sh`
 - `bash pipeline/apply-state-patchset.sh 002-edge-proxy-uncontainerized generated/code/components`
+- `./scripts/start-state-002-edge-proxy-generated.sh --build-only`
 - `./scripts/start-state-002-edge-proxy-generated.sh`
 - `./scripts/test-state-002-edge-proxy.sh`

--- a/specs/002-edge-proxy-uncontainerized/quickstart.md
+++ b/specs/002-edge-proxy-uncontainerized/quickstart.md
@@ -9,6 +9,7 @@ bash pipeline/generate-state.sh 002-edge-proxy-uncontainerized
 ## 2) Start / Verify / Test / Stop
 
 ```bash
+./scripts/start-state-002-edge-proxy-generated.sh --build-only
 ./scripts/start-state-002-edge-proxy-generated.sh
 ./scripts/status-state-002-edge-proxy-generated.sh
 ./scripts/test-state-002-edge-proxy.sh

--- a/specs/002-edge-proxy-uncontainerized/spec.md
+++ b/specs/002-edge-proxy-uncontainerized/spec.md
@@ -59,5 +59,6 @@
 ## Generation + Runtime Entry Points
 
 - generation: `bash pipeline/generate-state.sh 002-edge-proxy-uncontainerized`
-- runtime: `./scripts/start-state-002-edge-proxy-generated.sh`
+- runtime (first run/build): `./scripts/start-state-002-edge-proxy-generated.sh --build-only`
+- runtime (start after build): `./scripts/start-state-002-edge-proxy-generated.sh`
 - smoke test: `./scripts/test-state-002-edge-proxy.sh`

--- a/specs/003-agentic-harness-foundation/quickstart.md
+++ b/specs/003-agentic-harness-foundation/quickstart.md
@@ -9,6 +9,7 @@ bash pipeline/generate-state.sh 003-agentic-harness-foundation
 ## 2) Start Runtime
 
 ```bash
+./scripts/start-state-003-agentic-harness-foundation-generated.sh --build-only
 ./scripts/start-state-003-agentic-harness-foundation-generated.sh
 ```
 

--- a/specs/004-containerized-compose-runtime/README.md
+++ b/specs/004-containerized-compose-runtime/README.md
@@ -19,3 +19,8 @@ Implemented architecture artifacts:
 - `scripts/start-state-004-containerized-generated.sh`
 - `scripts/test-state-004-containerized.sh`
 - `tests/smoke/README.md`
+
+Runtime lifecycle:
+
+- default build + start: `./scripts/start-state-004-containerized-generated.sh`
+- restart without image rebuild: `./scripts/start-state-004-containerized-generated.sh --skip-build`

--- a/specs/004-containerized-compose-runtime/components/container-runtime-packaging.md
+++ b/specs/004-containerized-compose-runtime/components/container-runtime-packaging.md
@@ -32,3 +32,8 @@ Define container build/run packaging for the full TraderX baseline component set
 - `scripts/stop-state-004-containerized-generated.sh`
 - `scripts/status-state-004-containerized-generated.sh`
 - `scripts/test-state-004-containerized.sh`
+
+Runtime start modes:
+
+- default build + start: `./scripts/start-state-004-containerized-generated.sh`
+- restart without image rebuild: `./scripts/start-state-004-containerized-generated.sh --skip-build`

--- a/specs/004-containerized-compose-runtime/quickstart.md
+++ b/specs/004-containerized-compose-runtime/quickstart.md
@@ -10,6 +10,7 @@ bash pipeline/generate-state.sh 004-containerized-compose-runtime
 
 ```bash
 ./scripts/start-state-004-containerized-generated.sh
+./scripts/start-state-004-containerized-generated.sh --skip-build
 ./scripts/status-state-004-containerized-generated.sh
 ./scripts/test-state-004-containerized.sh
 ./scripts/stop-state-004-containerized-generated.sh

--- a/specs/005-postgres-database-replacement/quickstart.md
+++ b/specs/005-postgres-database-replacement/quickstart.md
@@ -10,6 +10,7 @@ bash pipeline/generate-state.sh 005-postgres-database-replacement
 
 ```bash
 ./scripts/start-state-005-postgres-database-replacement-generated.sh
+./scripts/start-state-005-postgres-database-replacement-generated.sh --skip-build
 ./scripts/status-state-005-postgres-database-replacement-generated.sh
 ./scripts/test-state-005-postgres-database-replacement.sh
 ./scripts/stop-state-005-postgres-database-replacement-generated.sh

--- a/specs/005-postgres-database-replacement/spec.md
+++ b/specs/005-postgres-database-replacement/spec.md
@@ -30,7 +30,7 @@
 ## Success Criteria
 
 - SC-901: `pipeline/generate-state-005-postgres-database-replacement.sh` generates a runnable PostgreSQL-based runtime pack.
-- SC-902: `scripts/start-state-005-postgres-database-replacement-generated.sh` starts runtime successfully.
+- SC-902: `scripts/start-state-005-postgres-database-replacement-generated.sh` starts runtime successfully, and `--skip-build` supports restart without image rebuild.
 - SC-903: `scripts/test-state-005-postgres-database-replacement.sh` passes core smoke checks.
 - SC-904: State catalog points to `code/generated-state-005-postgres-database-replacement`.
 - SC-905: ADR for database engine choice is published and linked from state artifacts.

--- a/specs/006-messaging-nats-replacement/quickstart.md
+++ b/specs/006-messaging-nats-replacement/quickstart.md
@@ -10,6 +10,7 @@ bash pipeline/generate-state.sh 006-messaging-nats-replacement
 
 ```bash
 ./scripts/start-state-006-messaging-nats-replacement-generated.sh
+./scripts/start-state-006-messaging-nats-replacement-generated.sh --skip-build
 ./scripts/status-state-006-messaging-nats-replacement-generated.sh
 ./scripts/test-state-006-messaging-nats-replacement.sh
 ./scripts/stop-state-006-messaging-nats-replacement-generated.sh

--- a/specs/007-observability-lgtm-compose/quickstart.md
+++ b/specs/007-observability-lgtm-compose/quickstart.md
@@ -10,6 +10,7 @@ bash pipeline/generate-state.sh 007-observability-lgtm-compose
 
 ```bash
 ./scripts/start-state-007-observability-lgtm-compose-generated.sh
+./scripts/start-state-007-observability-lgtm-compose-generated.sh --skip-build
 ```
 
 ## 3) Run Smoke Tests

--- a/specs/007-observability-lgtm-compose/spec.md
+++ b/specs/007-observability-lgtm-compose/spec.md
@@ -31,7 +31,7 @@
 
 ## Success Criteria
 
-- SC-01101: `./scripts/start-state-007-observability-lgtm-compose-generated.sh` brings up app + observability stack successfully.
+- SC-01101: `./scripts/start-state-007-observability-lgtm-compose-generated.sh` brings up app + observability stack successfully, and `--skip-build` supports restart without image rebuild.
 - SC-01102: `./scripts/test-state-007-observability-lgtm-compose.sh` validates observability endpoints, dashboard provisioning, and baseline functional flow.
 - SC-01104: Smoke checks fail if Grafana dashboards are present but Loki-backed panels have no ingesting log content.
 - SC-01103: `http://localhost:3001` shows provisioned TraderX dashboard(s) and connected datasources.

--- a/specs/008-pricing-awareness-market-data/quickstart.md
+++ b/specs/008-pricing-awareness-market-data/quickstart.md
@@ -10,6 +10,7 @@ bash pipeline/generate-state.sh 008-pricing-awareness-market-data
 
 ```bash
 ./scripts/start-state-008-pricing-awareness-market-data-generated.sh
+./scripts/start-state-008-pricing-awareness-market-data-generated.sh --skip-build
 ./scripts/status-state-008-pricing-awareness-market-data-generated.sh
 ./scripts/test-state-008-pricing-awareness-market-data.sh
 ./scripts/stop-state-008-pricing-awareness-market-data-generated.sh

--- a/specs/009-order-management-matcher/quickstart.md
+++ b/specs/009-order-management-matcher/quickstart.md
@@ -10,6 +10,7 @@ bash pipeline/generate-state.sh 009-order-management-matcher
 
 ```bash
 ./scripts/start-state-009-order-management-matcher-generated.sh
+./scripts/start-state-009-order-management-matcher-generated.sh --skip-build
 ```
 
 ## 3) Run Smoke Tests

--- a/specs/010-kubernetes-runtime/plan.md
+++ b/specs/010-kubernetes-runtime/plan.md
@@ -16,6 +16,7 @@
 5. Generation hook implementation in `pipeline/generate-state-010-kubernetes-runtime.sh`.
 6. Runtime control scripts:
    - `scripts/start-state-010-kubernetes-runtime-generated.sh`
+   - `scripts/start-state-010-kubernetes-runtime-generated.sh --skip-build`
    - `scripts/stop-state-010-kubernetes-runtime-generated.sh`
    - `scripts/status-state-010-kubernetes-runtime-generated.sh`
 7. Smoke test implementation in `scripts/test-state-010-kubernetes-runtime.sh`.

--- a/specs/010-kubernetes-runtime/quickstart.md
+++ b/specs/010-kubernetes-runtime/quickstart.md
@@ -10,6 +10,7 @@ bash pipeline/generate-state.sh 010-kubernetes-runtime
 
 ```bash
 ./scripts/start-state-010-kubernetes-runtime-generated.sh --provider kind
+./scripts/start-state-010-kubernetes-runtime-generated.sh --provider kind --skip-build
 ./scripts/status-state-010-kubernetes-runtime-generated.sh --provider kind
 ./scripts/test-state-010-kubernetes-runtime.sh http://localhost:8080 traderx kind traderx-state-010
 ./scripts/stop-state-010-kubernetes-runtime-generated.sh --provider kind

--- a/specs/010-kubernetes-runtime/spec.md
+++ b/specs/010-kubernetes-runtime/spec.md
@@ -33,6 +33,6 @@
 ## Success Criteria
 
 - SC-401: `bash pipeline/generate-state.sh 010-kubernetes-runtime` produces Kubernetes artifacts under `generated/code/target-generated/kubernetes-runtime`.
-- SC-402: `./scripts/start-state-010-kubernetes-runtime-generated.sh` creates/uses a Kind cluster, applies manifests, and reaches `http://localhost:8080/health`.
+- SC-402: `./scripts/start-state-010-kubernetes-runtime-generated.sh` creates/uses a Kind cluster, applies manifests, and reaches `http://localhost:8080/health`; reruns with `--skip-build` preserve startup behavior without rebuilding images.
 - SC-403: `./scripts/test-state-010-kubernetes-runtime.sh` passes core ingress/API/UI smoke checks and inherited observability checks (`/grafana`, `/prometheus`), including `order-matcher` ingress health and orders listing endpoints.
 - SC-404: Catalog metadata marks state `009` as implemented with canonical runtime commands.

--- a/specs/011-tilt-kubernetes-dev-loop/README.md
+++ b/specs/011-tilt-kubernetes-dev-loop/README.md
@@ -26,6 +26,7 @@ Core artifacts:
 Runtime entrypoints:
 
 - `./scripts/start-state-011-tilt-kubernetes-dev-loop-generated.sh`
+- `./scripts/start-state-011-tilt-kubernetes-dev-loop-generated.sh --skip-build`
 - `./scripts/status-state-011-tilt-kubernetes-dev-loop-generated.sh`
 - `./scripts/test-state-011-tilt-kubernetes-dev-loop.sh`
 - `./scripts/stop-state-011-tilt-kubernetes-dev-loop-generated.sh`

--- a/specs/011-tilt-kubernetes-dev-loop/quickstart.md
+++ b/specs/011-tilt-kubernetes-dev-loop/quickstart.md
@@ -10,6 +10,7 @@ bash pipeline/generate-state.sh 011-tilt-kubernetes-dev-loop
 
 ```bash
 ./scripts/start-state-011-tilt-kubernetes-dev-loop-generated.sh --provider kind
+./scripts/start-state-011-tilt-kubernetes-dev-loop-generated.sh --provider kind --skip-build
 ./scripts/status-state-011-tilt-kubernetes-dev-loop-generated.sh --provider kind
 ./scripts/test-state-011-tilt-kubernetes-dev-loop.sh http://localhost:8080 traderx kind traderx-state-011
 ./scripts/stop-state-011-tilt-kubernetes-dev-loop-generated.sh --provider kind

--- a/specs/012-platform-convergence-c3/README.md
+++ b/specs/012-platform-convergence-c3/README.md
@@ -29,6 +29,7 @@ Core artifacts:
 Runtime entrypoints:
 
 - `./scripts/start-state-012-platform-convergence-c3-generated.sh`
+- `./scripts/start-state-012-platform-convergence-c3-generated.sh --skip-build`
 - `./scripts/status-state-012-platform-convergence-c3-generated.sh`
 - `./scripts/test-state-012-platform-convergence-c3.sh`
 - `./scripts/stop-state-012-platform-convergence-c3-generated.sh`

--- a/specs/012-platform-convergence-c3/quickstart.md
+++ b/specs/012-platform-convergence-c3/quickstart.md
@@ -10,6 +10,7 @@ bash pipeline/generate-state.sh 012-platform-convergence-c3
 
 ```bash
 ./scripts/start-state-012-platform-convergence-c3-generated.sh --provider kind
+./scripts/start-state-012-platform-convergence-c3-generated.sh --provider kind --skip-build
 ./scripts/status-state-012-platform-convergence-c3-generated.sh --provider kind
 ./scripts/test-state-012-platform-convergence-c3.sh http://localhost:8080 traderx kind traderx-state-012
 ./scripts/stop-state-012-platform-convergence-c3-generated.sh --provider kind

--- a/specs/013-radius-kubernetes-platform/README.md
+++ b/specs/013-radius-kubernetes-platform/README.md
@@ -27,6 +27,7 @@ Core artifacts:
 Runtime entrypoints:
 
 - `./scripts/start-state-013-radius-kubernetes-platform-generated.sh`
+- `./scripts/start-state-013-radius-kubernetes-platform-generated.sh --skip-build`
 - `./scripts/status-state-013-radius-kubernetes-platform-generated.sh`
 - `./scripts/test-state-013-radius-kubernetes-platform.sh`
 - `./scripts/stop-state-013-radius-kubernetes-platform-generated.sh`

--- a/specs/013-radius-kubernetes-platform/quickstart.md
+++ b/specs/013-radius-kubernetes-platform/quickstart.md
@@ -10,6 +10,7 @@ bash pipeline/generate-state.sh 013-radius-kubernetes-platform
 
 ```bash
 ./scripts/start-state-013-radius-kubernetes-platform-generated.sh --provider kind
+./scripts/start-state-013-radius-kubernetes-platform-generated.sh --provider kind --skip-build
 ./scripts/status-state-013-radius-kubernetes-platform-generated.sh --provider kind
 ./scripts/test-state-013-radius-kubernetes-platform.sh http://localhost:8080 traderx kind traderx-state-013
 ./scripts/stop-state-013-radius-kubernetes-platform-generated.sh --provider kind

--- a/specs/014-fdc3-intent-interoperability/quickstart.md
+++ b/specs/014-fdc3-intent-interoperability/quickstart.md
@@ -5,12 +5,14 @@
 ```bash
 bash pipeline/generate-state.sh 012-platform-convergence-c3
 ./scripts/start-state-012-platform-convergence-c3-generated.sh --provider kind
+./scripts/start-state-012-platform-convergence-c3-generated.sh --provider kind --skip-build
 ```
 
 ## 2) Start Local Sail Sidecar (State 014 Target Behavior)
 
 ```bash
 ./scripts/start-state-014-fdc3-intent-interoperability-generated.sh --provider kind --with-sail
+./scripts/start-state-014-fdc3-intent-interoperability-generated.sh --provider kind --with-sail --skip-build
 ```
 
 Expected UI endpoints:


### PR DESCRIPTION
THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS Corporate Contributor License Agreement.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.

---

## Summary
- add explicit lifecycle modes for generated runtime startup scripts
- process states use `--build-only` for build preflight + artifact checks before startup
- compose/kubernetes states use `--skip-build` for restart without rebuild
- add formal lifecycle contract gate: `pipeline/validate-lifecycle-script-contract.sh`
- wire lifecycle gate into spec coverage pipeline
- update catalog/runtime script consumers for process build-command split
- update specs/NFR traceability (state 001) for formal lifecycle behavior
- update docs and runbooks (state quickstarts, spec-kit docs, RUN_FROM_CLONE/RUN_FROM_GENERATED templates)

## Validation
- `bash pipeline/validate-lifecycle-script-contract.sh`
- `bash pipeline/speckit/verify-spec-expressiveness.sh`
- `bash pipeline/verify-spec-coverage.sh`

## Notes
- Remote target branch `agentic-refactor` was not found; PR base is `feature/agentic-renovation`.
