### PR TITLE
fix(generation): honor TRADERX_GENERATED_ROOT in source validation

### DIFF
--- a/pipeline/generate-from-spec.sh
+++ b/pipeline/generate-from-spec.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${ROOT}/generated}"
-REPO_ROOT="${ROOT}"
 CSV="${ROOT}/catalog/component-spec.csv"
 MANIFEST_DIR="${GENERATED_ROOT}/manifests"
 COMPONENTS_DIR="${GENERATED_ROOT}/code/components"
@@ -39,7 +38,7 @@ while IFS=, read -r component_id kind source_path target_path language framework
     continue
   fi
 
-  source_dir="${REPO_ROOT}/${source_path}"
+  source_dir="${COMPONENTS_DIR}/$(basename "${source_path}")"
   if [[ ! -d "${source_dir}" ]]; then
     echo "[fail] missing synthesized component source for ${component_id}: ${source_dir}"
     exit 1


### PR DESCRIPTION
## Summary
- fix `pipeline/generate-from-spec.sh` post-generation validation to resolve component source directories from `COMPONENTS_DIR`
- remove unused `REPO_ROOT` variable
- preserve default behavior when `TRADERX_GENERATED_ROOT` is unset

## Root Cause
Validation used a repo-relative path:

```bash
source_dir="${REPO_ROOT}/${source_path}"
```

When `TRADERX_GENERATED_ROOT` points outside the repo, this incorrectly checks `<repo>/generated/...` instead of the configured generated output root.

## Fix
Validation now resolves from the generated components directory:

```bash
source_dir="${COMPONENTS_DIR}/$(basename "${source_path}")"
```

## Verification
Executed:

```bash
tmpdir=$(mktemp -d /tmp/traderx-generated.XXXXXX)
TRADERX_GENERATED_ROOT="$tmpdir" bash pipeline/generate-from-spec.sh
```

Observed:
- all components regenerated under `$tmpdir/code/components`
- component index written to `$tmpdir/manifests/component-index.csv`
- script exit code `0`

Fixes #340.
