### PR TITLE
Add market order support

### DIFF
--- a/trade-processor/src/main/java/finos/traderx/tradeprocessor/model/OrderType.java
+++ b/trade-processor/src/main/java/finos/traderx/tradeprocessor/model/OrderType.java
@@ -1,0 +1,8 @@
+package finos.traderx.tradeprocessor.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "The order type, ie market order")
+public enum OrderType {
+    Market
+}

--- a/trade-processor/src/main/java/finos/traderx/tradeprocessor/model/TradeOrder.java
+++ b/trade-processor/src/main/java/finos/traderx/tradeprocessor/model/TradeOrder.java
@@ -8,7 +8,7 @@ public class TradeOrder {
     private Integer quantity;
     private Integer accountId;
     private TradeSide side;
-
+    private OrderType orderType;
     public TradeOrder(){}
     
     public TradeOrder(String id, int accountId, String security, TradeSide side, int quantity) {
@@ -17,6 +17,10 @@ public class TradeOrder {
         this.side = side;
         this.quantity = quantity;
         this.id = id;
+    }
+
+    public OrderType getOrderType() {
+        return orderType;
     }
 
     public String getId() {

--- a/trade-processor/src/main/java/finos/traderx/tradeprocessor/service/TradeService.java
+++ b/trade-processor/src/main/java/finos/traderx/tradeprocessor/service/TradeService.java
@@ -34,6 +34,10 @@ public class TradeService {
     
 	public TradeBookingResult processTrade(TradeOrder order) {
 		log.info("Trade order received : "+order);
+		if (order.getOrderType() == null || order.getOrderType() != OrderType.Market) {
+			throw new IllegalArgumentException("Only Market orders are currently supported.");
+		}
+
         Trade t=new Trade();
         t.setAccountId(order.getAccountId());
 

--- a/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/controller/TradeOrderController.java
@@ -21,6 +21,9 @@ import finos.traderx.tradeservice.model.Security;
 import finos.traderx.tradeservice.model.TradeOrder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.http.HttpStatus;
+
+import finos.traderx.tradeservice.model.OrderType;
 
 @CrossOrigin("*")
 @RestController
@@ -44,7 +47,25 @@ public class TradeOrderController {
 	@PostMapping("/")
 	public ResponseEntity<TradeOrder> createTradeOrder(@Parameter(description = "the intendeded trade order") @RequestBody TradeOrder tradeOrder) {
 		log.info("Called createTradeOrder");
-		
+		if (tradeOrder.getSecurity() == null || tradeOrder.getSecurity().isBlank()) {
+			return ResponseEntity.badRequest().build();
+		}
+
+		if (tradeOrder.getAccountId() == null) {
+			return ResponseEntity.badRequest().build();
+		}
+
+		if (tradeOrder.getQuantity() == null || tradeOrder.getQuantity() <= 0) {
+			return ResponseEntity.badRequest().build();
+		}
+
+		if (tradeOrder.getSide() == null) {
+			return ResponseEntity.badRequest().build();
+		}
+
+		if (tradeOrder.getOrderType() == null || tradeOrder.getOrderType() != OrderType.Market) {
+			return ResponseEntity.badRequest().build();
+		}
 		if (!validateTicker(tradeOrder.getSecurity())) 
 		{
 			throw new ResourceNotFoundException(tradeOrder.getSecurity() + " not found in Reference data service.");

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/OrderType.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/OrderType.java
@@ -1,0 +1,8 @@
+package finos.traderx.tradeservice.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "The order type, ie market order")
+public enum OrderType {
+    Market
+}

--- a/trade-service/src/main/java/finos/traderx/tradeservice/model/TradeOrder.java
+++ b/trade-service/src/main/java/finos/traderx/tradeservice/model/TradeOrder.java
@@ -8,6 +8,7 @@ public class TradeOrder {
     private Integer quantity;
     private Integer accountId;
     private TradeSide side;
+    private OrderType orderType;
 
     public TradeOrder(){}
     
@@ -18,7 +19,9 @@ public class TradeOrder {
         this.quantity = quantity;
         this.id = id;
     }
-
+    public OrderType getOrderType() {
+        return orderType;
+    }
     public String getId() {
         return id;
     }

--- a/web-front-end/react/src/ActionButtons/CreateTradeButton.tsx
+++ b/web-front-end/react/src/ActionButtons/CreateTradeButton.tsx
@@ -13,6 +13,10 @@ export const CreateTradeButton = ({accountId}:ActionButtonsProps) => {
 	);
 	
 	const handleSubmit = async () => {
+		if (!security || !side || !quantity || quantity <= 0) {
+			setError("Please select security, side, and a positive quantity.");
+			return;
+		}
 		try {
 			const response = await fetch(`${Environment.trade_service_url}/trade/`, {
 				method: 'POST',
@@ -23,6 +27,7 @@ export const CreateTradeButton = ({accountId}:ActionButtonsProps) => {
 					quantity: quantity,
 					accountId: accountId,
 					side: side,
+					orderType: "Market",
 				}),
 			});
 			if (response.ok) {
@@ -99,6 +104,13 @@ export const CreateTradeButton = ({accountId}:ActionButtonsProps) => {
 							style={{width: "8em"}}
 							onChange={handleSecurityChange}
 						>
+							<TextField
+								label="Order Type"
+								value="Market"
+								variant="outlined"
+								disabled
+								style={{width: "8em"}}
+							/>
 							{tickerItem}
 						</TextField>
 						<TextField


### PR DESCRIPTION
## Summary

Adds explicit Market order support across the TraderX trade submission flow.

This PR implements a focused vertical slice for issue #304 under:

Track 3 → Application Functionality Challenge → Add Trading → Adding market order

## What changed

### Backend

- Added `OrderType` enum with `Market` support in `trade-service`
- Added `orderType` to the `trade-service` `TradeOrder` request model
- Added request validation in `TradeOrderController` before publishing the trade order
- Validates required trade order fields:
  - `security`
  - `accountId`
  - `quantity`
  - `side`
  - `orderType`
- Returns `400 Bad Request` for missing or invalid request fields
- Keeps existing ticker and account validation flow unchanged
- Added `OrderType` enum with `Market` support in `trade-processor`
- Added `orderType` to the `trade-processor` `TradeOrder` model
- Added a Market-order guard in `trade-processor` before processing a trade

### Frontend

- Updated the React trade submission flow to send:

```json
{
  "orderType": "Market"
}