### PR TITLE
Bring docs theme polish to main

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -2,7 +2,6 @@
 
 const projectName = 'TraderX'
 const projectSlug = 'traderX'
-const copyrightOwner = 'FINOS - The Fintech Open Source Foundation'
 const docsUrl = process.env.DOCUSAURUS_URL || 'https://traderx.finos.org'
 const docsBaseUrl = process.env.DOCUSAURUS_BASE_URL || '/'
 
@@ -64,14 +63,6 @@ module.exports = {
   },
   themes: ['@docusaurus/theme-mermaid'],
   themeConfig: {
-    announcementBar: {
-      id: 'traderx-v2-welcome',
-      backgroundColor: '#0b3a5e',
-      textColor: '#ffffff',
-      isCloseable: false,
-      content:
-        'Welcome to the new <strong>TraderX</strong> docs. Read the <a href="/docs/blog/2026-03-29-traderx-speckit-migration"><strong>engineering migration story</strong></a>.',
-    },
     navbar: {
       title: `TraderX`,
       logo: {
@@ -87,17 +78,17 @@ module.exports = {
         {to: '/docs/learning', label: 'Learning', position: 'right'},
         {type: 'search', position: 'right'},
         {
-          href: 'https://github.com/finos/',
+          href: repoUrl,
           label: 'GitHub',
           position: 'right',
         }
       ],
     },
     footer: {
-      copyright: `Copyright © ${new Date().getFullYear()} TraderX - ${copyrightOwner}`,
+      copyright: `Copyright © ${new Date().getFullYear()} Fintech Open Source Foundation.`,
       logo: {
-        alt: 'FINOS Logo',
-        src: 'img/favicon/favicon-finos.ico',
+        alt: 'Fintech Open Source Foundation Logo',
+        src: 'img/finos/finos-white.png',
         href: 'https://finos.org'
       },
       links: [
@@ -127,6 +118,10 @@ module.exports = {
             {
               label: 'Specs',
               to: '/specs',
+            },
+            {
+              label: 'Source Code',
+              to: repoUrl,
             }
           ]
         },

--- a/website/src/components/homepage/Footer.jsx
+++ b/website/src/components/homepage/Footer.jsx
@@ -12,7 +12,7 @@ export default function Footer() {
           <img src="/img/finos/finos-blue.png" alt="FINOS" className={styles.footerFinosLogo} />
           <span />
           <div>
-            <p>Copyright 2026 Fintech Open Source Foundation.</p>
+            <p>Copyright &copy; 2026 Fintech Open Source Foundation.</p>
             <small>
               Homepage state list sourced from{' '}
               <ExternalLink href={catalogSource.catalogUrl}>

--- a/website/src/components/homepage/Hero.jsx
+++ b/website/src/components/homepage/Hero.jsx
@@ -26,10 +26,6 @@ function HeroNav() {
       </Link>
 
       <div className={styles.navLinks}>
-        <ExternalLink href="https://www.finos.org" className={styles.finosNavBadge}>
-          <img src="/img/finos/finos-white.png" alt="FINOS" />
-          <span>A FINOS project</span>
-        </ExternalLink>
         {internalNav.map((item) => (
           <Link key={item.to} to={item.to} className={styles.navLink}>
             {item.label === 'Blog' && <Icon name="blog" />}
@@ -40,9 +36,10 @@ function HeroNav() {
           GitHub
           <Icon name="external" />
         </ExternalLink>
-        <span className={styles.navIcon} aria-hidden="true">
-          <Icon name="sun" />
-        </span>
+        <ExternalLink href="https://www.finos.org" className={styles.finosNavBadge}>
+          <img src="/img/finos/finos-white.png" alt="" />
+          <span>FINOS</span>
+        </ExternalLink>
       </div>
     </nav>
   );

--- a/website/src/components/homepage/Icons.jsx
+++ b/website/src/components/homepage/Icons.jsx
@@ -31,13 +31,6 @@ export function Icon({name, className}) {
           <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
         </svg>
       );
-    case 'sun':
-      return (
-        <svg {...shared}>
-          <circle cx="12" cy="12" r="4" />
-          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
-        </svg>
-      );
     case 'branch':
       return (
         <svg {...shared}>

--- a/website/src/components/homepage/TraderXHomepage.module.css
+++ b/website/src/components/homepage/TraderXHomepage.module.css
@@ -124,10 +124,6 @@
   transition: color 160ms ease, background 160ms ease;
 }
 
-.navIcon {
-  display: inline-flex;
-}
-
 .icon {
   display: inline-block;
   height: 1.1em;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -5,8 +5,16 @@
  * work well for content-centric websites.
  */ 
 
-/* You can override the default Infima variables here. */
 :root {
+  --tx-navy-950: #081523;
+  --tx-navy-900: #0b2138;
+  --tx-navy-800: #12395c;
+  --tx-cyan-500: #00b5e2;
+  --tx-cyan-600: #0086bf;
+  --tx-text: #172033;
+  --tx-muted: #5c6b7d;
+  --tx-border: #dce6ef;
+  --tx-surface: #f6f9fc;
   --ifm-color-primary: #00b5e2;
   --ifm-color-primary-dark: #0079ac;
   --ifm-color-primary-darker: #0072a2;
@@ -14,20 +22,189 @@
   --ifm-color-primary-light: #0093d2;
   --ifm-color-primary-lighter: #009adc;
   --ifm-color-primary-lightest: #00aef8;
-  --ifm-font-color-base: #1C1E21;
-  --ifm-heading-color: #19B6CC;
-  --ifm-navbar-background-color: #0086BF;
-  --ifm-navbar-link-color: #FFFFFF;
-  --ifm-navbar-shadow: 0;
-  --ifm-footer-background-color: #0086BF;
-  --ifm-footer-title-color: #ffffff;
-  --ifm-footer-color: #ffffff;
-  --ifm-footer-link-color: #ffffff;
+  --ifm-background-surface-color: #ffffff;
   --ifm-code-font-size: 95%;
+  --ifm-font-color-base: var(--tx-text);
+  --ifm-heading-color: var(--tx-navy-900);
+  --ifm-link-color: #006fa3;
+  --ifm-link-hover-color: #004f77;
+  --ifm-menu-color-active: #006fa3;
+  --ifm-navbar-background-color: var(--tx-navy-950);
+  --ifm-navbar-link-color: #eef7ff;
+  --ifm-navbar-link-hover-color: #7ee3fa;
+  --ifm-navbar-shadow: none;
+  --ifm-footer-background-color: var(--tx-navy-950);
+  --ifm-footer-title-color: #ffffff;
+  --ifm-footer-color: #d8e4ee;
+  --ifm-footer-link-color: #eef7ff;
+  --ifm-toc-border-color: var(--tx-border);
 }
 
-.navbar__items {
+[data-theme='dark'] {
+  --tx-text: #eef5fb;
+  --tx-muted: #aebdcc;
+  --tx-border: #20394f;
+  --tx-surface: #0f2133;
+  --ifm-background-color: #081523;
+  --ifm-background-surface-color: #0d1d2e;
+  --ifm-font-color-base: var(--tx-text);
+  --ifm-heading-color: #f4fbff;
+  --ifm-link-color: #5fd6f4;
+  --ifm-link-hover-color: #94e7fb;
+  --ifm-navbar-background-color: #081523;
+  --ifm-navbar-link-color: #eef7ff;
+  --ifm-navbar-link-hover-color: #7ee3fa;
+  --ifm-menu-color-active: #7ee3fa;
+  --ifm-footer-background-color: #050d16;
+  --ifm-toc-border-color: var(--tx-border);
+}
+
+body {
+  font-family: 'Overpass', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}
+
+.navbar {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.navbar__brand {
+  color: var(--ifm-navbar-link-color);
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.navbar__logo {
+  height: 2rem;
+}
+
+.navbar__link {
+  border-radius: 6px;
+  font-weight: 700;
+  transition: background-color 140ms ease, color 140ms ease;
+}
+
+.navbar__link:hover,
+.navbar__link--active {
+  background: rgba(126, 227, 250, 0.14);
+  color: var(--ifm-navbar-link-hover-color);
+  text-decoration: none;
+}
+
+.navbar__toggle {
+  color: var(--ifm-navbar-link-color);
+}
+
+.navbar [class*='toggleButton'] {
+  border-radius: 6px;
+  color: var(--ifm-navbar-link-color);
+  transition: background-color 140ms ease, color 140ms ease;
+}
+
+.navbar [class*='toggleButton']:hover {
+  background: rgba(126, 227, 250, 0.14);
+  color: var(--ifm-navbar-link-hover-color);
+}
+
+.navbar [class*='toggleButton'] svg {
+  color: inherit;
+}
+
+.navbar .DocSearch-Button,
+.navbar__search-input {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.16);
   color: #ffffff;
+}
+
+.navbar .DocSearch-Button:hover,
+.navbar__search-input:focus {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.navbar .DocSearch-Button-Placeholder,
+.navbar .DocSearch-Button-Key,
+.navbar__search-input::placeholder {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.theme-doc-sidebar-container {
+  border-right-color: var(--tx-border);
+}
+
+.menu__link {
+  border-radius: 6px;
+}
+
+.menu__link--active:not(.menu__link--sublist) {
+  background: rgba(0, 181, 226, 0.12);
+  color: var(--ifm-menu-color-active);
+  font-weight: 700;
+}
+
+.theme-doc-markdown a:not(.hash-link) {
+  font-weight: 700;
+  text-underline-offset: 0.18em;
+}
+
+.theme-doc-markdown table {
+  display: table;
+  width: 100%;
+  border: 1px solid var(--tx-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.theme-doc-markdown th {
+  background: var(--tx-surface);
+  color: var(--ifm-heading-color);
+}
+
+.theme-admonition {
+  border-radius: 8px;
+  box-shadow: none;
+}
+
+.theme-code-block {
+  border: 1px solid var(--tx-border);
+  border-radius: 8px;
+  box-shadow: none;
+}
+
+.breadcrumbs__link,
+.pagination-nav__link {
+  border-radius: 8px;
+}
+
+.footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 2rem 0 1.5rem;
+}
+
+.footer__logo {
+  height: auto;
+  max-height: 120px;
+  max-width: 96px;
+}
+
+.footer__bottom {
+  margin-top: 1.25rem;
+}
+
+.footer__title {
+  letter-spacing: 0;
+}
+
+.footer__link-item:hover {
+  color: #7ee3fa;
+  text-decoration: none;
+}
+
+@media (max-width: 996px) {
+  .navbar__link:hover,
+  .navbar__link--active {
+    background: transparent;
+  }
 }
 
 .docusaurus-highlight-code-line {
@@ -35,57 +212,6 @@
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
-}
-
-.hero.hero--primary {
-  background-color: #0086BF;
-  background-repeat: no-repeat;
-  background-size: cover;
-}
-
-.hero.hero--primary img {
-  margin-bottom: 30px;
-  width: 50%;
-}
-
-.hero__title {
-  color: #ffffff;
-}
-
-.hero--subtitle {
-  margin-bottom: 50px;
-  font-size: 1.5rem;
-}
-
-.row h2 {
-  margin-bottom: 30px;
-}
-
-.button.button--secondary {
-  color: white;
-}
-
-.button.button--secondary.button--outline:not(.button--active):not(:hover) {
-  color: white;
-}
-
-.row--center h2{
-  color: #29327A;
-  font-size: 35px;
-  font-weight: bolder;
-  text-align: center;
-  margin-left: 0;
-  margin-right: 0;
-  width:100%;
-}
-
-span {
-  color: var(#ffffff);
-}
-
-body{
-  font-family: 'Overpass', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
-  sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
 
 .padding {


### PR DESCRIPTION
## Summary

This brings the docs-theme polish from #405 into `main` after the homepage portal work from #404 landed.

- removes the Docusaurus announcement bar now that the homepage carries the portal positioning
- gives the non-home Docusaurus navbar a darker, more substantial treatment while keeping the title as `TraderX`
- preserves the Docusaurus light/dark toggle on docs pages and restores icon contrast in both modes
- keeps the custom homepage free of a light/dark toggle, moves the FINOS pill to the far right, and shortens it to `FINOS`
- aligns footer branding/copyright with the homepage and FINOS wording

## Validation

From #405:

- `git diff --check`
- `cd website && npm run build`
- browser-checked `/` for no homepage color-mode toggle and compact FINOS pill
- browser-checked `/docs/home` for visible light/dark toggle icons in both light and dark modes
