### PR TITLE
docs: add GitHub Pages CNAME for traderx.finos.org

### DIFF
--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+traderx.finos.org


### PR DESCRIPTION
## Summary
Add a Pages `CNAME` artifact so deployments consistently carry the intended custom domain.

## Change
- add `website/static/CNAME` with `traderx.finos.org`

## Why
- keeps custom-domain intent in version control
- avoids accidental domain drift during future site publishes
