### PR TITLE
Avoid node cleanup during runtime dry-run

### DIFF
--- a/scripts/start-base-uncontainerized-generated.sh
+++ b/scripts/start-base-uncontainerized-generated.sh
@@ -269,7 +269,7 @@ for (const [packagePath, metadata] of Object.entries(packages)) {
 NODE
   }
 
-  if echo "${build_cmd}" | grep -q 'node_modules' && [[ -d "${workdir}/node_modules" ]]; then
+  if ((DRY_RUN != 1)) && echo "${build_cmd}" | grep -q 'node_modules' && [[ -d "${workdir}/node_modules" ]]; then
     if ! node_modules_match_package_lock "${workdir}"; then
       echo "[build] ${process}: removing stale node_modules"
       rm -rf "${workdir}/node_modules"


### PR DESCRIPTION
## Summary
- prevent runtime dry-run checks from removing stale node_modules
- keep stale Node install cleanup limited to real build/start flows

## Validation
- bash -n scripts/start-base-uncontainerized-generated.sh
- full publish retry reached state 001 dry-run and exposed this mutation path