### PR TITLE
Fix observability baseline smoke compose context

### DIFF
--- a/scripts/test-state-006-messaging-nats-replacement.sh
+++ b/scripts/test-state-006-messaging-nats-replacement.sh
@@ -13,7 +13,7 @@ if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
     exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
   fi
 fi
-COMPOSE_FILE="${GENERATED_ROOT}/code/target-generated/messaging-nats-replacement/docker-compose.yml"
+COMPOSE_FILE="${TRADERX_COMPOSE_FILE:-${GENERATED_ROOT}/code/target-generated/messaging-nats-replacement/docker-compose.yml}"
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "[error] docker command not found"

--- a/scripts/test-state-007-observability-lgtm-compose.sh
+++ b/scripts/test-state-007-observability-lgtm-compose.sh
@@ -197,7 +197,7 @@ if ! awk "BEGIN {exit !(${loki_service_last} > 0)}"; then
 fi
 
 echo "[check] baseline behavior under observability runtime"
-COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-007}"
+TRADERX_COMPOSE_FILE="${COMPOSE_FILE}" COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}" \
   "${REPO_ROOT}/scripts/test-state-006-messaging-nats-replacement.sh" "${INGRESS_URL}" "${ORIGIN}"
 
 echo "[done] state 007 observability runtime smoke tests passed"


### PR DESCRIPTION
## Summary
- allow the state 006 messaging smoke to accept an explicit compose file via TRADERX_COMPOSE_FILE
- pass the state 007 observability compose file/project into the inherited state 006 baseline smoke
- keeps standalone state 006 smoke defaults unchanged

## Validation
- bash -n scripts/test-state-006-messaging-nats-replacement.sh scripts/test-state-007-observability-lgtm-compose.sh
- tools/validate-frontmatter.sh
- bash pipeline/speckit/validate-root-spec-kit-gates.sh
- bash pipeline/speckit/validate-speckit-readiness.sh
- bash pipeline/verify-spec-coverage.sh
- TRADERX_LOCAL_RUNTIME_SCRIPT=1 TRADERX_SKIP_GENERATE=1 state 007 start/status/test/stop runtime smoke passed after warming Docker base images

## Notes
- Do not merge without explicit maintainer guidance; this PR captures the hardening issue found during generated branch regeneration.