### PR TITLE
Preserve pricing and order UI inheritance

### DIFF
--- a/pipeline/render-state-008-pricing-awareness-market-data.sh
+++ b/pipeline/render-state-008-pricing-awareness-market-data.sh
@@ -66,6 +66,24 @@ ensure_observability_ingress_routes() {
   mv "${tmp_file}" "${ingress_file}"
 }
 
+install_pricing_ux_contract_check() {
+  local generated_scripts_dir="${TARGET_ROOT}/scripts"
+  local contract_script="${ROOT}/scripts/test-web-angular-pricing-ux-contract.sh"
+  local state_test_script="${generated_scripts_dir}/test-state-008-pricing-awareness-market-data.sh"
+
+  require_file "${contract_script}"
+  require_file "${state_test_script}"
+
+  cp "${contract_script}" "${generated_scripts_dir}/test-web-angular-pricing-ux-contract.sh"
+  chmod +x "${generated_scripts_dir}/test-web-angular-pricing-ux-contract.sh"
+
+  if rg -Fq "test-web-angular-pricing-ux-contract.sh" "${state_test_script}"; then
+    return 0
+  fi
+
+  perl -0pi -e 's#(TRADERX_LOCAL_RUNTIME_SCRIPT=1 "\$\{REPO_ROOT\}/scripts/test-web-angular-baseline-ux-contract\.sh" "\$\{GENERATED_ROOT\}/code/target-generated/web-front-end/angular"\n)#$1echo "[check] web-front-end pricing summary UX contract"\nTRADERX_LOCAL_RUNTIME_SCRIPT=1 "${REPO_ROOT}/scripts/test-web-angular-pricing-ux-contract.sh" "${GENERATED_ROOT}/code/target-generated/web-front-end/angular"\n#' "${state_test_script}"
+}
+
 require_file "${COMPOSE_FILE}"
 require_file "${INGRESS_FILE}"
 
@@ -79,5 +97,7 @@ if [[ "${GEN_DEPTH}" == "1" ]]; then
 else
   echo "[info] nested generation depth=${GEN_DEPTH}; skipping ingress observability route mutation"
 fi
+
+install_pricing_ux_contract_check
 
 echo "[done] rendered state 008 pricing ingress + metadata refinements into ${STATE_DIR}"

--- a/pipeline/render-state-009-order-management-matcher.sh
+++ b/pipeline/render-state-009-order-management-matcher.sh
@@ -104,6 +104,24 @@ ensure_order_matcher_ingress_route() {
   mv "${tmp_file}" "${ingress_file}"
 }
 
+install_pricing_order_ux_contract_check() {
+  local generated_scripts_dir="${TARGET_ROOT}/scripts"
+  local contract_script="${ROOT}/scripts/test-web-angular-pricing-ux-contract.sh"
+  local state_test_script="${generated_scripts_dir}/test-state-009-order-management-matcher.sh"
+
+  require_file "${contract_script}"
+  require_file "${state_test_script}"
+
+  cp "${contract_script}" "${generated_scripts_dir}/test-web-angular-pricing-ux-contract.sh"
+  chmod +x "${generated_scripts_dir}/test-web-angular-pricing-ux-contract.sh"
+
+  if rg -Fq "test-web-angular-pricing-ux-contract.sh" "${state_test_script}"; then
+    return 0
+  fi
+
+  perl -0pi -e 's#(TRADERX_LOCAL_RUNTIME_SCRIPT=1 "\$\{REPO_ROOT\}/scripts/test-web-angular-baseline-ux-contract\.sh" "\$\{GENERATED_ROOT\}/code/target-generated/web-front-end/angular"\n)#$1echo "[check] web-front-end pricing/order/admin UX inheritance contract"\nTRADERX_LOCAL_RUNTIME_SCRIPT=1 "${REPO_ROOT}/scripts/test-web-angular-pricing-ux-contract.sh" "${GENERATED_ROOT}/code/target-generated/web-front-end/angular" --orders\n#' "${state_test_script}"
+}
+
 install_order_matcher_nats_publisher() {
   local order_matcher_root="${TARGET_ROOT}/order-matcher"
   local gradle_file="${order_matcher_root}/build.gradle"
@@ -717,5 +735,7 @@ else
   echo "[fail] frontend override source not found: ${FRONTEND_OVERRIDE_SOURCE_DIR}"
   exit 1
 fi
+
+install_pricing_order_ux_contract_check
 
 echo "[done] rendered state 009 order-management observability refinements into ${STATE_DIR}"

--- a/pipeline/render-state-010-kubernetes-runtime.sh
+++ b/pipeline/render-state-010-kubernetes-runtime.sh
@@ -75,6 +75,30 @@ patch_web_frontend_env_for_ingress() {
   echo "[info] patched web-front-end angular environments for ingress-routed APIs"
 }
 
+install_pricing_order_ux_contract_check() {
+  local generated_scripts_dir="${TARGET_ROOT}/scripts"
+  local contract_script="${ROOT}/scripts/test-web-angular-pricing-ux-contract.sh"
+  local state_test_script="${generated_scripts_dir}/test-state-010-kubernetes-runtime.sh"
+
+  [[ -f "${contract_script}" ]] || {
+    echo "[fail] required file missing for state 010 render: ${contract_script}"
+    exit 1
+  }
+  [[ -f "${state_test_script}" ]] || {
+    echo "[fail] required file missing for state 010 render: ${state_test_script}"
+    exit 1
+  }
+
+  cp "${contract_script}" "${generated_scripts_dir}/test-web-angular-pricing-ux-contract.sh"
+  chmod +x "${generated_scripts_dir}/test-web-angular-pricing-ux-contract.sh"
+
+  if rg -Fq "test-web-angular-pricing-ux-contract.sh" "${state_test_script}"; then
+    return 0
+  fi
+
+  perl -0pi -e 's#("\$\{REPO_ROOT\}/scripts/test-web-angular-baseline-ux-contract\.sh" "\$\{GENERATED_ROOT\}/code/target-generated/web-front-end/angular"\n)#$1echo "[check] web-front-end pricing/order/admin UX inheritance contract"\n"${REPO_ROOT}/scripts/test-web-angular-pricing-ux-contract.sh" "${GENERATED_ROOT}/code/target-generated/web-front-end/angular" --orders\n#' "${state_test_script}"
+}
+
 patch_web_frontend_env_for_ingress
 
 rm -rf "${STATE_DIR}"
@@ -1109,5 +1133,7 @@ EOF
     echo "  - ${component}-service.yaml"
   done < <(jq -r '.components[].name' "${SPEC_JSON}")
 } > "${MANIFEST_DIR}/kustomization.yaml"
+
+install_pricing_order_ux_contract_check
 
 echo "[done] rendered state 010 kubernetes runtime assets into ${STATE_DIR}"

--- a/scripts/test-web-angular-pricing-ux-contract.sh
+++ b/scripts/test-web-angular-pricing-ux-contract.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
+WEB_ROOT="${1:-${GENERATED_ROOT}/code/target-generated/web-front-end/angular}"
+EXPECT_ORDER_UI=0
+
+shift || true
+while (( "$#" )); do
+  case "$1" in
+    --orders)
+      EXPECT_ORDER_UI=1
+      ;;
+    *)
+      echo "[error] unknown argument: $1"
+      echo "[hint] usage: $0 [WEB_ROOT] [--orders]"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+TRADE_TS="${WEB_ROOT}/main/app/trade/trade.component.ts"
+TRADE_HTML="${WEB_ROOT}/main/app/trade/trade.component.html"
+POSITION_BLOTTER_TS="${WEB_ROOT}/main/app/trade/position-blotter/position-blotter.component.ts"
+HEADER_HTML="${WEB_ROOT}/main/app/header/header.component.html"
+ROUTING_TS="${WEB_ROOT}/main/app/routing.ts"
+ADMIN_TS="${WEB_ROOT}/main/app/admin/order-admin.component.ts"
+ADMIN_HTML="${WEB_ROOT}/main/app/admin/order-admin.component.html"
+
+require_pattern() {
+  local file="$1"
+  local pattern="$2"
+  local message="$3"
+  if [[ ! -f "${file}" ]]; then
+    echo "[error] missing expected source file: ${file}"
+    exit 1
+  fi
+  if ! grep -Eq "${pattern}" "${file}"; then
+    echo "[error] ${message}"
+    echo "        file=${file}"
+    exit 1
+  fi
+}
+
+echo "[check] pricing-aware trade page summary contract"
+require_pattern "${TRADE_TS}" "PortfolioSummary" "expected trade component to retain portfolio summary model"
+require_pattern "${TRADE_TS}" "PositionService" "expected trade component to load all positions for total portfolio summaries"
+require_pattern "${TRADE_TS}" "TradeFeedService" "expected trade component to subscribe to pricing stream"
+require_pattern "${TRADE_TS}" "subscribe\\('pricing\\.\\*'" "expected trade component pricing wildcard subscription"
+require_pattern "${TRADE_TS}" "loadAllPositions\\(" "expected all-accounts position bootstrap for summary cards"
+require_pattern "${TRADE_TS}" "recomputeAllAccountsSummary\\(" "expected all-accounts summary recomputation"
+require_pattern "${TRADE_TS}" "onSummaryChange\\(" "expected selected-account summary callback"
+require_pattern "${TRADE_HTML}" "Total Cost Basis \\(All Accounts\\)" "expected all-accounts cost basis summary card"
+require_pattern "${TRADE_HTML}" "Total Portfolio Value \\(All Accounts\\)" "expected all-accounts portfolio value summary card"
+require_pattern "${TRADE_HTML}" "Total Net P&amp;L \\(All Accounts\\)" "expected all-accounts P&L summary card"
+require_pattern "${TRADE_HTML}" "Account Cost Basis \\(" "expected selected-account cost basis summary card"
+require_pattern "${TRADE_HTML}" "Account Portfolio Value \\(" "expected selected-account portfolio value summary card"
+require_pattern "${TRADE_HTML}" "Account Net P&amp;L \\(" "expected selected-account P&L summary card"
+require_pattern "${TRADE_HTML}" '\(summaryChange\)="onSummaryChange\([$]event\)"' "expected position blotter summaryChange binding"
+require_pattern "${POSITION_BLOTTER_TS}" "@Output\\(\\) summaryChange" "expected position blotter to emit portfolio summaries"
+require_pattern "${POSITION_BLOTTER_TS}" "this\\.summaryChange\\.emit\\(" "expected position blotter summary emission"
+
+if [[ "${EXPECT_ORDER_UI}" -eq 1 ]]; then
+  echo "[check] order-management trade/admin UI inheritance contract"
+  require_pattern "${TRADE_TS}" "activeBlotter: 'trades' \\| 'orders'" "expected trade/order blotter mode state"
+  require_pattern "${TRADE_TS}" "setBlotterMode\\(" "expected trade/order blotter mode switch handler"
+  require_pattern "${TRADE_TS}" "this\\.activeBlotter = 'orders'" "expected order creation or intent to reveal orders view"
+  require_pattern "${TRADE_HTML}" "Create Order Ticket|Create Order" "expected order ticket launcher"
+  require_pattern "${TRADE_HTML}" "Trades / Positions" "expected trades/positions tab label"
+  require_pattern "${TRADE_HTML}" "Orders" "expected orders tab label"
+  require_pattern "${TRADE_HTML}" "\\*ngIf=\"activeBlotter === 'trades'\"" "expected trades/positions view gating"
+  require_pattern "${TRADE_HTML}" "\\*ngIf=\"activeBlotter === 'orders'\"" "expected orders view gating"
+  require_pattern "${TRADE_HTML}" "app-order-blotter" "expected account-scoped order blotter"
+  require_pattern "${HEADER_HTML}" "routerLink=\"/admin\"[^>]*>Admin<" "expected Admin functional tab"
+  require_pattern "${ROUTING_TS}" "path: 'admin'" "expected Admin route registration"
+  require_pattern "${ROUTING_TS}" "OrderAdminComponent" "expected Admin route to use order manager component"
+  require_pattern "${ADMIN_TS}" "selector: 'app-order-admin'" "expected order admin component"
+  require_pattern "${ADMIN_TS}" "forceFillOrder\\(" "expected order admin force-fill workflow"
+  require_pattern "${ADMIN_TS}" "cancelOrder\\(" "expected order admin cancel workflow"
+  require_pattern "${ADMIN_HTML}" "Order Matcher Admin" "expected order admin page heading"
+fi
+
+echo "[done] web-front-end-angular pricing/order UX contract checks passed"

--- a/scripts/test-web-angular-pricing-ux-contract.sh
+++ b/scripts/test-web-angular-pricing-ux-contract.sh
@@ -3,19 +3,21 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
-WEB_ROOT="${1:-${GENERATED_ROOT}/code/target-generated/web-front-end/angular}"
+WEB_ROOT="${GENERATED_ROOT}/code/target-generated/web-front-end/angular"
 EXPECT_ORDER_UI=0
 
-shift || true
 while (( "$#" )); do
   case "$1" in
     --orders)
       EXPECT_ORDER_UI=1
       ;;
-    *)
+    -*)
       echo "[error] unknown argument: $1"
       echo "[hint] usage: $0 [WEB_ROOT] [--orders]"
       exit 1
+      ;;
+    *)
+      WEB_ROOT="$1"
       ;;
   esac
   shift

--- a/specs/008-pricing-awareness-market-data/generation/frontend-overrides/web-front-end/angular/main/app/trade/trade.component.html
+++ b/specs/008-pricing-awareness-market-data/generation/frontend-overrides/web-front-end/angular/main/app/trade/trade.component.html
@@ -12,24 +12,15 @@
             </app-ngx-dropdown>
         </div>
         <div class="trade-ticket mb-4">
-            <div class="d-flex flex-wrap gap-2 mb-2">
-                <button type="button" id="createTicketBtn" class="btn btn-sm btn-primary" (click)="openTicket(tradeTicketTemplate)" [disabled]="isAllAccountsSelected">
-                    Create Trade Ticket
-                </button>
-                <button type="button" id="createOrderBtn" class="btn btn-sm btn-outline-primary" (click)="openOrderTicket(orderTicketTemplate)" [disabled]="isAllAccountsSelected">
-                    Create Order Ticket
-                </button>
-            </div>
+            <button type="button" id="createTicketBtn" class="btn btn-sm btn-primary mb-2" (click)="openTicket(ticketComponent)" [disabled]="isAllAccountsSelected">
+                Create Trade Ticket
+            </button>
             <div *ngIf="isAllAccountsSelected" class="text-muted small mb-2">
-                Ticket creation is disabled in <strong>All Accounts</strong> mode.
+                Trade ticket is disabled in <strong>All Accounts</strong> mode.
             </div>
-            <ng-template #tradeTicketTemplate>
+            <ng-template #ticketComponent>
                 <app-trade-ticket [stocks]="stocks" [account]="accountModel" (create)="createTradeTicket($event)" (cancel)="closeTicket()">
                 </app-trade-ticket>
-            </ng-template>
-            <ng-template #orderTicketTemplate>
-                <app-order-ticket [stocks]="stocks" [account]="accountModel" [presetSecurity]="selectedOrderSecurity" (create)="createOrderTicket($event)" (cancel)="closeTicket()">
-                </app-order-ticket>
             </ng-template>
             <alert
                 *ngIf="createTicketResponse"
@@ -39,15 +30,6 @@
                 (onClosed)="onCloseAlert()"
             >
                 {{ createTicketResponse | json }}</alert
-            >
-            <alert
-                *ngIf="createOrderResponse"
-                [type]="createOrderResponse.orderId ? 'success' : 'danger'"
-                [dismissible]="true"
-                [dismissOnTimeout]="3000"
-                (onClosed)="onCloseOrderAlert()"
-            >
-                {{ createOrderResponse | json }}</alert
             >
         </div>
     </div>
@@ -94,20 +76,7 @@
         </div>
     </div>
 
-    <ul class="nav nav-pills mb-3">
-        <li class="nav-item">
-            <button type="button" class="btn btn-sm me-2" [ngClass]="activeBlotter === 'trades' ? 'btn-primary' : 'btn-outline-primary'" (click)="setBlotterMode('trades')">
-                Trades / Positions
-            </button>
-        </li>
-        <li class="nav-item">
-            <button type="button" class="btn btn-sm" [ngClass]="activeBlotter === 'orders' ? 'btn-primary' : 'btn-outline-primary'" (click)="setBlotterMode('orders')">
-                Orders
-            </button>
-        </li>
-    </ul>
-
-    <div *ngIf="activeBlotter === 'trades'" class="trade-blotter">
+    <div class="trade-blotter">
         <app-trade-blotter
             [account]="accountModel"
             [allAccountsMode]="isAllAccountsSelected"
@@ -122,14 +91,5 @@
             class="position-blotter-items"
             (summaryChange)="onSummaryChange($event)">
         </app-position-blotter>
-    </div>
-
-    <div *ngIf="activeBlotter === 'orders'" class="order-blotter mt-4">
-        <app-order-blotter
-            [account]="accountModel"
-            [allAccountsMode]="isAllAccountsSelected"
-            [accountNameById]="accountNameById"
-            (securitySelected)="onOrderSecuritySelected($event)">
-        </app-order-blotter>
     </div>
 </div>

--- a/specs/008-pricing-awareness-market-data/generation/frontend-overrides/web-front-end/angular/main/app/trade/trade.component.ts
+++ b/specs/008-pricing-awareness-market-data/generation/frontend-overrides/web-front-end/angular/main/app/trade/trade.component.ts
@@ -1,13 +1,11 @@
 import { Component, OnDestroy, OnInit, TemplateRef } from '@angular/core';
 import { Subject } from 'rxjs';
 import { PortfolioSummary, PriceTick, TradeTicket, Position } from '../model/trade.model';
-import { OrderCreateRequest } from '../model/order.model';
 import { Account } from '../model/account.model';
 import { AccountService } from '../service/account.service';
 import { Stock } from '../model/symbol.model';
 import { SymbolService } from '../service/symbols.service';
 import { BsModalService, BsModalRef } from 'ngx-bootstrap/modal';
-import { OrderAdminService } from '../service/order-admin.service';
 import { PositionService } from '../service/position.service';
 import { TradeFeedService } from '../service/trade-feed.service';
 
@@ -30,8 +28,6 @@ export class TradeComponent implements OnInit, OnDestroy {
     stocks: Stock[] = [];
     modalRef?: BsModalRef;
     createTicketResponse: any;
-    createOrderResponse: any;
-    activeBlotter: 'trades' | 'orders' = 'trades';
     portfolioSummary: PortfolioSummary = {
         totalMarketValue: 0,
         totalCostBasis: 0,
@@ -47,7 +43,6 @@ export class TradeComponent implements OnInit, OnDestroy {
         totalCostBasis: 0,
         totalPnl: 0
     };
-    selectedOrderSecurity = '';
     allPositions: Position[] = [];
     private readonly marketPriceByTicker = new Map<string, number>();
     private priceStreamUnsubscribeFn?: Function;
@@ -55,7 +50,6 @@ export class TradeComponent implements OnInit, OnDestroy {
 
     constructor(private accountService: AccountService,
         private symbolService: SymbolService,
-        private orderAdminService: OrderAdminService,
         private positionService: PositionService,
         private tradeFeed: TradeFeedService,
         private modalService: BsModalService) { }
@@ -99,13 +93,6 @@ export class TradeComponent implements OnInit, OnDestroy {
         this.modalRef = this.modalService.show(template);
     }
 
-    openOrderTicket(template: TemplateRef<any>) {
-        if (this.isAllAccountsSelected) {
-            return;
-        }
-        this.modalRef = this.modalService.show(template);
-    }
-
     createTradeTicket(ticket: TradeTicket) {
         if (this.isAllAccountsSelected) {
             this.createTicketResponse = { success: false, message: 'Select a specific account to create a trade.' };
@@ -120,22 +107,6 @@ export class TradeComponent implements OnInit, OnDestroy {
         this.closeTicket();
     }
 
-    createOrderTicket(order: OrderCreateRequest) {
-        if (this.isAllAccountsSelected) {
-            this.createOrderResponse = { success: false, message: 'Select a specific account to create an order.' };
-            return;
-        }
-        this.orderAdminService.createOrder(order).subscribe((response) => {
-            this.createOrderResponse = response;
-            this.activeBlotter = 'orders';
-        });
-        this.closeTicket();
-    }
-
-    onOrderSecuritySelected(security: string) {
-        this.selectedOrderSecurity = String(security || '').trim().toUpperCase();
-    }
-
     closeTicket() {
         this.modalRef?.hide();
     }
@@ -144,17 +115,9 @@ export class TradeComponent implements OnInit, OnDestroy {
         this.createTicketResponse = undefined;
     }
 
-    onCloseOrderAlert() {
-        this.createOrderResponse = undefined;
-    }
-
     onSummaryChange(summary: PortfolioSummary) {
         this.accountSummary = summary;
         this.portfolioSummary = this.isAllAccountsSelected ? this.allAccountsSummary : summary;
-    }
-
-    setBlotterMode(mode: 'trades' | 'orders') {
-        this.activeBlotter = mode;
     }
 
     private setAccount(account: Account) {
@@ -175,7 +138,6 @@ export class TradeComponent implements OnInit, OnDestroy {
     get isAllAccountsSelected(): boolean {
         return (this.accountModel?.id ?? -1) === this.allAccountsOption.id;
     }
-
     ngOnDestroy(): void {
         this.priceStreamUnsubscribeFn?.();
     }

--- a/specs/008-pricing-awareness-market-data/generation/frontend-overrides/web-front-end/angular/main/app/trade/trade.component.ts
+++ b/specs/008-pricing-awareness-market-data/generation/frontend-overrides/web-front-end/angular/main/app/trade/trade.component.ts
@@ -45,7 +45,7 @@ export class TradeComponent implements OnInit, OnDestroy {
     };
     allPositions: Position[] = [];
     private readonly marketPriceByTicker = new Map<string, number>();
-    private priceStreamUnsubscribeFn?: Function;
+    private priceStreamUnsubscribeFn?: () => void;
     private account = new Subject<Account>();
 
     constructor(private accountService: AccountService,
@@ -69,10 +69,11 @@ export class TradeComponent implements OnInit, OnDestroy {
         this.symbolService.getStocks().subscribe((stocks) => this.stocks = stocks);
         this.loadAllPositions();
         this.priceStreamUnsubscribeFn = this.tradeFeed.subscribe('pricing.*', (tick: PriceTick) => {
-            if (!tick?.ticker || tick.price == null) {
+            const ticker = this.normalizeTicker(tick?.ticker);
+            if (!ticker || tick.price == null) {
                 return;
             }
-            this.marketPriceByTicker.set(tick.ticker, Number(tick.price));
+            this.marketPriceByTicker.set(ticker, Number(tick.price));
             this.recomputeAllAccountsSummary();
         });
     }
@@ -142,6 +143,10 @@ export class TradeComponent implements OnInit, OnDestroy {
         this.priceStreamUnsubscribeFn?.();
     }
 
+    private normalizeTicker(ticker: string | undefined): string {
+        return String(ticker || '').trim().toUpperCase();
+    }
+
     private loadAllPositions() {
         this.positionService.getAllPositions().subscribe((positions: Position[]) => {
             this.allPositions = positions ?? [];
@@ -157,9 +162,10 @@ export class TradeComponent implements OnInit, OnDestroy {
         };
 
         for (const position of this.allPositions) {
-            const quantity = Number((position as any).quantity ?? 0);
-            const averageCostBasis = Number((position as any).averageCostBasis ?? (position as any).averagecostbasis ?? 0);
-            const security = String((position as any).security ?? '');
+            const pricingPosition = position as Position & { averagecostbasis?: number };
+            const quantity = Number(position.quantity ?? 0);
+            const averageCostBasis = Number(pricingPosition.averageCostBasis ?? pricingPosition.averagecostbasis ?? 0);
+            const security = this.normalizeTicker(position.security);
             const marketPrice = Number(this.marketPriceByTicker.get(security) ?? averageCostBasis);
             const marketValue = quantity * marketPrice;
             const costBasisValue = quantity * averageCostBasis;

--- a/specs/009-order-management-matcher/generation/frontend-overrides/web-front-end/angular/main/app/trade/trade.component.ts
+++ b/specs/009-order-management-matcher/generation/frontend-overrides/web-front-end/angular/main/app/trade/trade.component.ts
@@ -50,7 +50,7 @@ export class TradeComponent implements OnInit, OnDestroy {
     selectedOrderSecurity = '';
     allPositions: Position[] = [];
     private readonly marketPriceByTicker = new Map<string, number>();
-    private priceStreamUnsubscribeFn?: Function;
+    private priceStreamUnsubscribeFn?: () => void;
     private account = new Subject<Account>();
 
     constructor(private accountService: AccountService,
@@ -75,10 +75,11 @@ export class TradeComponent implements OnInit, OnDestroy {
         this.symbolService.getStocks().subscribe((stocks) => this.stocks = stocks);
         this.loadAllPositions();
         this.priceStreamUnsubscribeFn = this.tradeFeed.subscribe('pricing.*', (tick: PriceTick) => {
-            if (!tick?.ticker || tick.price == null) {
+            const ticker = this.normalizeTicker(tick?.ticker);
+            if (!ticker || tick.price == null) {
                 return;
             }
-            this.marketPriceByTicker.set(tick.ticker, Number(tick.price));
+            this.marketPriceByTicker.set(ticker, Number(tick.price));
             this.recomputeAllAccountsSummary();
         });
     }
@@ -180,6 +181,10 @@ export class TradeComponent implements OnInit, OnDestroy {
         this.priceStreamUnsubscribeFn?.();
     }
 
+    private normalizeTicker(ticker: string | undefined): string {
+        return String(ticker || '').trim().toUpperCase();
+    }
+
     private loadAllPositions() {
         this.positionService.getAllPositions().subscribe((positions: Position[]) => {
             this.allPositions = positions ?? [];
@@ -195,9 +200,10 @@ export class TradeComponent implements OnInit, OnDestroy {
         };
 
         for (const position of this.allPositions) {
-            const quantity = Number((position as any).quantity ?? 0);
-            const averageCostBasis = Number((position as any).averageCostBasis ?? (position as any).averagecostbasis ?? 0);
-            const security = String((position as any).security ?? '');
+            const pricingPosition = position as Position & { averagecostbasis?: number };
+            const quantity = Number(position.quantity ?? 0);
+            const averageCostBasis = Number(pricingPosition.averageCostBasis ?? pricingPosition.averagecostbasis ?? 0);
+            const security = this.normalizeTicker(position.security);
             const marketPrice = Number(this.marketPriceByTicker.get(security) ?? averageCostBasis);
             const marketValue = quantity * marketPrice;
             const costBasisValue = quantity * averageCostBasis;


### PR DESCRIPTION
## Summary

Fixes #435.

- Add the pricing-aware trade page override at state 008 so portfolio valuation UI starts where the spec introduces pricing awareness.
- Preserve that pricing summary UI in state 009 while adding order ticket creation and Trades/Orders blotter switching.
- Add a generated Angular UX contract that enforces pricing summaries plus the state 009+ Admin order manager tab/route/component surface.
- Wire the contract through state 008, 009, and 010 renderers so descendants through 014 inherit the checks unless a later spec intentionally changes the surface.

## Root Cause

State 008 had the pricing-aware backend/runtime behavior but did not install the pricing-aware trade page override. State 009 then overrode the trade page for order management without preserving the state 008 valuation UI, which made generated state 009 visually narrower than later local state 014 experiments.

## Generator Follow-up

A suspected state 004 patch drift failure was rechecked on PR #434 and on this branch with clean isolated generated roots. Clean generation for state 004 and state 008 passed, so no speculative generator fallback was added.

## Validation

- bash -n scripts/test-web-angular-pricing-ux-contract.sh pipeline/render-state-008-pricing-awareness-market-data.sh pipeline/render-state-009-order-management-matcher.sh pipeline/render-state-010-kubernetes-runtime.sh
- Targeted generated-branch overlay checks passed for 008, 009, and 014.
- Clean isolated generation passed for state 008 on this branch.
