### PR TITLE
Update trade-feed engine.io lockfile

### DIFF
--- a/templates/trade-feed-specfirst/package-lock.json
+++ b/templates/trade-feed-specfirst/package-lock.json
@@ -340,9 +340,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
-      "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.12",
@@ -354,7 +354,7 @@
         "cors": "~2.8.5",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3"
+        "ws": "~8.21.0"
       },
       "engines": {
         "node": ">=10.2.0"


### PR DESCRIPTION
## Summary

- Refresh the canonical trade-feed template lockfile so Socket.IO resolves patched `engine.io@6.6.9` instead of vulnerable `6.6.6`.

## Reason

Full generated-state republish stopped in the default prepublish CVE gate for state 002 because OWASP dependency-check flagged `engine.io@6.6.6` via `GHSA-r635-g3xr-vw7x`, `CVE-2026-59724`, and `CVE-2026-59725` with CVSS 7.5.

## Validation

- `npm update engine.io --package-lock-only` in `templates/trade-feed-specfirst`
- Confirmed the lockfile now resolves `engine.io@6.6.9`.
