### PR TITLE
Allow generated Windows clone wrappers in lineage validation

### DIFF
--- a/pipeline/validate-generated-state-lineage-invariants.sh
+++ b/pipeline/validate-generated-state-lineage-invariants.sh
@@ -181,7 +181,7 @@ is_ignored_entry() {
     AGENTS.md|ARCHITECTURE.md|CONTRIBUTING.md|FUNCTIONAL_TESTING.md|LEARNING.md|README.md|RUN_FROM_CLONE.md|RUN_FROM_GENERATED.md|STATE.md|.gitignore)
       return 0
       ;;
-    start-env.sh|stop-env.sh|status-env.sh|test-env.sh)
+    start-env.sh|stop-env.sh|status-env.sh|test-env.sh|start-env.bat|stop-env.bat|status-env.bat|test-env.bat)
       return 0
       ;;
     *)


### PR DESCRIPTION
## Summary

Allow generated clone wrapper batch files in the generated-state lineage invariant root allowlist.

This unblocks republishing generated-state branches after the publisher writes Windows-supported clone entrypoints.

## Validation
- `bash pipeline/validate-generated-state-lineage-invariants.sh --policy-only`
-  `tools/validate-frontmatter.sh`
- `bash pipeline/speckit/validate-root-spec-kit-gates.sh`
- `bash pipeline/speckit/validate-speckit-readiness.sh`
- `bash pipeline/verify-spec-coverage.sh`