### PR TITLE
specs for aws compose deployment

### DIFF
--- a/docs/spec-kit/aws-ec2-compose-prerequisites.md
+++ b/docs/spec-kit/aws-ec2-compose-prerequisites.md
@@ -1,0 +1,169 @@
+---
+title: AWS EC2 Compose Prerequisites (AL2023)
+---
+
+# AWS EC2 Compose Prerequisites (AL2023)
+
+This runbook captures the validated EC2 host setup for deploying TraderX generated state branches with the `aws-ec2-compose` deployment bundle.
+
+Use this for host preparation and operational baseline. Use each generated state's `runtime/deploy/aws-ec2-compose/README.md` for state-specific deploy variables and commands.
+
+## 1) Environment Coordinates
+
+Add environment coordinates to `~/.bashrc`:
+
+```bash
+# Optional PAT used for authenticated clone
+# export GITHUB_PAT="..."
+
+# 004 demo
+# export FQDN_NAME="demo.traderx.finos.org"
+# export STATE_BRANCH="code/generated-state-004-containerized-compose-runtime"
+
+# 009 advanced demo
+# export FQDN_NAME="demo-advanced.traderx.finos.org"
+# export STATE_BRANCH="code/generated-state-009-order-management-matcher"
+```
+
+Reload shell config:
+
+```bash
+source ~/.bashrc
+```
+
+## 2) Docker + Compose + Buildx
+
+Install Docker and Git:
+
+```bash
+sudo yum install -y docker git
+sudo usermod -a -G docker ec2-user
+id ec2-user
+newgrp docker
+sudo systemctl enable docker.service
+sudo systemctl start docker.service
+```
+
+Install Docker Compose plugin binary:
+
+```bash
+sudo mkdir -p /usr/libexec/docker/cli-plugins/
+sudo curl -SL \
+  "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$(uname -m)" \
+  -o /usr/libexec/docker/cli-plugins/docker-compose
+sudo chmod +x /usr/libexec/docker/cli-plugins/docker-compose
+sudo systemctl restart docker
+```
+
+Validate CLI plugins:
+
+```bash
+docker compose version
+docker buildx version
+```
+
+Important: `docker compose up --build` requires Buildx. If deploy fails with `compose build requires buildx 0.17.0 or later`, update/install Buildx before retry.
+
+## 3) Cron Baseline
+
+```bash
+sudo yum install -y cronie
+sudo systemctl enable crond.service
+sudo systemctl start crond.service
+crontab -e
+```
+
+Example entries:
+
+```cron
+0 5 * * * /home/ec2-user/traderx/runtime/deploy/aws-ec2-compose/deploy.sh
+0 6 * * * sudo /sbin/shutdown -r +5
+0 0,12 * * * /usr/bin/python3 -c 'import random,time; time.sleep(random.random() * 3600)' && sudo certbot renew -q
+```
+
+## 4) NGINX + Certbot
+
+```bash
+wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+sudo rpm -ihv --nodeps ./epel-release-latest-8.noarch.rpm
+sudo yum install -y pip nginx
+sudo systemctl enable nginx.service
+pip3 install certbot certbot-nginx
+```
+
+Set `server_name` in nginx to `${FQDN_NAME}` and ensure at minimum:
+
+```nginx
+location / {
+    proxy_pass http://localhost:8080/;
+}
+```
+
+State `009` requires NATS websocket passthrough:
+
+```nginx
+location /nats-ws {
+    proxy_pass http://localhost:8080/nats-ws;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_read_timeout 86400;
+}
+```
+
+Issue certificate:
+
+```bash
+sudo certbot --nginx -d "${FQDN_NAME}" --agree-tos -m infra@finos.org
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+## 5) Disk Pressure Cleanup
+
+Use when EC2 host reports `no space left on device`:
+
+```bash
+docker system prune -af
+docker system prune --volumes -f
+docker builder prune -af
+```
+
+## 6) Utility Scripts (Optional)
+
+`~/redeploy.sh`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+cd ~
+rm -rf traderx
+git clone "https://${GITHUB_PAT}@github.com/finos/traderx.git"
+cd traderx
+git checkout "$STATE_BRANCH"
+./runtime/deploy/aws-ec2-compose/cleanup.sh
+./runtime/deploy/aws-ec2-compose/deploy.sh
+```
+
+`~/cleanup.sh`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+sudo rm -rf /var/log/journal/*
+docker system prune -a -f
+docker system prune --volumes -f
+docker builder prune -af
+docker rm -v $(sudo docker ps -a -q -f status=exited)
+docker rmi -f $(sudo docker images -f "dangling=true" -q)
+docker volume ls -qf dangling=true | xargs -r docker volume rm
+```
+
+Make executable:
+
+```bash
+chmod +x ~/redeploy.sh ~/cleanup.sh
+```

--- a/docs/spec-kit/demo-004-cutover-checklist.md
+++ b/docs/spec-kit/demo-004-cutover-checklist.md
@@ -1,0 +1,78 @@
+---
+title: Demo 004 Cutover Checklist
+---
+
+# Demo 004 Cutover Checklist
+
+This checklist is for replacing `demo.traderx.finos.org` with state `004-containerized-compose-runtime` on EC2.
+
+## Preconditions
+
+- EC2 host prepared using `/docs/spec-kit/aws-ec2-compose-prerequisites`.
+- DNS for `demo.traderx.finos.org` points to the target instance.
+- TLS certificate issued and nginx active.
+- Security group allows inbound `80` and `443`.
+- Repository has `runtime/deploy/aws-ec2-compose/*` in the selected generated-state branch.
+
+## Environment Setup
+
+```bash
+export FQDN_NAME="demo.traderx.finos.org"
+export STATE_BRANCH="code/generated-state-004-containerized-compose-runtime"
+```
+
+## Dry Run Validation
+
+```bash
+cd ~/traderx
+git fetch --all --prune
+git checkout "${STATE_BRANCH}"
+git reset --hard "origin/${STATE_BRANCH}"
+TRADERX_FQDN="${FQDN_NAME}" ./runtime/deploy/aws-ec2-compose/deploy.sh --dry-run
+```
+
+Expected:
+
+- branch resolves successfully
+- compose file path is valid
+- rendered deploy command includes `docker compose ... up -d --build`
+
+## Deploy
+
+```bash
+TRADERX_FQDN="${FQDN_NAME}" ./runtime/deploy/aws-ec2-compose/cleanup.sh
+TRADERX_FQDN="${FQDN_NAME}" ./runtime/deploy/aws-ec2-compose/deploy.sh
+```
+
+If build fails with Buildx version errors:
+
+```bash
+docker buildx version
+```
+
+Update Buildx per prerequisites runbook, then rerun deploy.
+
+## Post-Deploy Smoke
+
+```bash
+docker ps
+curl -fsS "http://localhost:8080/health"
+curl -I "https://${FQDN_NAME}"
+```
+
+Optional app-level checks:
+
+- load `/` in browser
+- verify trades/positions update flow
+- verify websocket-backed endpoints (`/socket.io/`, `/trade-feed/`) work through nginx
+
+## Rollback
+
+Keep a previous known-good generated branch value:
+
+```bash
+export ROLLBACK_BRANCH="<previous-generated-branch>"
+TRADERX_BRANCH="${ROLLBACK_BRANCH}" TRADERX_FQDN="${FQDN_NAME}" ./runtime/deploy/aws-ec2-compose/deploy.sh
+```
+
+If rollback branch is unknown, use repository history to pick prior successful snapshot SHA and deploy from that ref.

--- a/docs/spec-kit/demo-009-cutover-checklist.md
+++ b/docs/spec-kit/demo-009-cutover-checklist.md
@@ -1,0 +1,100 @@
+---
+title: Demo 009 Cutover Checklist
+---
+
+# Demo 009 Cutover Checklist
+
+This checklist is for deploying state `009-order-management-matcher` to `demo-advanced.traderx.finos.org`.
+
+## Preconditions
+
+- EC2 host prepared using `/docs/spec-kit/aws-ec2-compose-prerequisites`.
+- DNS for `demo-advanced.traderx.finos.org` points to the target instance.
+- TLS certificate issued and nginx active.
+- Security group allows inbound `80` and `443`.
+- Repository has `runtime/deploy/aws-ec2-compose/*` in the selected generated-state branch.
+
+## Environment Setup
+
+```bash
+export FQDN_NAME="demo-advanced.traderx.finos.org"
+export STATE_BRANCH="code/generated-state-009-order-management-matcher"
+```
+
+## NGINX Requirement for 009
+
+State `009` requires websocket proxying for `/nats-ws`. Ensure the TLS server block includes:
+
+```nginx
+location /nats-ws {
+    proxy_pass http://localhost:8080/nats-ws;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_read_timeout 86400;
+}
+```
+
+Then validate and reload:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+## Dry Run Validation
+
+```bash
+cd ~/traderx
+git fetch --all --prune
+git checkout "${STATE_BRANCH}"
+git reset --hard "origin/${STATE_BRANCH}"
+TRADERX_FQDN="${FQDN_NAME}" ./runtime/deploy/aws-ec2-compose/deploy.sh --dry-run
+```
+
+Expected:
+
+- branch resolves successfully
+- compose file path is valid
+- rendered deploy command includes `docker compose ... up -d --build`
+
+## Deploy
+
+```bash
+TRADERX_FQDN="${FQDN_NAME}" ./runtime/deploy/aws-ec2-compose/cleanup.sh
+TRADERX_FQDN="${FQDN_NAME}" ./runtime/deploy/aws-ec2-compose/deploy.sh
+```
+
+If build fails with Buildx version errors:
+
+```bash
+docker buildx version
+```
+
+Update Buildx per prerequisites runbook, then rerun deploy.
+
+## Post-Deploy Smoke
+
+```bash
+docker ps
+curl -fsS "http://localhost:8080/health"
+curl -I "https://${FQDN_NAME}"
+```
+
+009-specific checks:
+
+- open app and validate order ticket + order blotter behavior
+- confirm browser console has no recurring NATS websocket errors
+- in browser Network, verify websocket reaches `wss://${FQDN_NAME}/nats-ws`
+
+## Rollback
+
+Keep a previous known-good generated branch value:
+
+```bash
+export ROLLBACK_BRANCH="<previous-generated-branch>"
+TRADERX_BRANCH="${ROLLBACK_BRANCH}" TRADERX_FQDN="${FQDN_NAME}" ./runtime/deploy/aws-ec2-compose/deploy.sh
+```
+
+If rollback branch is unknown, use repository history to pick prior successful snapshot SHA and deploy from that ref.

--- a/docs/spec-kit/generated-state-branches.md
+++ b/docs/spec-kit/generated-state-branches.md
@@ -39,6 +39,12 @@ Generated branches include metadata files so consumers can always see provenance
 - `docs/learning/*` generated learning artifacts (component list, system design, architecture, diagram)
 - optional `runtime/deploy/*` deployment bundle artifacts for containerized states that explicitly opt in
 
+Deployment runbooks:
+
+- host prerequisites: `/docs/spec-kit/aws-ec2-compose-prerequisites`
+- 004 cutover checklist: `/docs/spec-kit/demo-004-cutover-checklist`
+- 009 cutover checklist: `/docs/spec-kit/demo-009-cutover-checklist`
+
 These files record:
 
 - current state id/title

--- a/docs/spec-kit/generated-state-ci.md
+++ b/docs/spec-kit/generated-state-ci.md
@@ -219,6 +219,7 @@ Policy:
 - Deployment scripts MUST support `--dry-run` and use env vars for environment-specific values (for example target branch, domain/FQDN, image tag).
 - Deployment scripts MUST NOT contain embedded credentials/tokens/secrets.
 - Deployment bundle generation must come from canonical templates/generator logic, not manual edits on generated-state branches.
+- Host-level EC2 setup is documented in `/docs/spec-kit/aws-ec2-compose-prerequisites` (AMI bootstrap, Docker/Compose/Buildx, nginx/certbot, and state-specific websocket routing notes such as `/nats-ws` for state `009`).
 
 Recommended minimum deployment bundle assets:
 

--- a/docs/spec-kit/index.md
+++ b/docs/spec-kit/index.md
@@ -38,6 +38,9 @@ bash pipeline/state-playbook.sh --state <state-id> --publish-neighborhood --push
 4. Understand generated-code branch publishing:
    - `/docs/spec-kit/generated-state-branches`
    - `/docs/spec-kit/generated-state-ci`
+   - `/docs/spec-kit/aws-ec2-compose-prerequisites`
+   - `/docs/spec-kit/demo-004-cutover-checklist`
+   - `/docs/spec-kit/demo-009-cutover-checklist`
 5. Follow patch-set implementation workflow:
    - `/docs/spec-kit/patchset-authoring`
    - `/docs/spec-kit/messaging-subject-map-standard`


### PR DESCRIPTION
This is what we've tested for deploying 004 state to demo.traderx.finos.org and 009 to demo-advanced.traderx.finos.org

Both environments share the same configuration; the configurations that are needed in the box are:
- `STATE_BRANCH` and `FQDN_NAME` in .bashrc file
- Docker and docker compose plugin installed
- Nginx and certbot installed
- Cron installed

In order to trigger a redeployment (which is scheduled on a daily bases), simply run `./redeploy.sh` from the ec2-user home folder.