### PR TITLE
Refresh state 004 generated overlay patch

### DIFF
--- a/specs/004-containerized-compose-runtime/generation/patches/0001-state-overlay.patch
+++ b/specs/004-containerized-compose-runtime/generation/patches/0001-state-overlay.patch
@@ -90,239 +90,6 @@ index 0000000..e719c7a
 +        with:
 +          image: ${{ env.GHCR_ORG }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image_name }}:${{ github.sha }}
 +          severity: HIGH
-diff --git a/.github/workflows/license-scanning-node.yml b/.github/workflows/license-scanning-node.yml
-index 9e53b81..91e5754 100644
---- a/.github/workflows/license-scanning-node.yml
-+++ b/.github/workflows/license-scanning-node.yml
-@@ -9,7 +9,26 @@ on:
-       - '.github/workflows/license-scanning-node.yml'
- 
- jobs:
--  no-node-targets:
-+  scan:
-     runs-on: ubuntu-latest
-+    strategy:
-+      fail-fast: false
-+      matrix:
-+        module_folder:
-+          - reference-data
-+          - trade-feed
-+          - web-front-end/angular
-     steps:
--      - run: echo "No Node.js modules detected for license scanning."
-+      - uses: actions/checkout@v4
-+      - name: Set up Node.js
-+        uses: actions/setup-node@v4
-+        with:
-+          node-version: 20
-+      - name: Install production dependencies
-+        run: npm install --omit=dev
-+        working-directory: ${{ matrix.module_folder }}
-+      - name: Install license validator
-+        run: npm install -g node-license-validator
-+      - name: Validate licenses
-+        run: node-license-validator . --allow-licenses Apache-2.0 MIT BSD-2-Clause BSD BSD-3-Clause Unlicense ISC
-+        working-directory: ${{ matrix.module_folder }}
-diff --git a/.github/workflows/security.yml b/.github/workflows/security.yml
-index c806717..d4f367f 100644
---- a/.github/workflows/security.yml
-+++ b/.github/workflows/security.yml
-@@ -11,9 +11,193 @@ on:
-       - '**/*.csproj'
-       - '.github/*-cve-ignore-list.xml'
-       - '.github/workflows/security.yml'
-+      - '**/Dockerfile'
-+      - '**/Dockerfile.compose'
- 
- jobs:
--  no-security-targets:
-+  node-modules-scan:
-+    name: ${{ matrix.module_folder }}-node-scan
-     runs-on: ubuntu-latest
-+    strategy:
-+      fail-fast: false
-+      matrix:
-+        module_folder:
-+          - reference-data
-+          - trade-feed
-+          - web-front-end/angular
-     steps:
--      - run: echo "No dependency or container targets detected for security scanning."
-+      - name: Checkout
-+        uses: actions/checkout@v4
-+      - name: Set up Node
-+        uses: actions/setup-node@v4
-+        with:
-+          node-version: 20
-+      - name: Install production dependencies
-+        run: npm install --omit=dev
-+        working-directory: ${{ matrix.module_folder }}
-+      - name: Prepare artifact name
-+        shell: bash
-+        run: |
-+          echo "UPNAME=$(echo '${{ matrix.module_folder }}' | tr '/\\ ' '---' | tr -cd '[:alnum:]._-')" >> "${GITHUB_ENV}"
-+      - name: Dependency check
-+        uses: dependency-check/Dependency-Check_Action@main
-+        with:
-+          project: ${{ matrix.module_folder }}
-+          path: ${{ matrix.module_folder }}
-+          format: HTML
-+          out: ${{ matrix.module_folder }}-reports
-+          args: >
-+            --suppression .github/node-cve-ignore-list.xml
-+            --nodeAuditSkipDevDependencies
-+            --nodePackageSkipDevDependencies
-+            --failOnCVSS 5
-+            --enableRetired
-+      - name: Upload reports
-+        if: ${{ always() }}
-+        uses: actions/upload-artifact@v4
-+        with:
-+          name: security-node-${{ env.UPNAME }}-${{ github.run_id }}-${{ github.run_attempt }}
-+          path: ${{ github.workspace }}/${{ matrix.module_folder }}-reports
-+
-+  dotnet-modules-scan:
-+    name: ${{ matrix.module_folder }}-dotnet-scan
-+    runs-on: ubuntu-latest
-+    strategy:
-+      fail-fast: false
-+      matrix:
-+        module_folder:
-+          - people-service/PeopleService.WebApi
-+    steps:
-+      - name: Checkout
-+        uses: actions/checkout@v4
-+      - name: Setup .NET
-+        uses: actions/setup-dotnet@v4
-+        with:
-+          dotnet-version: 9.0.x
-+      - name: Build project
-+        run: dotnet build --configuration Release
-+        working-directory: ${{ matrix.module_folder }}
-+      - name: Prepare artifact name
-+        shell: bash
-+        run: |
-+          echo "UPNAME=$(echo '${{ matrix.module_folder }}' | tr '/\\ ' '---' | tr -cd '[:alnum:]._-')" >> "${GITHUB_ENV}"
-+      - name: Dependency check
-+        uses: dependency-check/Dependency-Check_Action@main
-+        with:
-+          project: ${{ matrix.module_folder }}
-+          path: ${{ matrix.module_folder }}
-+          format: HTML
-+          out: ${{ matrix.module_folder }}-reports
-+          args: >
-+            --suppression .github/dotnet-cve-ignore-list.xml
-+            --failOnCVSS 5
-+            --enableRetired
-+      - name: Upload reports
-+        if: ${{ always() }}
-+        uses: actions/upload-artifact@v4
-+        with:
-+          name: security-dotnet-${{ env.UPNAME }}-${{ github.run_id }}-${{ github.run_attempt }}
-+          path: ${{ github.workspace }}/${{ matrix.module_folder }}-reports
-+
-+  gradle-modules-scan:
-+    name: ${{ matrix.module_folder }}-gradle-scan
-+    runs-on: ubuntu-latest
-+    strategy:
-+      fail-fast: false
-+      matrix:
-+        module_folder:
-+          - account-service
-+          - database
-+          - position-service
-+          - trade-processor
-+          - trade-service
-+    steps:
-+      - name: Checkout
-+        uses: actions/checkout@v4
-+      - name: Set up JDK 21
-+        uses: actions/setup-java@v4
-+        with:
-+          distribution: temurin
-+          java-version: 21
-+      - name: Build project
-+        shell: bash
-+        working-directory: ${{ matrix.module_folder }}
-+        run: |
-+          if [[ -x ./gradlew ]]; then
-+            ./gradlew clean build --no-daemon
-+          else
-+            gradle clean build --no-daemon
-+          fi
-+      - name: Prepare artifact name
-+        shell: bash
-+        run: |
-+          echo "UPNAME=$(echo '${{ matrix.module_folder }}' | tr '/\\ ' '---' | tr -cd '[:alnum:]._-')" >> "${GITHUB_ENV}"
-+      - name: Dependency check
-+        uses: dependency-check/Dependency-Check_Action@main
-+        env:
-+          JAVA_HOME: /opt/jdk
-+        with:
-+          project: ${{ matrix.module_folder }}
-+          path: ${{ matrix.module_folder }}
-+          format: HTML
-+          out: ${{ matrix.module_folder }}-reports
-+          args: >
-+            --suppression .github/gradle-cve-ignore-list.xml
-+            --failOnCVSS 5
-+            --enableRetired
-+            --disableCentral
-+      - name: Upload reports
-+        if: ${{ always() }}
-+        uses: actions/upload-artifact@v4
-+        with:
-+          name: security-gradle-${{ env.UPNAME }}-${{ github.run_id }}-${{ github.run_attempt }}
-+          path: ${{ github.workspace }}/${{ matrix.module_folder }}-reports
-+
-+  docker-image-scan:
-+    name: ${{ matrix.image_name }}-docker-scan
-+    runs-on: ubuntu-latest
-+    strategy:
-+      fail-fast: false
-+      matrix:
-+        include:
-+          - directory: account-service
-+            dockerfile: Dockerfile.compose
-+            image_name: account-service
-+          - directory: database
-+            dockerfile: Dockerfile.compose
-+            image_name: database
-+          - directory: ingress
-+            dockerfile: Dockerfile.compose
-+            image_name: ingress
-+          - directory: people-service
-+            dockerfile: Dockerfile.compose
-+            image_name: people-service
-+          - directory: position-service
-+            dockerfile: Dockerfile.compose
-+            image_name: position-service
-+          - directory: reference-data
-+            dockerfile: Dockerfile.compose
-+            image_name: reference-data
-+          - directory: trade-feed
-+            dockerfile: Dockerfile.compose
-+            image_name: trade-feed
-+          - directory: trade-processor
-+            dockerfile: Dockerfile.compose
-+            image_name: trade-processor
-+          - directory: trade-service
-+            dockerfile: Dockerfile.compose
-+            image_name: trade-service
-+          - directory: web-front-end/angular
-+            dockerfile: Dockerfile.compose
-+            image_name: web-front-end-angular
-+    steps:
-+      - uses: actions/checkout@v4
-+      - name: Set up Docker Buildx
-+        uses: docker/setup-buildx-action@v3
-+      - name: Build image for scan
-+        run: docker build -f "${{ matrix.directory }}/${{ matrix.dockerfile }}" -t "traderx-security/${{ matrix.image_name }}:scan" "${{ matrix.directory }}"
-+      - name: Scan image for vulnerabilities
-+        uses: crazy-max/ghaction-container-scan@v3
-+        with:
-+          image: traderx-security/${{ matrix.image_name }}:scan
-+          severity: HIGH
 diff --git a/.gitignore b/.gitignore
 new file mode 100644
 index 0000000..a933d4c
@@ -355,83 +122,9 @@ index 0000000..a933d4c
 +**/.env.*
 +**/.idea/
 +**/.vscode/
-diff --git a/.traderx-state/state.json b/.traderx-state/state.json
-new file mode 100644
-index 0000000..0b34c3b
---- /dev/null
-+++ b/.traderx-state/state.json
-@@ -0,0 +1,19 @@
-+{
-+  "stateId": "004-containerized-compose-runtime",
-+  "stateTitle": "Containerized Compose Runtime (NGINX Ingress)",
-+  "stateStatus": "implemented",
-+  "featurePack": "specs/004-containerized-compose-runtime",
-+  "previousStates": ["003-agentic-harness-foundation"],
-+  "nextStates": ["005-postgres-database-replacement"],
-+  "isConvergenceState": true,
-+  "convergenceLevel": "C0",
-+  "lineageRole": "canonical",
-+  "dottedParents": [],
-+  "previousConvergenceState": "",
-+  "nextConvergenceState": "007-observability-lgtm-compose",
-+  "sourceBranch": "feature/agentic-renovation",
-+  "sourceCommit": "136dbf7bf223141f406620a11f12ce44b1484d4d",
-+  "generatedAtUtc": "2026-05-20T09:44:59Z",
-+  "generationEntryPoint": "bash pipeline/generate-state.sh 004-containerized-compose-runtime",
-+  "publishTagHint": "generated/004-containerized-compose-runtime/v1"
-+}
-diff --git a/AGENTS.md b/AGENTS.md
-index 4621c9a..2937369 100644
---- a/AGENTS.md
-+++ b/AGENTS.md
-@@ -1,8 +1,8 @@
- # AGENTS.md
- 
--This generated codebase is a reproducible runtime snapshot for state `003-agentic-harness-foundation`.
-+This generated codebase is a reproducible runtime snapshot for state `004-containerized-compose-runtime`.
- 
--- Treat this snapshot as generated output; expect it to be replaced on regeneration.
--- Prototype and experiment locally here when needed.
--- Promote durable changes into upstream state packs and specs, not generated snapshots.
--- Use `./scripts` and `./RUN_FROM_GENERATED.md` as the runtime entrypoints.
-+- Treat this snapshot as generated output; expect regeneration to replace it.
-+- Use this branch for local experimentation and runtime validation.
-+- Promote durable changes into upstream `specs/` state packs and generation assets.
-+- Use `RUN_FROM_CLONE.md` and `scripts/` as runtime entrypoints.
-diff --git a/ARCHITECTURE.md b/ARCHITECTURE.md
-index 1d68b19..337c660 100644
---- a/ARCHITECTURE.md
-+++ b/ARCHITECTURE.md
-@@ -1,7 +1,7 @@
- # ARCHITECTURE.md
- 
--This snapshot was generated from TraderX state `003-agentic-harness-foundation`.
-+This snapshot was generated from TraderX state `004-containerized-compose-runtime`.
- 
--- Service/runtime topology is defined by the source state pack in the upstream repository.
--- This generated directory contains runnable artifacts, not the authoritative architecture source.
--- Rebuild this snapshot through the generation pipeline instead of manually editing generated files.
-+- Architecture source-of-truth remains in the upstream feature pack and SpecKit docs.
-+- This branch contains runnable generated artifacts for the selected state.
-+- Re-generate instead of manually editing generated runtime/source artifacts.
-diff --git a/CONTRIBUTING.md b/CONTRIBUTING.md
-index e3aab6e..c65c2a5 100644
---- a/CONTRIBUTING.md
-+++ b/CONTRIBUTING.md
-@@ -1,7 +1,7 @@
- # CONTRIBUTING.md
- 
--This directory is generated output.
-+This branch is generated output.
- 
--- Enhancement contributions should be made in upstream `specs/` state packs and generation pipeline artifacts.
-+- Enhancement contributions should be made in upstream `specs/` state packs and pipeline generation scripts.
- - Generated snapshots are outputs and are routinely replaced during regeneration.
--- Local edits here are useful for experimentation and debugging, then should be translated back into specs/state packs.
-+- Local edits here are for experimentation and debugging, then should be translated back into source specs/state packs.
 diff --git a/FUNCTIONAL_TESTING.md b/FUNCTIONAL_TESTING.md
 new file mode 100644
-index 0000000..ec55442
+index 0000000..897193c
 --- /dev/null
 +++ b/FUNCTIONAL_TESTING.md
 @@ -0,0 +1,35 @@
@@ -469,10 +162,10 @@ index 0000000..ec55442
 +- Snapshot learning guide: [LEARNING.md](./LEARNING.md)
 +- Snapshot metadata: [STATE.md](./STATE.md)
 +- Canonical Getting Started (main): https://github.com/finos/traderX/blob/main/docs/spec-kit/getting-started-with-traderx.md
-+- Canonical SpecKit docs (source commit): https://github.com/finos/traderX/tree/136dbf7bf223141f406620a11f12ce44b1484d4d/docs/spec-kit
++- Canonical SpecKit docs (source commit): https://github.com/finos/traderX/tree/072c53d558884d7b14142168239860086c7cdee2/docs/spec-kit
 diff --git a/LEARNING.md b/LEARNING.md
 new file mode 100644
-index 0000000..9de4f05
+index 0000000..6419db6
 --- /dev/null
 +++ b/LEARNING.md
 @@ -0,0 +1,26 @@
@@ -500,14 +193,14 @@ index 0000000..9de4f05
 +- State docs map route: `/docs/spec-kit/state-docs`
 +- Learning guide route: `/docs/learning/state-004-containerized-compose-runtime`
 +- Learning guide markdown path in source branch: `docs/learning/state-004-containerized-compose-runtime.md`
-+- Source branch feature pack (exact commit): https://github.com/finos/traderX/tree/136dbf7bf223141f406620a11f12ce44b1484d4d/specs/004-containerized-compose-runtime
-+- Source branch learning guide (exact commit): https://github.com/finos/traderX/blob/136dbf7bf223141f406620a11f12ce44b1484d4d/docs/learning/state-004-containerized-compose-runtime.md
++- Source branch feature pack (exact commit): https://github.com/finos/traderX/tree/072c53d558884d7b14142168239860086c7cdee2/specs/004-containerized-compose-runtime
++- Source branch learning guide (exact commit): https://github.com/finos/traderX/blob/072c53d558884d7b14142168239860086c7cdee2/docs/learning/state-004-containerized-compose-runtime.md
 diff --git a/README.md b/README.md
 new file mode 100644
-index 0000000..1b92491
+index 0000000..4eb101f
 --- /dev/null
 +++ b/README.md
-@@ -0,0 +1,116 @@
+@@ -0,0 +1,118 @@
 +# TraderX Generated Code Snapshot
 +
 +This branch is an auto-published generated-code snapshot for FINOS TraderX.
@@ -518,9 +211,9 @@ index 0000000..1b92491
 +- State Title: `Containerized Compose Runtime (NGINX Ingress)`
 +- Status: `implemented`
 +- Suggested Version Tag: `generated/004-containerized-compose-runtime/v1`
-+- Source Branch: `feature/agentic-renovation`
-+- Source Commit: `136dbf7bf223141f406620a11f12ce44b1484d4d`
-+- Generated At (UTC): `2026-05-20T09:44:59Z`
++- Source Branch: `main`
++- Source Commit: `072c53d558884d7b14142168239860086c7cdee2`
++- Generated At (UTC): `2026-06-21T08:49:24Z`
 +
 +## State Summary
 +
@@ -599,6 +292,8 @@ index 0000000..1b92491
 +- Account service API sample: `http://localhost:18088/account/22214`
 +- Position service health: `http://localhost:18090/health/alive`
 +
++
++
 +Detailed clone-first instructions: [RUN_FROM_CLONE.md](./RUN_FROM_CLONE.md)
 +Functional validation guide: [FUNCTIONAL_TESTING.md](./FUNCTIONAL_TESTING.md)
 +
@@ -621,9 +316,9 @@ index 0000000..1b92491
 +- Functional validation guide: [FUNCTIONAL_TESTING.md](./FUNCTIONAL_TESTING.md)
 +- Snapshot metadata: [STATE.md](./STATE.md), [state.json](./.traderx-state/state.json)
 +- Canonical Getting Started (main): https://github.com/finos/traderX/blob/main/docs/spec-kit/getting-started-with-traderx.md
-+- Source commit: https://github.com/finos/traderX/commit/136dbf7bf223141f406620a11f12ce44b1484d4d
-+- Feature pack at source commit: https://github.com/finos/traderX/tree/136dbf7bf223141f406620a11f12ce44b1484d4d/specs/004-containerized-compose-runtime
-+- SpecKit docs at source commit: https://github.com/finos/traderX/tree/136dbf7bf223141f406620a11f12ce44b1484d4d/docs/spec-kit
++- Source commit: https://github.com/finos/traderX/commit/072c53d558884d7b14142168239860086c7cdee2
++- Feature pack at source commit: https://github.com/finos/traderX/tree/072c53d558884d7b14142168239860086c7cdee2/specs/004-containerized-compose-runtime
++- SpecKit docs at source commit: https://github.com/finos/traderX/tree/072c53d558884d7b14142168239860086c7cdee2/docs/spec-kit
 diff --git a/RUN_FROM_CLONE.md b/RUN_FROM_CLONE.md
 new file mode 100644
 index 0000000..741d0cc
@@ -666,63 +361,9 @@ index 0000000..741d0cc
 +```
 +
 +Wrappers intentionally delegate to numbered state scripts to maximize reuse while keeping clone-first commands stable.
-diff --git a/RUN_FROM_GENERATED.md b/RUN_FROM_GENERATED.md
-deleted file mode 100644
-index 338a225..0000000
---- a/RUN_FROM_GENERATED.md
-+++ /dev/null
-@@ -1,48 +0,0 @@
--# Run From Generated (State 003)
--
--Start:
--
--```bash
--# Build/preflight only (no runtime start)
--./scripts/start-state-003-agentic-harness-foundation-generated.sh --build-only
--
--# Start runtime (will build if needed)
--./scripts/start-state-003-agentic-harness-foundation-generated.sh
--```
--
--```powershell
--# Build/preflight only (no runtime start)
--./scripts/start-state-003-agentic-harness-foundation-generated.ps1 -BuildOnly
--
--# Start runtime (will build if needed)
--./scripts/start-state-003-agentic-harness-foundation-generated.ps1
--```
--
--Status / stop:
--
--```bash
--./scripts/status-state-003-agentic-harness-foundation-generated.sh
--./scripts/stop-state-003-agentic-harness-foundation-generated.sh
--```
--
--```powershell
--./scripts/status-state-003-agentic-harness-foundation-generated.ps1
--./scripts/stop-state-003-agentic-harness-foundation-generated.ps1
--```
--
--Smoke test:
--
--```bash
--./scripts/test-state-003-agentic-harness-foundation.sh
--```
--
--```powershell
--./scripts/test-state-003-agentic-harness-foundation.ps1
--```
--
--## Interactive URLs
--
--- UI (edge): `http://localhost:18080`
--- API explorer (edge): `http://localhost:18080/api/docs`
--- Trade service Swagger (edge): `http://localhost:18080/trade-service/v3/api-docs`
--- Account service Swagger (edge): `http://localhost:18080/account-service/v3/api-docs`
 diff --git a/STATE.md b/STATE.md
 new file mode 100644
-index 0000000..ea605eb
+index 0000000..ea123d9
 --- /dev/null
 +++ b/STATE.md
 @@ -0,0 +1,20 @@
@@ -740,9 +381,9 @@ index 0000000..ea605eb
 +- Dotted Parents: `none`
 +- Previous Convergence State: `none`
 +- Next Convergence State: `007-observability-lgtm-compose`
-+- Source Branch: `feature/agentic-renovation`
-+- Source Commit: `136dbf7bf223141f406620a11f12ce44b1484d4d`
-+- Generated At (UTC): `2026-05-20T09:44:59Z`
++- Source Branch: `main`
++- Source Commit: `072c53d558884d7b14142168239860086c7cdee2`
++- Generated At (UTC): `2026-06-21T08:49:24Z`
 +- Suggested Tag: `generated/004-containerized-compose-runtime/v1`
 +
 +Machine-readable metadata: `.traderx-state/state.json`
@@ -802,13 +443,13 @@ index 0000000..55504ee
 +- CORS allowlist: `CORS_ALLOWED_ORIGINS` (default `*`)
 diff --git a/account-service/SPEC.manifest.json b/account-service/SPEC.manifest.json
 new file mode 100644
-index 0000000..bee681e
+index 0000000..61ad0e2
 --- /dev/null
 +++ b/account-service/SPEC.manifest.json
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,33 @@
 +{
 +  "schemaVersion": "1.0.0",
-+  "generatedAtUtc": "2026-03-31T12:59:32Z",
++  "generatedAtUtc": "2026-07-22T12:27:30Z",
 +  "component": {
 +    "id": "account-service",
 +    "kind": "service",
@@ -822,7 +463,8 @@ index 0000000..bee681e
 +  "runtime": {
 +    "defaultPort": 18088,
 +    "dependsOn": ["database","people-service"],
-+    "requiredEnv": ["ACCOUNT_SERVICE_PORT","DATABASE_TCP_HOST","PEOPLE_SERVICE_HOST","PEOPLE_SERVICE_URL","CORS_ALLOWED_ORIGINS"]
++    "requiredEnv": ["ACCOUNT_SERVICE_PORT","DATABASE_TCP_HOST","PEOPLE_SERVICE_HOST","PEOPLE_SERVICE_URL","CORS_ALLOWED_ORIGINS"],
++    "healthHint": "http://<host>:18088/account/"
 +  },
 +  "contracts": {
 +    "primary": "specs/001-baseline-uncontainerized-parity/contracts/account-service/openapi.yaml"
@@ -840,17 +482,18 @@ index 0000000..bee681e
 +}
 diff --git a/account-service/build.gradle b/account-service/build.gradle
 new file mode 100644
-index 0000000..549bccf
+index 0000000..2dc2847
 --- /dev/null
 +++ b/account-service/build.gradle
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,40 @@
 +plugins {
 +  id 'java'
-+  id 'org.springframework.boot' version '3.5.15'
++  id 'org.springframework.boot' version '3.5.16'
 +  id 'io.spring.dependency-management' version '1.1.7'
 +}
 +
-+ext['tomcat.version'] = '10.1.55'
++ext['jackson-bom.version'] = '2.22.1'
++ext['tomcat.version'] = '10.1.57'
 +
 +group = 'finos.traderx.account-service-specfirst'
 +version = '0.1.0'
@@ -868,13 +511,13 @@ index 0000000..549bccf
 +  implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 +  implementation 'com.h2database:h2:2.4.240'
 +  implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.17'
++  implementation 'org.apache.logging.log4j:log4j-api:2.26.1'
++  implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.26.1'
 +
 +  implementation ('ch.qos.logback:logback-core:1.5.34') {
-+    because 'version brought in by spring boot 3.5.15 affected by CVE-2024-12798'
++    because 'version brought in by spring boot affected by CVE-2024-12798'
 +  }
 +  implementation 'ch.qos.logback:logback-classic:1.5.34'
-+  implementation 'org.apache.logging.log4j:log4j-api:2.26.0'
-+  implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.26.0'
 +  implementation 'org.apache.commons:commons-lang3:3.20.0'
 +
 +  testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -883,6 +526,1141 @@ index 0000000..549bccf
 +tasks.withType(Test).configureEach {
 +  useJUnitPlatform()
 +}
+diff --git a/account-service/gradle/wrapper/gradle-wrapper.jar b/account-service/gradle/wrapper/gradle-wrapper.jar
+new file mode 100644
+index 0000000000000000000000000000000000000000..9bbc975c742b298b441bfb90dbc124400a3751b9
+GIT binary patch
+literal 43705
+zcma&Obx`DOvL%eWOXJW;<L>V64viP??$)@wHcsJ<yG!Hl?(U7dFYnCW{r1k?dA}jz
+z`Gcs6s9#i`JSR_PKBXuF4uJsz0|NsB0z&+G{=YvI5Lgg7F;yWtDS2@QSt$`Qc@;4=
+zRY(xfzuvO0rR}uJ{>68)>bJS6*&iHnskXE8MjvIPVl|FrmV}Npeql07fCw6`pw`0s
+zGauF(<*@v{3t!qoUU*=j)6;|-(yg@jvDx&fV^trtZt27?4Tkn729qrItVh@PMwG5$
+z+oXHSPM??iHZ!cVP~gYact-CwV`}~Q+R}PPNRy+T-geK+>fHrijpllon_F4N{@b-}
+z1M0=a!VbVmJM8Xk@NRv)m&aRYN}FSJ{LS;}2ArQ5baSjfy40l@T5)1r-^0fAU6f_}
+zzScst%$Nd-^ElV~H0TetQhMc%S{}Q4lssln=|;LG?Ulo}*mhg8YvBAUY7YFdXs~vv
+zv~{duzVw%C#GxkBwX=TYp1Dh*Uaum2?RmsvPaLlzO^fIJ`L?&OV?Y&kKj~^kWC`Ly
+zfL-}J^4a0Ojuz9O{jUbIS;^JatJ5+YNNHe}6nG9Yd6P-lJiK2ms)A^xq^H2fKrTF)
+zp!6=`Ece~57>^9(RA4OB9;f1FAhV%zVss%#rDq$9ZW3N2cXC7dMz;|UcRFecBm`DA
+z1pCO!#6zKp#@mx{2>Qcme8y$Qg_gnA%(`Vtg3ccwgb~D(&@y8#Jg8nNYW*-P{_M#E
+zZ|wCsQoO1(iIKd-2B9xzI}?l#Q@G5d$m1Lfh0q;iS5FDQ&9_2X-H)VDKA*fa{b(sV
+zL--krNCXibi1+*C2;4qVjb0KWUVGjjRT{A}Q*!cFmj0tRip2ra>WYJ>ZK4C|V~RYs
+z6;~+*)5F^x^aQqk9tjh)L;DOLlD8j+0<>kHc8<MT8<q;@cs^TP%TBGLJb3?hF`f1u
+zr^#HdaN9hgmYP%3&4eX^>MN|68PxQV`tJFbgxSfq-}b(_h`luA0&<H)Ks&ZC5avn$
+zblv>;Vk<@5<kF$(jU%Y1<)oJ9n#F!_Nzr$1q5g8vk%4E5n+!%&?C??!2P`6+_1%cB
+zz~CmX+0avvVR!Fm9DBz=5OYDMzyT5o=mbbC1@y!;y!`Xf(U~IBp=}v8UBCUG8>1i0
+z_cu6{_*=vlvYbKjDawLw+t^H?OV00_73Cn3goU<yjj&HS+sgjt5ulpVMAFPV!h#%(
+z;O+R^(R7duR?KDiP~~*Sz}yNf2S{i|h1xTKnI_B>5?})UYFuoSX6Xqw;TKcrsc|r#
+z$sMWYl@cs#SVopO$hpHZ)cdU-+Ui%z&Sa#lMI~zWW@vE%QDh@bTe0&V9nL>4Et9`N
+zGT8(X{l@A~loDx}BDz`m6@tLv@$mTlVJ;4MGuj!;9Y=%;;_kj#o8n5tX%@M)2I@}u
+z_{I!^7N1BxW9`g&Z+K#lZ@7_dXdsqp{W9_`)zgZ=sD~%WS5s$`7z#XR!Lfy(4se(m
+zR@a3twgMs19!-c4jh`PfpJOSU;vShBKD|I0@rmv_x|+ogqslnLLOepJpPMOxhRb*i
+zGHkw<C6i>f#?ylQ@k9QJL?!}MY4i7joSzMcEhrDKJH&?2v{-tgCqJe+Y0njl7HYff
+z{&~M;JUXVR$qM1FPucIEY(IBAuCHC@^~QG6O!dAjzQBxDOR~lJEr4KS9R*idQ^p{D
+zS#%NQADGbAH~6wAt}(1=Uff-1O#ITe)31zCL$e9~{w)gx)g>?zFE{Bc9nJT6xR!i8
+z)l)~9&~zSZTH<f>k{?iQL^MQo$wLi}`B*qnvUy+Y*jEraZMnEhuj`Fu+>b5xD1_Tp
+z)8|wedv42#3AZUL7x&G@p@&zcUvPkv<gOT$sg9nDsP`h2d9g#)Sfr@kmW^OuGVzBe
+z-mcj_6tCQbJjPpCR0_6&eS`PLDmBn1jc_}#l=&oN(1kZX%4pnohcH*OTaAUFUQR9I
+zJsE{W;L}Y`SMW2`Yxlamz6R=sERGI$HJ&wT!!xuJCXi~%#!zT5#JMaroI8+$NZU!j
+zFFo1(OoSgnZ`tOBNEeS}AJTa*w)!5g*s2NJdIyH_O<3^t7uCBd5c|%jlVJAD=GPv6
+zGy{$r4IuY4V;#IhoM9(k9N?|GBT!0wNQtL*(Wla6D)K3^HTQh9<!?y8pnvCIy%Of4
+zum(WCu{ljigy+8e*vg{OEP4h-N6?BPRwPrLau9K*^W?WW;LAPzYRy1|S<{}2ayMO6
+z8Gk5*s)+cT;R6e$f61Q!-QhR7$s`=CY0vN!#Gm}?vOh0St8%mcv%@1{x_S+@@wk7+
+zFHA$hX%gbrT2VQ8hV%{#=997-Aa7v_qGy2j`{6(KD}jjYS=X4TTgcc_#&`99oP{`1
+z+?qRA0-j~Bi$<R4kd7i0PY(>g=YJS6?1B7ZEXr4b>M+9Gli$gK-Sgh{O@>q7TUg+H
+zNJj`6q#O@>4HpPJEHvNij`sYW&u%#=215HKNg;C!0#hH1vlO<x`KH1(L52Jfzqckp
+zK+CZ7Ysjx9Ry1%Exbc$7q$%?P{F`qK)zp<pKl6?{P-tc#d(^voQM{*HzaqZ$MF6+j
+zS~SbNnOTb~v^`{pTqA`20=exoU<o^ZUk`ng!~@i!3dZcf;2^$k_C@g8WV8ec1R9H3
+z1`mCus@E!98f~!1rPz5UtUeu7G^^TU%W)2pTm^QP5I*2-sUu2=PL2Gs`-60K_$N2v
+zq}PJt3O#wc`jCA!5t<`h+K4FljR)C<HUy;}xwV&b`+VADm9(!vPCRX?^<oG+Vqeyc
+zzAmc*_iJ~=?~J-H*{$GHN4NIN0}j0yD3GR_r7^*==U{*u<)Ms-C|SiYB&zk-Wp@Y%
+zp&S*-{+zxwY`#DQ<w|BzbKuAp({yI0gR5k4q=KVfX|Z@&C2D=%htF<kWp>5+dFq9&
+zS)8{5_%hz?#D#wn&nm@aB?1_|@kpA<uzp&}l&AD1u)JhYR;ZXh9aBhZCzAtxS13Bp
+zA6Zy}vU8v^?dRy1PIC=7_PA-v<La!D;#*&-5%sU))yJ_yayZVijq+d8MU%ahLUSA$
+zb0EHFFV2D{O}X^o(5AJif==$^X=iGGhpJ4KYw@<T@0PxkDnjx1LyF6S1hcurMfQm5
+zJhtbDMr1*Q{|1EZ*mS}Qd33Qo7~2#jY)+05;Xfi)zKK9EDUF$=6E5F1W+xgADW`s2
+zH|$E3Fed+2a!z;4mZn&JN5DxUfPSaKxluwruV#d2eoAHtR&D=*wdN6FVZ6oI2g0Hw
+zOP;PSG}*`dJEr(*FvR10V<#_MSwpBkIpj_jL>@{%jYcs{K%$a4W{<UY0d}<G_tvcW
+zMNcwn<nVcftdCFzNuiwF_|8?DI$6#{zbc7GvkUvU3|!{Ax?HKf@j9mrId!xHE6!-2
+z{C)xYPtH9rOV?L9kcZN6$krD3qudB?$8^ttXzA!P2B|T6$sO-q_YsmhfI9ntr>k@F
+zPyTav?jb;F(|GaZhm6&M#g|`ckO+|mCtAU)5_(<C;Peqq9IE<_AsNiFs{{>hn&Ogd
+z9Ku}orOMu@K^Ac>eRh3+0-y^F`j^noa*OkS3p^tLV`TY$F$cPXZJ48!xz1d7%vfA(
+zUx2+sDPqHfiD-_wJDb38K^LtpN2B0w=$A10z%F9f_P2aDX63w7zDG5CekVQJGy18I
+zB!tI`6rZr7TK10L(8bpiaQ>S@b7r_u@lh^vakd0e6USWw7W%d_Ob%M!a`K>#I3r-w
+zo2^+9Y)Sb?P9)x0iA#^ns+Kp{JFF|$09jb6ZS2}_<-=$?^#IUo5;g`4ICZknr!_aJ
+zd73%QP^e-$%Xjt|28xM}ftD|V@76V_qvNu#?Mt*A-OV{E4_zC4Ymo|(cb+w^`Wv==
+z>)c%_U0w`d$^`lZQp@midD89ta_qTJW~5lRrIVwjRG_9aRiQGug%f3p@<N8PMQE{a
+zd_6w48$rsd^cXZQ7Dwk9nz}YC&*86L&Yst+a`$%*_e1yJh%kgNQXk4z5r6m?Y@2xN
+zly?J=iN07}T>;*%Y@J5uQ|#dJ+P{Omc`d2VR)DXM*=ukjVqIpkb<9gn9{*+&#p)Ek
+zN=4zwNWHF~=Gqc<UjtcOL9OLcIawlSDS7cyPainIsyG~{9o!H&xa9hYf#oyhSccci
+zt8ciEDfpw+|JDHKvIGdAID*M?Ww(Uo_>Lkd!q0p(S2_K=Q`$whZ}r@ec_cb9hhg9a
+z6CE=1n8Q;hC?;ujo0numJBSYY6)GTq^=kB~`-qE*h%*V6-ip=c4+Yqs*7C@@b4YAi
+zuLjsmD!5M7r7d5ZPe>4$;iv|zq=9=;B$lI|xuAJwi~j~^Wuv!Qj2iEPWjh<cjq`B2
+zQQyz_oTCXImfm@9L;Jg(EcYq6*mZ2Ar7Wg-A&#d%mn;}2vkz#+K|`?Os_iMQICL7M
+z%X3DlLx`B&@S70b+8_uUYlQ7Jjwqbip^{Sy&<=Xy_(h{9O0(ZA&bm55akipSI@h-P
+zouFPBu_Do|z_f_JGMu+d26M|qD0mf|&pPvU(0X6B(p676+94<iS<G;?SQn?!TsCT<
+zW`oSdht$$w66GB-l}L1v_Gel0yjn`(hShw}$Zca>9Z&#<HMI*Z2_1}T(Ag7?VQuOk
+z`{mYjKhEP<qwlCQ<3{~SgOxwbx2t!SbHzjBYU=s|B(D4sC75oIbo;F+(N+m9uUJay
+z3zRQ;6klQ`P7c#H*XA(0OTAp7rMZSXB;)Q$&ymhbN*ra}sd<0WM1I3@<CsDWXd;ki
+z&@?%;r2lEn-Rstvl;9}rizIur@q3(@kvLvHJ^t^eGQ9G#)J~{}lP*OWXqf7ze8OWy
+z5Rgs^5D>+G>lZQpZ@(xfBrhc{rlLwOC;opt<Bi<dsH_Yf{WPKs9reW6WSuhO9Lv`J
+z^%&id)VSO@jT9{?+)0RW%3gsMRWsJNqP+s@Agpg+Fbck0IbJz}ettAGj7<$cpWvte
+z6!<*<{!y4dAH~kmjKRziU~Fx|U}SB<AYx}@1F$ugwXii2ax`<XF|l<Pb2l=vceb#z
+zr8lw$I63{F=af?zmj-7-$zEDn&|(O{iskxs=4#PjtBP81^sD$wd-1XbZiaEHaTAOo
+zQD4&~nfoQEH>JZDj4Xfu3$u6rt_=YY0~lxoy~fq=*L_&RmD7dZWBUmY&12S;(Ui^y
+zBpHR0?Gk|`U&CooNm_(kkO~pK+cC%uVh^cnNn)MZjF@l{_bvn4`Jc}8QwC5_)k$zs
+zM2qW1Zda%bIgY^3NcfL)9ug`05r5c%8ck)J6{fluBQhVE>h+IA&Kb}~$55m-^c1S3
+zJMXGlOk+01qTQUFlh5Jc3xq|7McY$nCs$5=`8Y;|il#Ypb{O9}GJZD8!kYh{TKqs@
+z-mQn1K4q$yGeyMcryHQgD6Ra<6^5V(>6_qg`3uxbl|T&cJVA*M_+OC#>w(xL`RoPQ
+zf1ZCI3G%;<gu?&p>o-x>RzO!mc}K!XX{1rih0$~9XeczHgHdPfL}4IPi~5EV#ZcT9
+zdgkB3+NPbybS-d;{8%bZW^U+x@Ak+uw;a5JrZ<t9b~FAko|dNnqw@`fG4fl;gO}GN
+zja@xAhij0PWn_9yAtqa|Q~JyS@OCX>H!WbNvl<c^f{)!@kr}sV306x!m(JFK2Su#H
+zA{l>!b~r4*vs#he^bqz`W93PkZna2oYO9dBrKh2QCWt{dGOw)%Su%1bIjtp4dKjZ^
+zWfhb$M0MQiDa4)9rkip9DaH0_tv=XxNm>6MKeWv>`KNk@QVkp$Lhq_~>M6S$oliq2
+zU6i7bK;TY)m>-}X7hDTie>cc$J|`*}t=MAMfWIALRh2=O{L57{#fA_9LMnrV(HrN6
+zG0K_P5^#$eKt{J|#l~U0WN_3)p^LLY(XEqes0OvI?3)GTNY&S13X+9`6PLVFRf8K)
+z9x@c|2T72+-KOm|kZ@j4EDDec>03FdgQlJ!&FbUQQH+nU^=U3Jyrgu97&#-W4C*;_
+z(WacjhBDp@&Yon<9(BWPb;Q?Kc0gR5ZH~aRNkPAWbDY!FiYVSu!~Ss^9067|JCrZk
+z-{Rn2KEBR|Wti<xxNV#Db47^*a|{iSLoUSn+}XCk5${GR@Qb+|Eox;WbSB?b>_iy)
+zXnh2wiU5Yz2L!W{{_#LwNWXeNPHkF=jj<Oca}a<VYq$(Z)L~2{hsCZ>XmHC@n*oiz
+zIoM~Wvo^T@@t!QQW?Ujql-GBOlnB|HjN@x~K8z)c(X}%%5Zcux09vC8=@tvgY>czq
+z3D(U&FiETaN9aP}FDP3ZSIXIffq>M3{~eTB{uauL07oYiM=~K(XA{SN!rJLyXeC+Y
+zOdeebgHOc2aCIgC=8>-Q>zfuXV*=a&gp{l#E@K|{qft@YtO>xaF>O7sZz%8);e86?
+z+jJlFB{0fu6%8ew^_<+v>>%6eB8|t*_v7gb{x=vLLQYJKo;p7^o9!9A1)fZZ8i#ZU
+z<|E?bZakjkEV8xGi?n+{Xh3EgFKdM^;4D;5fHmc04PI>6oU>>WuLy6jgpPhf8$K4M
+zjJo*MbN0rZbZ!5DmoC^@hbqXiP^1l7I5;Wtp2i9Jkh+KtDJoXP0O8qmN;Sp(+%upX
+zAxXs*qlr(ck+-QG_mMx<HJPMiiyFhyvyc$BVLB{06!#fNnvcq+4(CeJ9NSp(yBP{p
+zz9+FDyloDA-5BFzU$X6O5`cUWFMHGQXtH9zX=W;Z0SMrXCMHY77EA&39fq<AIjYX_
+zL-)E@whkh@FYnG!*@-)hr`+%$^!mR-H_bvW274&&>?hQNXVV~LT{$Q$ShX+&x?Q7v
+z@8t|UDylH6@RZ?WsMVd3B0z5zf50BP6U<&X_}+y3uJ0c5OD}+J&2T8}A%2Hu#Nt_4
+zoOoTI$A!hQ<2pk5wfZDv+7Z{yo+Etqry=$!*pvYyS+kA4xnJ~3b~TBmA8Qd){w_bE
+zqDaLIjnU8m$wG#&T!}{e0qmHHipA{$j`%KN{&#_Kmjd&#X-hQN+ju$5Ms$iHj4r?)
+z&5m8tI}L$ih&95AjQ9EDfPKSmMj-@j?Q+h~C3<|Lg2zVtfKz=ft{YaQ1i6Om&EMll
+zzov%MsjSg=u^%EfnO+W}@)O<s4y0<!F*}jN{~^*=<<M!`pCE38_&X5u{wE+7HZiqx
+zG!eIObaGa4G5p`k`7da0P_t5)HNf!I6NGD^#Jcju!NjqqL7(FK$?;p8B-cTjS(f#p
+zHML@9bjCH8>6u0LwoX709h3Cxdc2Rwgjd%LLTChQvHZ+y<1q6kbJXj3_pq1&MBE{8
+zd;aFotyW>4WHB{JSD8Z9M@jBitC1RF;!B8;Rf-B4nOiVbGlh9w51(8WjL&e{_iXN(
+zAvuMDIm_>L?rJPxc>S`bqC|W$njA0MKWa?V$u6mN@PLKYqak!bR!b%c^ze(M`ec(x
+zv500337YCT4gO3+9>oVIJLv$pkf`01S(DUM+4u!HQob|IFHJHm#>eb#eB1X5;bMc|
+z>QA4Zv}$S?fWg~31?Lr(C>MKhZg>gplRm`2WZ--iw%&&YlneQYY|PXl;_4*>vkp;I
+z$VYTZq|B*(3(y17#@ud@o)XUZPYN*rStQg5U1Sm2gM}7hf_G<>*T%6ebK*tF(kbJc
+zNPH4*xMnJNgw!ff{YXrhL&V$6`ylY={qT_xg9z<NbPza#S5_;7-HDWW5RigZ=LV6*
+zC(tYTyWThzXHf4MXBa7hZbsubd?Ryu_#A)%-?VnWgzy8ET!tu|{8#c_&gaH`oCBdA
+zDZ_rb+3zi849gP{1S5P<jk#MGP++DGAy-3vwo{u^X(9-1cLI-eD^5-vRFWj~@&pA;
+zVHMOE7R0Uo3r+HxoApr;N3Ucb6+Fi&Rw>nQWw9>PlG~IbhnpsG_94Kk_(V-o&v7#F
+znra%uD-}KOX2dkak**hJnZZQyp#ERyyV^lNe!Qrg=VHiyr7*%j#PMvZMuYNE8o;JM
+zGrnDWmGGy)(UX{rLzJ*<yAEppP~EY>QEBd(VwMBXnJ@>*F8eOFy|FK*Vi0tYDw;#E
+zu#6eS;%Nm2KY+7dHGT3m{TM7sl=z8|V0e!DzEkY-RG8vTWDdSQFE|?+&FYA146@|y
+zV(JP>LWL;TSL6rao@W5fWqM1-xr$gRci#RQV2DX-x4@`w{uEUgoH4G|`J%H!N?*Qn
+zy~rjzuf(E7E!A9R2bSF|{{U(zO+;e29K_dGmC^p7MCP!=Bz<LU?&i-}KG6X?-t~{t
+z6;cwZkN#6(bfNz)LHYiZ1eLM1bF=-Y%KTGzRGb0MCjXM5S?b4b=q6Yne5@ub&Z1fi
+zwe1K(xpIl(UuqiL&9zbE3--S?_yjh~vM9{@56fnz)vH22_-yvCYe2Y7H${#(Jncbu
+zdEOFD?GkNqW$#j4@v}(bNmkD>q@}&AdF5=rt<!COJnb)nu<w2#Fc9&zR-N5X<)-uZ
+z$<fUbN+So80PB;-k3&vQQgFt#a4A~G5i7YfkwVod(g_caMdbNUgH}RSd$;2i>Cwka
+zTT1A?5o}i*sXCsRXBt)`?nOL$zxuP3i*rm<aImxvw^U@{B*fUS0^1}v7Fr7%=t{5R
+zr{ZxLLkwm{RxNy^ZS6xw>3Gmbmr6}9HCLvL*45d|(zP;q&(v%}S5yBmRVdYQQ24zh
+z6qL2<2>StU$_Ft29Iy<fP{_A}(TLFc`ulnZB85D4f`?3P{(NRH&`r%oRcE}aoRUTu
+zE?7Y|z|k@bRY%JdWY5F(IA^2{CsLJ|)7+Sk)-1LuGjdpW2<~xRpIawD7|b}pzW)Q9
+zAY5MSu{bw_VLh`wPo4Jb7n0QMsV))LK}%s$WqXQ<7NQ-5!+}@QkF+dLPzuz#x@W)<
+znhWO;3yF&C)0P|n)1lp<2aeQ_$@3&mI?kFLSzhC?s<NQdC{FP%I#bp;kORX{l<3x0
+zI8yQp7E^WBY)WEgiAkeUv{*@dstpdRH)q&jD@2v`EidG8QsD}**_mj0v08)ZlDq;v
+z=LqggR_Jz_t>F!6=!@;tW=o8vNzVy*hh}XhZhUbxa&;9~woye<_YmkUZ)S?PW{7t;
+zmr%({tBlRLx=ffLd60`e{PQR3NUniWN2W^~7Sy~MPJ>A#!6PLnlw7O0(`=PgA}JLZ
+ztqhiNcKvobCcB<yMplTfXcPqrYE+vVszVQmm@rg}2{rJGaO7?|y?`3a_S!XcQLG&V
+z?bgXaiD}w%%A$ShO3yHwQZ52?;xk}hq`az4Qz(&ZI4P8rn`^{UhqrR}d!P@Af>el2
+z-N82?4-()eGOisnWcQ9Wp23|ybG?*g!2j#>m3~0__IX1o%dG4b;VF@^B+mRgKx|ij
+zWr5G4jiRy}5n*(qu!W`y54Y*t8g`$YrjSunUmOsqykYB4-D(*(A~?QpuFWh;)A;5=
+zPl|=x+-w&H9B7EZGjUMqXT}MkcSfF}bHeRFLttu!vHD{Aq)3HVhvtZY^&-lxYb2%`
+zDXk7>V#WzPfJs6u{?ZhXpsMdm3kZscOc<^P&e&684Rc1-d=+=VOB)NR;{?0NjTl~D
+z1MXak$#X4{VNJyD$b;U~Q@;zlGoPc@ny!u7Pe;N2l4;i8Q=8>R3<TEv>H{>HU<axH
+zp`GSL-T`v+`h{A=aX;JW4CEU!(+?Uoa0aOL$De+GUOkWsAqa2ZK4FC`K3!1~Zy9HB
+zzvq?1%x_y$*Bv$0)GEimNLh#E5__f1Mpw)(hNBlqy(D20`q=1`jdMVFIk`mBE8>(z
+z%hV2?rSinAg6&wuv1DmXo<vm47<QjMysD@bzHIj93EKq|LsScFN}?1q^I)(oMd!rn
+zn|DubZt_^bCFb75g5Trh|4Qx?zo0F<A>k`5@a3@H0BrqsF~L$pRYHNEXXuRIWom0l
+zR9hrZpn1LoYc+G@q@VsFyMDNX;>_Vf%4>6$Y@j;KSK#g)TZRmjJxB!_NmUMTY(cAV
+zmew<J38CI3YanL~W|fbwxrqJqw<my@*XH*?z?)KSw#4MywnI6A#4U@pFSNEc`Lrv-
+z-S!+OS6bh_zm$&432UozL4&En7L86;ghp^8;$ppb%xO{FV^Pm{yQ`>n7H{z`M3^Z&
+z2O$pWlDuZHAQJ{xjA}B;fuojAj8WxhO}_9>qd0|p0nBXS6IIRMX|8Qa!YDD{9NYYK
+z%JZrk2!Ss(Ra@NRW<7U#%8SZdWMFDU@;q<}%F{|6n#Y|?FaBgV$7!@|=NSVox<B(`
+zIq)S_BbU4&5Y;#+zzGVxaXAWCz*U+(@Q+o!?%YbO5Lnd}NLZ#m2X87gxZsJLNwk+3
+z@~G>lJI4G-G(rn}bh|?m<PI-QoC(rF$EW8<oaZlKv17e{ZZEs5gI5rI>KkaBF$-Yr
+zA;t0r?^5Nz;u6gwxURapQ0$(-su(S+24Ffmx-aP(@8d>GhMtC5x*iEXIKthE*mk$`
+zOj!Uri|EAb4>03C1xaC#(q_I<;t}U7;1Jq<Pun#t0_d*_eJ@mw@913m0*PYiG@}tB
+ztP(s*U6EvObA-KfU!e+*)h*+A8wNY(z9PpR7|ng1RQ75YwD8Ip`2*1~IH(z=Ujxyl
+z<ntP1@(4b<498kKUoYg<(N=o2;8F4n|CejK@H@|3g8~6DMEW~D{f`P>ISVHz3tO{)
+zD(Yu@=>I9FDmDtUiWt81;BeaU{_=es^#QI7>uYl@e$$lGeZ~Q(f$?^3>$<<{n`Bn$
+zn8ba<y1J3mk7QrBkS`^06lBb%XobuZz0Uc3vJW$}oz5rqH-CVXbQ?TYcYWkt$y+%%
+zDGW6>mZlL@6r^RZHV_c5WV7m2(G6X|OI!+04eAnNA5=0v1Z3lxml2#p<Q2Hk_3rET
+z#;|JLdCr%w6PIsdU-R${5=&H%MpF|6*IQEs*~vt<`)osFM7~B}S2*^XM|R%(!bK5x
+z?B98-@YWD?D?WIa89ue2g+&}MCA&<zv{-XU9dkW^Z!-wg1^SV3v?-k+`&iNJ0Tmf1
+z6uA?;4A2J1dJC}17}snGhxuUKB>~Zo57ri;4>;#16sSXXEK#QlH>=b$inEH0`G#<_
+zvp;{+iY)BgX$R!`HmB{S&1TrS=V;*5SB$7*&%4rf_2wQS2ed2E%Wtz@y$4ecq4w<)
+z-?1vz_&u>s?BMrCQG6t9;t&gvYz;@K@$k!Zi=`tgpw*v-#U1Pxy%S9%52`uf$XMv~
+zU}7FR5L4F<#9i%$P=t29nX9VBVv)-y7S$ZW;gmMVBvT$BT8d}B#XV^@;wXErJ-W2A
+zA=Jft<sUW%eIzvD`%|;&1KUO!vBts9$jx)aLl#J~zQpxlFUxMboZ!i0c9Fc`OtVN_
+zc!Oz?NJ1z_+?YXWzG9yyn`e=Y8ro2cgXxj=V=SljU>QR<YtbUwpQ+@vL?uI{$gmcZ
+zYC3@UzzpYKLZewwpeTE~#NkBl55_$s{)OK@ziuA6Ps5h_w}$OMst5l!aNPioCjY)3
+z3|9SgY>L>vNO(!n4mcd3O27bHYZD!a0kI)6b4hzzL9)l-OqWn)a~{VP;=Uo|D~?AY
+z#8grAAASNOkFMbRDdlqVUfB;GIS-B-_YXNlT_8~a|LvRMVXf!<^uy;)d$^OR(u)!)
+zHHH=FqJF-*BXif9uP~`SXlt0pYx|W&7jQnCbjy|8b-i>NWb@!6bx;1L&$v&+!%9BZ
+z0nN-l`&}xvv|wwxmC-ZmoFT_B#BzgQZxtm|4N<cR35n#bARS74OQDTms<32~v8v=`
+z7-caF<C)1AG)W4zO)YE8SJ$Y@<CJ4$G=}`=!37S-py?UnU1Gh2h2n_6&p(Ao5Qqf6
+z=k(-OuAx!R!Y>+|;+(YW&Jtj^g!)iqPG++Z%x0LmqnF875%Ry&2QcCamx!T@FgE@H
+zN39P6e#I5y6Yl&K4eUP{^biV`u9{&CiCG#U6xgGR<Po=AznL^)f6o>Qr)zew;Z%x+
+z-gC>y%gvx<e=sLpgCWdgi6XpJK8=uXJkkm8YE@{r>|dM=OrO`N@P+h2klPtb<Ry(x
+zpu?Xm?4btAWLp$6D_`$o&fb}lDqgV$`64jZuZt*NMiKvp57y55K7Ikao<AXqBElPW
+zh~1j8oF$DxMm1(>YvjS!mNnk4yE0+I&YrSRi?F^plh}hIp_+OKd#o7ID;b;%*c0ES
+z!J))9D&YufGIvNVwT|qsGWiZAwFODugFQ$VsNS%gMi8OJ#i${a4!E3<-4Jj<9SdSY
+z<OXh$_?#e&cT#EB-U!=XwtowFV|9Uhv$sUK3q>&xe|D0V1c`dZv+$8>(}RE|zL{E3
+z-$5Anhp#7}oO(xm#}tF+W=K<zEDOn&&TBZukL{eI>E*3(xxKxhBt-uuJP}`_K#0A<
+zE%rhMg?=b$ot^i@BhE3&)bNBpt1V*O`g?8hhcsV-n#=|9wGCOYt8`^#T&H7{U`yt2
+z{l9Xl5CVsE=`)w4A^%PbIR6uG_5Ww9k`=q<@t9Bu662;o{8PTj<F}p=3(;yTV~Qyf
+zgQDdrLzMjDw7>DBzzbY#tL;$wrpjONqZ{^Ds4oanFm~uyPm#y1Ll3(H57YDWk9TlC
+zq;kebC!e=`FU&q2ojmz~GeLxaJHfs0#F%c(i+~gg$#$XOHIi@<TM;Hv2aC}$s8#Sv
+z+Dd3KT+?=#!iTV?Ms~47n*H>1mA72g2pFEdZSvp}m0zgQb5u2?tSRp#oo!bp`FP}<
+zaK4iuMpH+Jg{bb7n9N6e<k8B#=)v)d%-lnDQKtnG^2KYKtU2;<n>R*NZfgL7QiLxI
+zk6{uKr>xxJ42sR%bJ%m8QgrL|fzo9@?9eQiMW8O`j3teoO_R8cXPe_XiLnlYkE3U4
+zN!^F)Z4ZWcA8gekEPLtFqX-Q~)te`LZnJK_pgdKs)<s7#%|5P$s1t)kN+!Um>Dp50
+zdUq)JjlJeELskKg^6KY!sIou-HUnSFRsqG^lsHuRs`Z{f(Ti9eyd3cwu*Kxp?Ws7l
+z3cN>hGPXTnQK@qBgqz(n*qdJ2wbafELi?b90fK~+#XIkFGU4+Hihn<y_>Wq;{{)1J
+zv*Txl@GlnIMOjzjA1z%g?GsB2(6Zb-8fooT*8b0KF2CdsIw}~Hir$d3TdVHRx1m3c
+z4C3#h@1Xi@{t4zge-#B6jo*ChO%s-R%+9%-E|y<*4;L>$766RiygaLR?X%izyqMXA
+zb|<FVRVPIkP%(S)yIvuu+5z_83buf`qe#ezb);jn)u$oPrWvD(s&~KHbqKNL%cobC
+zN-|C-DK*$CAI~b2Ac6>N=Z-0PSFeH;W6aQ3(5VZWVC>5Ibgi&cj*c%_3=o#VyUJv*
+zM&bjyFOzlaFq;ZW(q?|yyi|_zS%oIuH^T*MZ6NNXBj;&yM3eQ7!CqXY?`7+*+GN47
+zNR#%*ZH<^x{(0@hS8l{seisY~IE*<IWx!UK-u2j(e2O!c*%v`vbRdmnwY3~F@WfqY
+z%qQlFf<s6fB4WlqklvTVl*JK;YI>)BD+R6^OJX}<2HRzo^fC$n>#yTOAZbk<pxtmH
+zJ~q1kaL=GoN56akk-6RD`q2mzV0mH8>4%=Bei=<kddu{Z(hj1<vW)@wW7M&+@6=2s
+zZD&Op_jWe#TTdH<JbSg3bLF85E$EBmVzcroiC)+RvF8h>JEe=o$jm`or0YDw*G?d>
+z=i$eEL7^}_?UI^9$;1Tn9b>$KOM@NAnvWrcru)r`?LodV%lz55O3y(%FqN;cKgj7t
+zlJ7BmLTQ*NDX#uel<G9Op(1@^PULS#3C#Zq5&eylEB%v#D2Qdisi+`5Pk=N?QpqNe
+zn3Q0BprVD+s9yvAi-Ka>GbCY>k+&H*iSK?x-{w;f5G%%!^e4QT9z<_0vHbXW^MLR}
+zeC*jezrU|{*_F`I0mi)9=sUj^G03i@MjXx@ePv@(Udt2CCXVOJhRh4yp~fpn>ssHZ
+z?k(C>2uOMWKW5FVsBo#Nk!oqYbL`?#i~#!{3w^qmCto05uS|hKkT+iPrC-}hU_nbL
+zO622#mJupB21nChpime}&M1+whF2XM?prT-Vv)|EjWYK(yGYwJLRRMCkx;nMSpu?0
+zNwa*<?h%^Uxlo#rhlXX^1ry~0-r)@+JQ4MlP_WRi_c8}Pe;l(#WnThfspZ$^3+`@%
+zmW}tS#o_f`H(V@)Qt__Qwx4kv+ooP8ZrPBV-j<==nbQ*DT}dlBw*|*N7vHSJyQH}0
+zm|S-J1_lheA!DE{g6^Xv;AA#SxCooopboet4w*f2U~sm_9-x1=xp|LI-xxj9006QY
+z1mgxK<wER;C#1B$%?%3n>{0n+Yg6=SR3-S&;<?krxZxGO!Tw^S=d_=26`yQ0@waRw
+z@SmVU&DQEaY5x6V*rbHQm)eLi0+(WkiJ>vq=-lRqN`s9~#)OOaIcy3GZ&~l4g@2h|
+zThAN#=dh{3U<aA#cPR4&ofsaO#bX_do9RRvi_^pV^V=?kpT`)pH$SJl(tC+UO9KU%
+zw*Fj&O-G3~P~VA<unl1F2&AK=52kP@qipFV?Oj1#&{KUN^>N7Xil;nb8@%)wx5t!l
+z0RSe_yJQ+_y#qEYy$B)m2yDlul^|m9V2Ia$1CKi6Q19~GTbzqk*{y4;ew=_B4V8zw
+zScDH&QedBl&M*-S+bH}@IZUSkUfleyM45G>CnYY{hx8J9q}ME?Iv%XK`#DJRNmAYt
+zk2uY?A*uyBA<BiMLU_*M#NCCxjGD{)FKf5%TR%^0(tj%ZEC|pB`lh!G8#P^_7rgl6
+zHD8H9#lPg#uyjB59dckNv=l!fBEB{M6vF+Eh;w^K5=@MUOHXMhDuV2p%rP)^5%vfh
+zn^LIqAcivg*z)=%xYv);q@8+WaMY5huI1GOD-9N$`j-dE7hH0tcwmf1#`ceO!mOHP
+zCyw-!`T<sF+;H*u*8-P5M#r^Q!nW)d+HW6<4*Bj<y{xwPJ5aVv2w6&T;_`2#jdBoY
+zJBy`lJrSwb+PH8(hrh;>=nlYjkcNPMGi*552=*Q>%l?gDK_XYh<zL<ke_eZ$ot|PF
+zZVgv}4Sq{EZ4ogcRofdp&JliroypZ_e}$4iKs?X|D!2Ac$5!nj(ZskdL0_wd=BN37
+zZG}#$eUO#D_A!-?os3(Syu!QKCTTw$pZe08wZZN8KnynfmowC;MZ_o?kig}nxLgNw
+zM?*Zz05oY7v>*Rya_c)ve{=ps`QYE0n!n!)_$TrGi_}J|>1v}(VE7I~aP-wns#?>Y
+zu+O7`5kq32zM4mAQpJ50vJsUDT_^s&^k-llQMy9!@wRnxw@~kXV6{;z_wLu3i=F3m
+z&eVsJmuauY)8(<=pNUM5!!fQ4uA6hBkJoElL1asWNkYE#qaP?a+biwWw~vB48PRS7
+zY;DSHvgbIB$)!uJU)xA!yLE*kP0owzYo`v@wfdux#~f!dv#u<u)VAl7h<(Ox?_8|-
+zieXQ0tIl#N(#Ubvm=#=RRW-l$qV+J9qkYE;+MW4sd~tDdcA{`>Nc_$SF@Qq9#3q5R
+zfuQnPPN_(z;#X#nRHTV>TWL_Q%}5N-a=PhkQ^GL+$=QYfoDr2JO-zo#j;mCsZVUQ)
+zJ96e^OqdLW6b-T@CW@eQg)EgIS9*k`xr$1yDa1NWqQ|gF^2pn#dP}3NjfRYx$pTrb
+zwGrf8=bQAjXx*8?du*?rlH2x~^pXjiEmj^XwQo{<CPx+@82|8@X@<D@6UUi%p$ehj
+zhXQlcfF2phkkCDxVFxfI?!~Bx<^Y(i{JB%4bav+Pbd2%<Y>`NMonBN=Q@Y21!H)D(
+zA~%|VhiTjaRQ%|#Q9d*K4j~JDXOa4wmHb0L)hn*;Eq#*GI}@#ux4}bt+olS(M4$>c
+z=v8x74V_5~xH$sP+LZCTrMxi)VC%(Dg!2)KvW|Wwj@pwmH6%8zd*x0rUUe$e(Z%AW
+z@Q{4LL9#(A-9QaY2*+q8Yq2P`pbk3!V3mJkh3uH~uN)+p?67d(r|Vo0CebgR#u}i?
+zBxa^w%U|7QytN%L9bKaeYhwdg7(z=AoMeP0)M3XZA)NnyqL%D_x-(jXp&tp*`%Qsx
+z6}=lGr;^m1<{;e=QQZ!FNxvLcvJVGPkJ63at5%*`W?46!6|5FHYV0qhizSMT>Zoe8
+zsJ48kb2@=*txGRe;?~KhZgr-ZZ&c0rNV7eK+h$I-UvQ=552@psVrvj#Ys@EU4p8`3
+zsNqJu-o=#@9N!Pq`}<=|((u)>^r0k^*%r<{YTMm+mOPL>EoSREuQc-e2~C#ZQ&Xve
+zZ}OUzmE4{N-7cqhJiUoO_V#(nHX11fdfVZJT>|6CJGX5RQ+Ng$Nq9xs-C86-)~`>p
+zW--X53<fjk))~(Y7xt;2-3Mp_sh^OGttxT8JXcE>J`O~vS{WWjsAuGq{K#8f#2iz`
+zzSSNIf6;?5sXrHig%X(}0q^Y=eYwvh{TWK-fT>($8Ex>!vo_oGFw#ncr{<A-F%$p&
+zc|DGKq;$_R8E0EodRv?$JW^Po<Ex>vmERi^m7lRi%8Imph})ZopLoIWt*eFWSPuBK
+zu>;Pu2B#+e_W|IZ0_Q9E9(s@0>C*1ft`V{*UWz^K<0Ispxi@4umgGXW!j%7n+NC~*
+zBDhZ~k6sS44(G}<L8r7U{uvHTXWzD_JuHzxZ-XY|N?p*qndC=U0c*Cl@BtNW7i{&R
+z-Me?NHPa(a(vIZUFSMee2{hPx14nk+e_C|^?Bd;r8#<I5LFO<RoqQ`w{VLAmJAmJ-
+zf-f}_R{!XhIih6nYvLOxM^4vM+l^NaQ|ty{<XIb6;HnNe&IB3k;~%;YB%OMx`D8+)
+z&)Zf1-i7=>*zg||X#9Weto;u*Ty;fP!+v*7be%cYG|yEOBomch#m8Np!Sw`L)q+T`
+zmrTMf2^}7j=RPwgpO9@eXfb{Q>GW#{X=+xt`AwTl!=TgYm)aS2x5*`FSUaaP_I{Xi
+zA#irF%G33Bw>t?^1YqX%czv|JF0+@Pzi%!KJ?z!u$A`Catug*tYPO`_Zho5iip0@!
+z;`rR0-|Ao!YUO3yaujlSQ+j-@*{m9dHLtve!sY1Xq_T2L3&=8N;n!!Eb8P0Z^p4PL
+zQDdZ?An2uzbIakOpC|d@=xEA}v-srucnX3Ym{~I#Ghl~JZU(a~Ppo9Gy1oZH&Wh%y
+zI=KH_s!Lm%lAY&`_KGm*Ht)j*C{-t}Nn71drvS!o|I|g>ZKjE3&Mq0TCs6}W;p>%M
+zQ(e!h*U~b;rsZ1OPigud>ej=&hRzs@b>>sq6@Yjhnw?M26YLnDH_Wt#*7S$-BtL08
+zVyIKBm$}^vp?ILpIJ<dp3ooa+cndqkSQ3UA!R3}}yC4bxfeA6S8LO9hE~vx|Yi68@
+zNr?jvc2@*eXxky?<YJ*9EIA;CdIbdqd2SQpx9uQtXD#8(J3Vt<5%NQ*o02|K+6bY0
+z;sT8vn@o8e%0|hi^#v|34DqvO58NzmQDAp!LXk*AcbC{I;vTjGcE|?=;e?ESe2XV{
+zRUgP)(rNkqS#Yhf8ziDbO6ep!K;GEwl%7iVkc_KR&%z8}O~7*V=?=DsoCZuiU?(w*
+zHV&rJy*1isBFt8he4l73U>etMkW1VtIc&7P3z0M|{y5gA!Yi5x4}UNz5C0Wdh02!h
+zNS>923}vrkzl07CX`hi)nj-B?#n?B<Q|A1|76WLZEE&m-hhR<X$5TK&X`9{ZnvFM%
+zu_h)S<XvC@S;kBiJJBt>J2Vk0zOGsF<~{Fo7OMCN_85daxhk*pO}x_8;<dX=<+?Qg
+z#r>-h>}pcw26V6CqR-=x2vRL?GB#y%tYqi;J}kvxaz}*iFO6YO0ha6!fHU9#UI2Nv
+z_(`F#QU1B+P;E!t#Lb)^KaQYYSewj4L!_w$RH%@IL-M($?DV<J?Z?(&T(jN~E*h4k
+zjT$bEE;1X$dKstuB%kL?N}i|18#(T<X%h{nQolXBTKBIbWb9u%<<*n%KAruYiv41M
+z(BV$!uq)MDNOGLcUNoFp1O|t~h!*SC05{|sLBD8s0{dGDvJFAn@fT!9#{nXqzUzhA
+ze1Wde$2)jpHttd7Vt%dJc<P1PQ_QtXhR)w~A<pGWwkJB}X>@lGj%3ZgVdHe^q>n(x
+zyd5PDpGbvR-&p*eU9$#e5#g3-W_Z@loCSz}f~{94>k6VRG`e5lI=SE0AJ7Z_+=nnE
+zTuHEW)W|a8{fJS>2<PuTj25j+DhXW(hd~r?Xh^MxKJCimxGsmwzKdi%?KCIX3{&)m
+zZ0nj+u3m}byL|gc@7el5sG0YZn703R7lHPF8j}A(O#keT{0lwVD2_|_3ZlF(l>TaX
+zuRoa=LCP~kP)kx4L+OqTjtJOtXiF=y;*eUFgCn^Y@`gtyp?n14PvWF=zhNGGsM{R-
+z^DsGx<p*94-ySu{F;3A%Gw(MuWcO5hc=1Fn6S6X-V`dR&jLKv;9Ov9;sNX7hCxxgJ
+z&)GGfI53?p5EUqj1kN{nL`cLj*Ny6Bb93QS#TWv+m?{)VTv#I?UM_EBDq&18Y1rBF
+zqj?j71ovsu1jc{FMqN`ZbtUe%y6G-sBQrAwb$+jv1%VjW_k<x<OD8=u&hN{;<-bn?
+z@rS2|Sdn<vp_N-gJ^Y{ISs}UnqwiH29Bq1>toDtx+g^hZi@E2Y(msb-hm{d<UuZ5B
+zF*RQXF90n8n5t!zMgUN!64)`l%MNqK%g0zqOLUu+a4FnHHt`Hf2k1Gsi_Mzb@Z^^=
+zxAOB&;5(e``nO6J%C~>WiHdoQvdX88EdM<JUQYg{sbyjNxshlKux2o|_*{in1UQ?k
+zIs#lx9Gw8xBIYJWRwj=B5<C|bZKqjrjCXeSc*C*6yaFuS2rWqx!(UR;j8e_%Q^I^0
+zj8p#CwJD3Wf>>^DS#f}&kCGpPFDu*KjEpv$FZtLpeT>@)mf|z#ZWEsueeW~hF78Hu
+zfY9a+Gp?<)s{Poh_qdcSATV2oZJo$OH<l8JXo;z<PcbGCYR0J9l8&nxRHHiz--^d2
+z8~J{Itr^Z$OtgTuQ6<JD;bmdLugNLaS^G}k$rEM-rW(6=U_mp(C><Q9gp1ZnUy!F0
+zwAdk5rFR<Ua`+2&K+(bk94CxMi5A;34dG4kTAucma$dNI_rA^e+RlExjm~4DcUPQV
+zUJ~3S<PG_W`@twX<bCoilw=BO0H-v<O^nbfi=xlVu&Cv1VWy=dd07F7ytH8mMU5a{
+zu#nKXVN5wbwo#QA!H4;0Ko9C5V@W}ba=cKzOSE;+-oDrv!(>~K@QzE2kCADZ@xX(;
+z)0i=kcAi%nvlsYagvUp(z0>3`39iKG9WBDu3z)h38p|hLGdD+Khk394PF3qkX!02H
+z#rNE`T~P9vwNQ_pNe0toMCRCBHuJUmNUl)KFn6Gu2je+p>{<9^oZ4Gfb!)rLZ3CR3
+z-<Jj6ofd&sk<LvELH)*PRT^`1cMjr9jc63Nl_{PuyZKn7*LCLu65p@97#0uR(E?9W
+zX`bZ}=9-Z$>o&b;Bh>51JOt=)$-9+Z!P}c@cKev_4F1ZZGs$I(A{*PoK!6j@ZJrAt
+zv2LxN#p1z2_0Ox|Q8PVblp9N${kXkpsNVa^tNWhof)8x8&VxywcJz#7&P&d8vvxn`
+zt75mu>yV=Dl#SuiV!^1BPh5R)`}k@Nr2+s8VGp?%Le>+fa{3&(XYi<NKc?C)>~{k{
+z-u4#CgYIdhp~GxLC+_wT%I*)tm4=w;ErgmAt<5i6c~)7JD2olIaK<AIVJAZuKkE<l
+z4Bm0%W2+6b=&ak;y7abRJFYhw&)H;bM_b*mAs4cDPr8CDbB=hVJk3YURR<;YVVe}i
+zH4VPi#sF`j{_5B)vN4u|e)jM(|JKI}{da==@2O^OXJqx+GG_R^W?=2&Wa0X`P-$%<
+zWMpLG<Rk~M1(^Mh#54JvEUXHm_-Lca3M)$jz5TrWVT^)HDZzq*6uqcRSEO&-H)J!v
+zox0RpNqqerD+o-nP(VP(;6Ij>8by{u-!tZWT#RQddptXRfEZxmfpt|@bs<*uh?Y_<
+zD>W09Iy4iM@@80&!e^~gj!N`3lZwosC!!ydvJtc0nH==K)v#ta_I}4Tar|;TLb|+)
+zSF(;=?$Z0?ZFdG6>Qz)6oPM}y1&zx_Mf`A&chb<i`Nr1_JKCJ^T_*s={KuqB@lhf>
+znSERvt9%wdPDBIU(07X+CY74u`J{@SSgesGy~)!Mqr#yV6$=w-dO;C`JDmv=YciTH
+zvcrN1kVvq|(3O)NNdth>X?ftc`W2X|FGnWV%s})+uV*bw>aoJ#0|$pIqK6K0Lw!@-
+z3pkPbzd`ljS=H2Bt0NYe)u+%kU%DWwWa>^vKo=lzDZHr>ruL5Ky&#q7davj-_$C6J
+z>V8D-XJ}0cL$8}Xud{T_{19#W5y}D9HT~$&YY-@=Th219U+#nT{tu=d|B)3K`pL53
+zf7`I*|L@^<akj8#_&*rXa0J-fn>dPEIDJkI3_oA9vsH7n7O}Ja<law4{uj~>R{G~8
+zfi$?kmKvu20(l`dV7=0S43VwVKvtF!7njv1Q{Ju#ysj=|dASq&iTE8ZTbd-iiu|2&
+zmll%Ee1|M?n9pf~?_tdQ<7%JA53!ulo1b^h#s|Su2S4r{TH7BRB3iIOiX5|vc^;5(
+zKfE1+ah18YA9o1EPT(AhBtve5(%GMbspXV)|1wf5VdvzeYt8GVGt0e*3|ELBhwRaO
+zE<IB-Cn|oj1SDl{xp8zad#YcCdtrs+9}i$s<*@)jbR<MzYyAq(U%KqfE2&l%Q`Tlq
+zFFOj{{w{t{I93tgk%#X+S#qY@HW9M}>|yMhl;Bm?8Ju3-;D<d0gaE$FN@5itD4g&V
+zgQbZVdU+i-wHuALtd^lmCPv@8>NnxM3Roelg`^!S%e({t)jvYtJCKPqN`LmMg^V&S
+z$9OIFLF$%Py~{l?#ReyMzpWixvm(n(Y^Am*#>atEZ8#YD&?>NUU=zLxOdSh0m6mL?
+z_twklB0SjM!3+7U^>-vV=KyQZI-6<(EZiwmNBzGy;Sjc#hQk%D;ba<AuKL_OVlNJ8
+zzJ~Op&$U`bGuaaEPGBR);C}uHL4psgioidnP6KL62R)y#$^To}F#LDexcw6-48nGH
+z&YxHT*vkPdY(F<p{z3^E)4$-vMrqU*T?nO|IF@Z74ohmQ)xMgvN&|_c7OfAIO#XAt
+zaL2E?e(>y$v#zczt%mFCHL*817X4R;E$~N5(N$1Tv{VZh7d4mhu?HgkE>O+^-C*R@
+zR0ima8PsEV*WFvz`NaB+lhX3&LUZcW<oTbF57ud5qxRCovnmT%0KJe~XJK}Gj*7_g
+z0&W(W*y&*@eIfyjN}|^Vg@Xk+l%k}&LK6+_!9US75W3aKwKA7N7eaP%(H`-gc7jx_
+zq4R52zNWM^&eZyQ!NoQEuNB3ura1z?O0n};Cx@E>WJJrG7ZjQrOWD%_jxv=)`cbCk
+zMgelcftZ%1-p9u!I-Zf_LLz{hcn5NRbxkWby@sj2XmYfAV?iw^0?hM<$&ZDctdC`;
+zsL|C-7d;w$z2Gt0@hsltNlytoPnK&$>ksr(=>!7}Vk#;)Hp)LuA7(2(Hh(y3LcxRY
+zim!`~j6`~<bW*$8$<<~?JS18Peo3DUOk=IRLX_ufFFmtupg*V26|}Y8;Di!sKr{px
+zU!wn|6erEM{4t*~C;Z!(|BF)mSIk8}_js-C0LEmZCZ+%vYv=#^U(wOd%<)qwWIx%%
+z#P)x%MYM{N-K;vs`}xdVg@cSV9;IsBd_FC#oCthSxj&+MND|t@FCnpb@*2FC0f*D2
+z?G^cWl=jPk-fVXO^6GAO{DQL0%m8{~;|J@R4tRbB$asqPCv~(P@*H}1{&>B+sRBv4
+z<mz=pCM?&uNVBoEf!$<Jl`Auv$WWg;Z6o}=Da&vNrmd(0r*Nq_WttlLt&FC;g7G}~
+zz%kSd_><#B{@38kH;sLB4eH2+8IPWklhd25r5j2VR}YK$lpZ%7eVF5CBr#~=kUp`i
+zlb+>Z%i%BJH}5dmfg1>h7U5Q(-F{1d=aHDbMv9TugohX5lq#szPAvPE|HaokMQIi_
+zTcTNsO53(oX=hg2w!XA&+qP}nwr$(C)pgG8emS@Mf7m0&*kiA!wPLS`88c=aD$niJ
+zp?3j%NI^uy|5*MzF`k4hFbsyQZ@wu!*IY+U&&9PwumdmyfL(S0#!2RFfmtzD3m9V7
+zsNOw9RQofl-XBfKBF^~~{oUVouka#r3EqRf=SnleD=r1Hm@<buigJ1Zgh}+47#N}=
+zA;FL!#2C23SP8!!apVBYzJ3fxxO$`OHLK}}G5fYfk`4&0f}B0=8mk!Hn*#TLB6~0w
+zVDX$-aLCK?dMa|C-1DpnLg1Y;dn>~`y8U7R)w16fgHvK-6?-TFth)f3WlklbZh+}0
+zx*}7oDF4U^1tX4^$qd%987I}g;+o0*$Gsd=J>~Uae~XY6UtbdF)J8TzJXoSrqHVC)
+zJ@pMgE#;zmuz?N2MIC+{&)tx=<l|D;tZlZQyALE=2ji-YLMO_Re>7A%$yq-{GAzyz
+zLzZLf=%2Jqy8wGHD;>^x57VG)sDZxU+EMfe0L{@1DtxrFOp)=zKY1i%HUf~Dro#8}
+zUw_Mj10K7iDsX}+fThqhb@&GI7PwONx!5z;`yLmB_92z0sBd#HiqTzDvAsTdx+%W{
+z2YL#U=9r!@3pNXMp_nvximh+@HV3psUaVa-lOB<kAlb5{e|+s3GRS<WGPVcKv}ufw
+zsm@L)j21fBT_PZS23MbS<jhcW_7ZmN8)9;FrTXBPApWUlG*$QXnli9;L`ce(&0uB<
+zK<7{*B6<8;LFx#98e~1Ipcz1=a?doj&-~;#cS-Pk$4@XT{MS|f&qHIFc^#?##d3%L
+zF_vTgzyFp0k4KXHb4gb>ekVuMf1RUd26~P*|MLouQrb}XM-bEw(UgQxMI6M&l3Nha
+z{MBcV=tl(b_4}oFdAo}<FNiIc;2!TENsPY_{u&vbEN_gH<2W2+zqz;HID|PS7~k-+
+z?orh+BjNq^{SNz=&lq$2>WX$~$Mj-z70FowdoB{TN|h<oa=NkAgwvViq7Zbbs20=(
+zjFf3J3IkKmvhA(1BFfTs0<}wn4tMNcYw*#d5+3#m^D7`Q>2BdYs?$imcj{IQpEf9q
+z)rzpttc0?iwop<FB}NoH|4vN8(!wS{7iPRZAtgAKfwm99$&fQSncFCAHTtkEGq%pm
+zWTY7<`y7xseX%vxnS$7Cg0<;j2&4>SmEoB&V!1aoZqEWEeO-MKMx(4iK7&Fhc(94c
+zdy}SOnSCOHX+A8q@i>gB@mQ~Anv|yiUsW!bO9hb&5JqTfDit9X6xDEz*mQEiNu$ay
+zwqkTV%WLat|Ar+xCOfYs0UQNM`sdsnn*zJr>5T=qOU4#Z(d90!IL76DaHIZeWKyE1
+zqwN%9+~lPf2d7)vN2*Q?En?DEPcM+GQwvA<#;X3v=fqsxmjYtLJpc3)A8~*g(KqFx
+zZEnqqruFDnEagXUM>TC7ngwKMjc2Gx%#Ll#=N4qkOuK|;>4%=0Xl7k`E69@QJ-*Vq
+zk9p5!+Ek#bjuPa<@Xv7ku4uiWo|_wy)6tIr`aO!)h>m5zaMS-@{HGIXJ0UilA7*I}
+z?|NZ!Tp8@o<g6{t!6GGpEZ3+xJO<~FK>-lnyde*H+@8IHME8VTQOGh96&XX3E+}OB
+zA>VLAGW+urF&J{H{9Gj3&u+Gyn?JAVW84_XBeGs1;mm?2SQm9^!3UE@(_FiMwgkJI
+zZ*caE={wMm`7>9R?z3Ewg!{PdFDrbzCmz=RF<@(yQJ<VyM+ly^hkKwrU?N(EcGTG)
+zusbNv5i$F3@Zf=?+&aeDOWDQ7$Qe9+B5{<3u0W4YeBR!LFJjuu&@SMl|F6jRfqiyz
+z{O`I${Euua!vE}0|0A#|Qib%yQO5k~F=XS~vL;+>_A6?PCd_MdUf5vv6G#9Mf)i#G
+z($OxDT~8RNZ>1R-vw|nN699a}MQN4gJE_9gA-0%>a?Q<9;f3ymgoi$O<?iymZH(Er
+zNGvX8A0}*i-nw7954=`Bwhd<ZUjO(yu}|0@?)GI5gP?*)IHp?Eg%^jP>I!=aE6Elw
+z2I`l!qe-1J$T$X&x9Zz#;3!P$I);jdOgYY1nqny-k=4|Q4F!mkqACSN`blRji>z1`
+zc8M57`~1lgL+Ha%@V9_G($HFBXH%k;Swyr>EsQvg%6rNi){Tr&+NAMga2;@85531V
+z_h+h{jdB&-l+%aY{$oy2hQfx`d{&?#psJ78iXrhrO)McOFt-o80(W^LKM{Zw93O}m
+z;}G!51qE?hi=Gk2VRUL2kYOBRuAzktql%_KYF4>944&lJKfbr+uo@)hklCHkC=i)E
+zE*%WbWr@9zoNjumq|kT<9Hm*%&ahcQ)|TCjp@uymEU!&mqqgS;d|v)QlBsE0Jw|+^
+zFi9xty2hOk?rlGYT3)Q7i4k65@$RJ-d<38o<`}3KsOR}t8sAShiVWevR8z^Si4>dS
+z)$&ILfZ9?H#H&l<RT2S~_Jj4$4(IRHJFV0?A!G0Qhg^SAVSGNU@RS<f${jo1F-$bS
+zyW`W1oDY=>umngpj7`|rKQQ`|tmMmFR+y-9PP`;-425w+#PRKKnx7o-Rw8;}*Ctyw
+zKh~1oJ5+0hNZ79!1fb(t7IqD8*O1I_hM;o*V~vd_LKqu7c_thyLalEF8Y3oAV=ODv
+z$F_m(Z>ucO(@?+g_vZ`S9+=~Msu6W-V5I-V6h7->50nQ@+TELlpl{SIfYYNvS6T6D
+z`9cq=at#zEZUmTfTiM3*vUamr!OB~g$#?9$&QiwDMbSaEmciWf3O2E<mlP_PonDwt
+zyitcRzTVrxyJMiqOZ6|7#G@nv5X=6&i;>8?oE0ApScg38hb&iN%K+kvRt#d))-tr^
+zD+%!d`<L4%gYWIkY!vD!A?&@isi9mjq}hc5uLusOi**W156CB;6jndj83!M&a=e4K
+zV{K2_%pB}vEiuAw60U0jUrMlCDCQLmYx75m`l(uEE8=2*7U?XVZesIds6ZgImrC6J
+zaSGNgykYte(u*RGC_Cdgw_=To1Sk<7c@waaCe^q4t!2!@1+<vcCZJJd`WP{XR`nxw
+zGu<m<ZH}qgdl57!HcrTLPnp>i!OOE3in0Q_HzNXE!JcZ<0;cu6P_@;_TIyMZ@Wv!J
+z)HSXAYKE%-oBk`Ye@W3S<fT|RJJ2x9j}N_gm*>hYu-bfC<JlS4ISeU0#72JEq&iV@
+z);;bzD{y$YwCJZhLJpC1#?j@p;n13~AR-U_7}H;)tO$ka&g;YU0hclMs2jggs@V)}
+z1ctUKqL*50yB=^24iD^`6e#NM3t6q_UJr0(0eheaY{0bzc8rmE8>AZ}1|J16hFnLy
+z?Bmg2_kLhlZ*?`5R8(1%Y?{O?xT)IMv{-)VWa9#<mvE`6Fsm;~;S~jwikf)Rjguu$
+z5vQddW;F{QVK_+$;)+G^5Vmb(r-Npc&G#KXM)uo^^@C#o|I{V8-x8LCrE4E&Qq(N-
+zMS66xhsVfaLJl|yc8xV__In+|p9mrG(%HWN_C^hqh)+P9$S6+nJmaAfIxP%v9WfYQ
+zL5;Uu-6T=cz->1pKH|oVRm4!lLmls=u}Lxs44@g^Zwa0Z_h>Rk<(_mHN47=Id4oba
+zQ-=qXGz^cNX(b*=NT0<^23+hpS&#OXzzVO@$Z2)D`@oS=#(s+eQ@+FSQcpXD@9npp
+zlxNC&q-PFU6|!;RiM`?o&Sj&)<4xG3#ozRyQxcW4=EE;E)wcZ&zUG*5elg;{9!j}I
+z9slay#_bb<)N!IKO16`n3^@w=Y%duKA-{8q``*!w9SW|SRbxcNl50{k&CsV@b`5Xg
+zWGZ1lX)zs_M65Yt&lO%mG0^IFxzE_CL_6$rDFc&#xX5EXEKbV8E2FOAt>Ka@e0aHQ
+zMBf>J$FLrCGL@$VgPKSbRkkqo>sOXmU!Yx+Dp7E3SRfT`v~!mjU3qj-*!!YjgI*^)
+z+*05x78FVnVwSGKr^A|FW*0B|HYgc{c;e3Ld}z4rMI7hVBKaiJRL_e$<k+t<^`D)J
+zEhcFT+>rxDW^8!nGLdJ<7ex9dFoyj|EkODflJ#Xl`j&bTO<I#P8edX2Zurtkc%j^@
+zNt6$0k5j7Tz*Hvqfi_&6#Q9+R)Fv6`GmW+`8bq@}anEonN&wkBMSbC3p65Q!BQJn9
+z($6ofVPsfai#?XWp7#{34OEeYG<ZeV`;e33{@dz|B}sgh&`J@Iq}UpnS6~gr0^_2`
+z<OPZ;lTV0rmf6o448!Uqt;aNgDOUMFk-WHp5yxc_@Pw(=_HnwV*fc`$ZOS^5Tv^Xj
+zs6|mx8FjhE6;^Q`ZD8?b*C=D)QP^dT)L|ZTke)O$7uVN>%=$v)c+gJsLK_%H3}A_}
+z6%rfG?a7+k7Bl(HW;wQ7BwY=YFMSR3J43?!;#~E&)-RV_L!|S%XEPYl&#`s!LcF>l
+zn&K8eemu&CJp2hOHJKaYU#hxEutr+O161ze&=j3w12)UKS%+LAwbjqR8sDoZH<g6`
+zeO;HbwrZ9reV{8OM|L-k?0OY=6?byB5<#Ri|6=ZM<cbTpfiMCe6D0+uuN~Snj^GI6
+zBGP94F2>nD<cul@`WjtmWkT9y3u`g7Ep4O>=m0(p62!zg<Af@s3vh7(o9SiY*ZKN>
+zxt!Sj65S<M*Zjht+%5QyX@dTS`ynS|*dw2j79o<R`%(HG^UA0FiEur$J4e>?6WPmm
+zL&U9c`6G}T`irf=NcOiZ!V)qhnvMNOPjVkyO2^CGJ+dKTnNAPa?!AxZEpO7yL_LkB
+zWpolpaDfSaO-&Uv=dj7`03^BT3_HJOAjn~X;wz-}03kNs@D^()_{*BD|0mII!J>5p
+z1h06PTyM#3BWzAz1FPewjtrQfvecWhkRR=^gKeFDe$rmaYAo!np6iuio3>$w?az$E
+zwGH|zy@OgvuXok}C)o1_&N6B3P7ZX&-yimXc1hAbXr!K&vclCL%hjVF$yHpK6i_Wa
+z*<Rda^MN8#r#%H(uhk!|+(Xdsw2E^5cUpnFp8p1^_KFVpjUj=6sF40s6^Zu$9=(bF
+zx1x^nKdB2b8!ICz8ygEJ+y4>CMg1RAH1(EuuA01@lA$sM<OVE;c)%cNQLi9uaS;hG
+z%fi;i)%@4^r8O+Wz2GPMFlZFnH;_-_U9)NAegHj_!}O-ZO`FT{#><S(uSx^)-K{gT
+zhG&r*35&meRW|1;vN}suvoTt-WY!oM-loV8;oR{IcSbtH!As;82qoT?HqV9V3*~qm
+z!SuufxJRefmX+!kF&rvO-e(?VCk%)$MRmimz$37siP-FuaN<K+5pNn#@=eC8%!@nb
+z2*5!qsZ<fp+A*NXf=8**@y(*g7NiBCiEV7bSE-BMr;5Zd;AV+}D!T7#a7AZhy$tZ}
+zBZj0LQc#mui!Lo2Q3KNe2agi@n?}tiW0Rj<VeQ<_*D6y|ViQ@=M%oDn5H>fe*s@9-
+z$jNWqM;a%d3?(>Hzp*MiOUM*?8eJ$=(0fYFis!YA;0m8s^Q=M0Hx4ai3eLn%CBm14
+zOb8lfI!^UAu_RkuHmKA-8gx8Z;##oCpZV{{NlNSe<<V1a7ju;v(TY8|0upX`)YP)i
+zhF9S0sKf|T)6o+<$QQ8snYX%z2pId%K2VdBjyrL|U&7n?j2gqBIlgc7sqRmR3rF|l
+zlUaMtZ*=q~vwXXK9=bFWx14^H@c)%dSINC6uKh#1>i;9!MfIN!&;JI-{|n{(A19|s
+z9oiGesEN<ynV})!iaH~auE<DSv%{<&k~X$kQz2b-qcNkA8P@0{SIU`uY<?@NmTQBx
+z)D?^>cLf@NN^9R0uIrgg(46r%kjR{0SbnjBqPq()wDJ@LC2{kUu_j$VR=l`#RdaRe
+zxx;b7bu+@I<Nh=^5@s63-0S!f#dfXn@}AC1>ntWaV$si1_nrQpo*IWGLBhhMS13qH
+zTy4NpK<-3aVc;M)5v(8JeksSAGQJ%6(PXGnQ-g^GQPh|xCop?zVXlFz>42%rbP@jg
+z)n<qUy~a=5h*jh6P7t^JBt^vIyENcV7ST}KUA-3{?3CB)-Fh4a#gMRWaLCBu<v>)%
+zM9anq5(R=uo4tq~W7wES$g|Ko<i2Il^N$GIC?!+;wqh32G+daBXSzA(l7+`)WY5H*
+zxN4$-v5B6xdBXsPjBQ?{pU&2{p1fGEo~A^$<7<6Ai9r_XJLEi2ERS5-WM=rJMwjp>
+z1iNIw@-{x@xKxSXAuTx@SEcw(%E49+JJCpT(y=d+n9PO0Gv1SmHkYbcxPgDHF}4iY
+zkXU4rkqkwVBz<{mcv~A0K|{zpX}aJcty9s(u-$je2&=1u(<Ijk*osoSbRG#RG2dxi
+zY2dIgjpsHFWw4YgUuLN}C3yiVDS7TfH_01AHBUEe$&x)yg`w@~!r_*o_*~bpU7c<5
+z`bmK&NU6Nw_v-jDi5@dldK4Fn1A<6r>e#Q~UA{gA!f;0EAaDzdQ=}x7g(9gWrWYe~
+zV98=VkHbI!5Rr;+SM;*#tOgYNlfr7;nLU~MD^jSdSpn@gYOa$TQPv+e8DyJ&>aInB
+zDk>JmjH=}<4H4N4z&QeFx><vCqo(8;VBNf?4{-ejyJD7h1Z5Qh!VF^s0~(Sx+W_U{
+zR};ybxF{rNR6jf3&Uli%SD1<DGAon!MxCaTjg2UoiPv{%y|HIy7wF&Vh+2it<&g@k
+z2+Wf#)mx-UNsAjpU<5>1VPY8GU&^1c&71T*@2#dINft%ibtY(bAm%<2YwPL?J0Mt{
+z7l7BR718o5=v|jB!<7PDBafdL>?cCdVmKC;)MCOobo5edt%RTWi<zJmle+?jwNYxN
+z4^6|EAjKcb86Lhb2TiEBh#*!<VO%f-!t(A33YL(fW`@*JF%L#%9n~L_x_&@iQ8p+r
+z50!J0d4(u}33+T-j40yL1x4WL)VTLI3<|eCyY3_SBtK8>ReAMaIU5X9h`@El0sR&Z
+z7Ed+F<Hz;iLDs#Hc0AY<Bv9{VG$$}Nxol9pHZ;R^PVSOq1+c`wf56t4>iyA+QAyWn
+zf7=%(8X<IsS*x5)IZjAvYsetv<jbdR10P8%td<*r6IM&L5LRrcOf|!8RQAgg6~$_=
+zBSd>pcS*C4^-L24TBUu%0;@s!Nzy{e95qjgkzE<W5xLBBDYXZDXN}?0z#DvAb||%H
+zZPS{|8~$Dai+w3|r0z;7J8SaSbF0|4F}$?B9(zK4Hfql>lf0#ou`sYng<}wG1M|L?
+zKl6ITA1X9mt6o@S(#R3B{uwJI8O$&<3{+A?T~t>Kapx6#QJDol6%?i-{b1aRu?&9B
+z*W@$T*o&IQ&5Kc*4LK_)MK-f&Ys^OJ9FfE?0SDbAPd(RB)Oju#S(LK<CirA2f_*u2
+zok`__!UM2k24u<34N&n2<rv2c5C+LG1_2&glf5C-MnxH;!hzUTv-tAoF?gV=0tG&*
+z&3NTXW=(G6=cQ0qDpT;#Hy7t96N4?Q={0R{&UH=JEWgy<75@6brLBmih;_W+NcLKU
+zn<HoD>)?EVandS1qb#KR;OP|86J?;TqI%E8`vszd&-kS%&~;1Als=NaLzRNnj4q=+
+zu5H#z<eB8n3vpKCZ_UBe2i$XZJvzC|oStL%r*N4lp0t3D`s9hT%+m%jPcLdrJAA8K
+z_Xy5FTlYi&>)BDKHo1EJTC?Cd_oq0qEqNAF8PwU7<g1n3gpVtS#>fK!-WwVEp4~4g
+z3SEmE3-$ddli))xY9KN$lxEIfyLzup@utHn=Q{OCoz9?>u%L^JjClW$M8OB`tx<B9
+zZzQvx^C^)R6f_#j34$T{qWzMIebqUHU#Mm4dIX;v?G*C~teYh!pha7{DB@cX4KxPS
+zH^Q;NkvbuF4d_@se8XmvFleR*sC@ep>g4r6Q-6UlVx3tR%%Z!VMb6#|BKRL`I))#g
+zij8#9gk|p&Iwv+4s+=XRDW7VQrI(+9>DikEq!_6vIX8$>poDjSYIPcju%=qluSS&j
+zI-~+ztl1f71O-B+s7Hf<J;>>AZ#}DNSf`7C7*)%(Xzf|ps6Dr7IOGSR417xsU=Rxb
+z1pgk9vv${17h7mZ{)*R{mc%R=!i}8EFV9pl8V=nXCZruBff`$cqN3tpB&R<?rJ^^G
+zLU#yZbVti(nuC|2|IXia=NN6mqd+?dR)7Jc*9;iC!a;f?+=#<s4C&g0_&NB8weC%l
+zS<iNL{)P(<k~BWt3Y%{Xrbk9d#iq+t;G9E%F%_rY<%%AD^lw^bplw!%%|-aF&{mk{
+z8v%Z~T)@9qJANVDtF7i6j_uAG%PQrIzYL<`zWN)?kg5G%9sC$@=vQ^>K^$yH!A8RL
+zJ5KltH$&5%xC7pLZD}6wjD2-uq3&XL8CM$@V9jqalF{mvZ)c4V<q)vM?$E(wfOg3Q
+zv%+110#sykOiRSt?0@;lgu4A3JD@U~_wpzdHgwI1fA5o$81_b21C0iEz!;O~RRRX1
+zGlEi0gdqWrOw3XkgEa2cwZ#ieSM+Bwx5supt!d$Nc0%<IFUjN0oH@W~IsyX(WZ$<d
+z|MaryZKLL%mzThJyCC#$>n?xXbvkB(q%<Z{kVQ;%LF$(<$dK2qdz`UK^3urTrD0B4
+z1&)CdFB?t|pWnGgd`vO!l5yW5V|rGsYb-Keu0g!I*6%Xh0JZtqeMa&LE(4Bo#scEB
+z2+Xh0IF3fHxOvz(nbw5~LC>xbSdjoXJXanVN@I;8I`)XlBX@6BjuQKD28Jrg<b?I+
+zxnRcDtmgY@D96{&H=|gt1$AWNvdJ3yEL}1j876RHewior=;z@yI+m%vO5~lw`>05}
+z^ImmK-Ux<q>*QMn_A|1ionE#AurP8Vi?x)7jG?v#YyVe_9^up@6^t_Zy^T1yKW*t*
+z&Z0+0Eo(==98ig=^`he&G<vo(#Q)G{9SIowKW2Tx<>^K$I!F~1l~gq}%o5#pR6?T+
+zLmZu&_ekx%^nys<^tC@)s$kD<AcM417>`^r8)1^tUazRkWEYPw0P)=%cqnyeFo3nW
+zyV$^0DXPKn5^Qi<LfvSpMIU#o(EG&Rpi2B@a5@RzAAQS3*j%A9U;6sg<98@jyPDmC
+zXKg0?&ACu)O$sr|d)+$ZH;RJR7V`iC489P}wQ3gU*M+C_X7Cw%nw^c(gNH_oV&C^!
+zc5Ja!U#d<n%*)0OuX(xIWS}X!VI4G5%&+mH^jQka0XK?`B*^+~@VtKToDTaE*!8R~
+z<nPU#JZXd+QYE>OtOi4MIX^#3wBPJjenU#2OIAgCHPKXv$OY=e;yf7+_vI7KcjKq%
+z?RVzC24ekYp2lEhIE^J$l&wNX0<}1Poir8PjM`m#zwk-AL0w6WvltT}*JN8WFmtP_
+z6#rK7$6S!nS!}PSFTG6AF7giGJw5%A%14ECde3x95(%>&W3zUF!8x5%*h-zk8b@Bz
+zh`7@ixoCVCZ&$$*YUJpur90Yg0X-P82>c~NMzDy7@Ed|6(#`;{)%t7#Yb>*DBiXC3
+zUFq<q;<NLVE3q+|RY;{7>(UDFjrgOsc%0KJ_L;WQKF0q!MINpQzSsqwv?#Wg+-NO;
+z84#4nk$+3C{2f#}TrRhin=Erdfs77TqBSvmxm0P?01Tn@V(}gI_ltHRzQKPyvQ2=M
+zX#i1-a(>FPaESNx+wZ6J{^m_q3i})1n~JG80c<%-Ky!ZdTs8cn{qWY%x%X^27-Or_
+z`KjiUE$OG9K4lWS16+?aak__C*)XA<mn7dO1IQ<7rt}jYvLS-$H~f<X5+N=(Ek`&&
+zUWHe^|Bwj1`@oeHlPUTz8D*6r?NpHjHK-@Dqy;NDtS}cg%!YayC0fs^iN;OYEP9kK
+zo5Vht9oQS7iDhR-OPXj9?q6@S&eFy#n-1R+kA`A0*{=#t%}!LRAXjjRywc~_uNoSv
+zszK4MM3XQ`!AP4Kj^Rx*7iMfV9^D$9ff(?N=BiGkohxx7DcQNG_tP#nT3_=hI7YLo
+zGAoH*rjQg^W(ap448geJyg*-Zsf^RAr9lW2dRNFv&HLWl7oARenT?<M#Z5`E1my@r
+zEvZ)*EFhV=Xn(d!ux{Tmfc~sd_)m;R7maZ)e8qGMx=q|X7Apwv&(Z7nX5hp;7Fa>{
+z6HmS*8#t_3dl}4;7ZZgn4|Tyy1lOEM1~6Qgl(|BgfQF{Mfjktc<V73_^4Y*JAxZ9&
+zk;vp)O|oP#qgjAs8&wb~jCgfwsBn#A5JV`I8M5Mt;ki^ey-B;1sC5O4oRWjC=0x>h
+zB5kc~4NeehRYO%)3Z!FFHhUVVcV@uEX$eft5Qn&V3g;}hScW_d)K_h5i)vxjKCxcf
+zL>XlZ^*pQNuX*R<VIWU<&k+#O#z05{>JQn)b6;blT3<7@Ap)55)aK3n-H08GIx65W
+zO9B%gE%`!fyT`)hKjm-&=on)l&!i-QH+mXQ&lbXg0d|F{Ac#U;6b$pqQcpqWSgAPo
+zmr$gOoE*0r#7J=cu1$5YZE%uylM!i3L{;GW{ae9uy)+EaV>GqW6QJ)*B2)-W`|kLL
+z)EeeBtpgm;79U_1;Ni5!c^0RbG8yZ0W98JiG~TC8rjFRjGc6Zi8BtoC);q1@8h7<W
+z{%QU=f~@E{*75;EPtq=QOC=`G(0Hdr_HmX;s)IO`uOsm?hi;HPRH2DMN!8p_6N*mR
+zXeVd+rX;e|)D{nmu3FxC){%4`fvkUoMM~{w*jYq7&hHz|64x(?E6&4jG;eJ*jSB0z
+zWIII4*kn~Ve25Pk+1h=4UMO&Fvq`3&FqVW1qQ})@8We8E6!Yt^Nic_&{<S5dR(OO{
+zb5!CWQqPU+0jYF<lXRIyMn^4F&DA<&TE_&-%x*k9PRqAjBu2+9eB|q?j^5xDz3>UV
+zFa&LRzYsq%6d!o5-yrqyjXi>jg&c8bu}{Bz9F2D(B%nnuVAz74zmBGv)PAdFXS2(A
+z=Z?uupM2f-ar0!A)C6l2o8a|+uT*~huH)<BklnFF@?8S@YKGOgvIkgvy?bVNlgCB_
+zoqeDw{3YNZ=l`nrK(ag;cr55JL-h60|J5N{s-NkNhFkQ*iwcZIFaTBfOzrkQWLJ*V
+zICw*3^B@Set{3BbuO`R#p?&bEzj(u;_I4rvE}iY2Q^FV4RYK^P{cWG=Da>!h3i!&$
+zr>76mt|lwexD(W_+5R{e@2SwR15lGxsnEy|gbS-s5?U}l*kcfQlfnQKo5=LZXizrL
+zM=0ty+$#f_qGGri-*t@LfGS?%7&LigUIU#JXvwEdJZvIgPCWFBTPT`@Re5z%%tRDO
+zkMlJCoqf2A=hkU7Ih=IxmPF~fEL90)u76nfFRQwe{m7b&Ww$pnk~$4Lx#s9|($Cvt
+ze|p{Xozhb^g1MNh-PqS_dLY|Fex4|rhM#lmzq&mhebD$5P>M<DmANA7)v1?A&u8?r
+zN#V^qY31R$$uOM7e!;99G3zfzxBI#kn<K!x%{#o+a5>$eqLoV|z=VQY<HWnoG0tOv
+z69l8*cSEJV=QU?Ns^-R%Uq*rJ%^Z2p;<g;km5p_x#;n0NJ&|94gMZ|Q>{)7&sR#tW
+zl(S1i!!Rrg7kv+V@EL51PGpm511he%MbX2-Jl+DtyYA(0gZyZQjPZP@`SAH{n&25@
+zd)emg(p2T3$A!Nmzo|%=z%AhLX)W4hsZNFhmd4<1l6?b3&Fg)G(Zh%J{Cf8Q;?_++
+zgO7O<(-)H|Es@QqUgcXNJEfC-BCB~#dhi6ADVZtL!)Mx|u7>ukD052z!QZ5UC-+rd
+zYXWNRpCmdM{&?M9OMa;OiN{Y#0+F>lBQ=W@M;OXq;-7v3niC$pM8p!agNmq7F04;|
+z@s-_98JJB&s`Pr6o$KZ=8}qO*7m6SMp7kVmmh$jfnG{r@O(auI7Z^jj!x}NTLS9>k
+zdo}&Qc2m4Ws3)5qFw#<$h=g%+QUKiYog33bE)e4*H~6tfd42q+|FT5+vmr6Y$6HGC
+zV!!q>B`1Ho|6E|D<2tYE;4`8WRfm2#AVBBn%_W)mi(~x@g;uyQV3_)~!#A6kmFy0p
+zY~#!R1%h5E{5;rehP%-#kjMLt*{g((o@0-9*8lKVu+t~CtnOxuaMgo2ssI6@kX09{
+zkn~q8Gx<6T)l}7tWYS#q0&~x|-3ho@l}qIr79qOJQcm&Kfr7H54=BQto0)vd1A_*V
+z)8b2{xa5O^u95~TS=HcJF5b9gMV%&M6uaj<DG%?NLS@ZBcw~|?Ph?A!$GyTtN#J(n
+z(N#33Z&MXkLNi3tlx}v1EUFXC!E2$+1Uui1Bx24YZRI7U{9C!4ye6`#_fxLyx><>E
+zPNM~qGjJ~xbg%QTy#(hPtfc46^nN=Y_GmPYY_hTL{q`W3NedZyRL<bGaMku?v;})8
+z39o7JEb=3hqE?4Vw{>^kgU@Q$_KMAjEzz*eip`3u6AhPDcWXzR=Io5EtZRPme>#K9
+z4lN&87i%YYjoCKN_z9YK+{fJu{yrriba#oGM|2l$ir017UH86Eoig3x+;bz32R*;n
+zt)Eyg#PhQbbGr^naCv0?H<=@+Poz)Xw*3Gn00qdSL|zGiyYKOA0CP%qk=rBAlt~hr
+zEvd3Z4nfW%g|c`_sfK$z8fWsXTQm@@eI-FpLGrW<^PIjYw)XC-xFk+M<6>MfG;WJr
+zuN}7b;p^`uc0j(73^=XJcw;|D4B(`)Flm|qEbB?>qBBv2V?`mWA?Q3yRdLkK7b}y&
+z+!3!JBI{+&`~;%Pj#n&&y+<;IQzw5SvqlbC<hrT)sBs!K|EW5H^76b8wi?&5jaqoB
+zdZ2NRMM|}GTQWlnULm3*Tw}|kY|0D0spF;??&YCTeOo~Duw_Bz&0>+V=kLZLAHOQb
+zS{{8E&JXy1p|B&$K!T*GKtSV^{|Uk;`oE*F;?@q1dX|>|KWb@|Dy*lbGV0Gx;gpA$
+z*N16`v*gQ?6Skw(f^|SL;;^ox6jf2AQ$Zl?gvEV&H|-ep*hIS@0TmGu1X1ZmEPY&f
+zKCrV{UgRAiNU*=+Uw%gjIQhTAC@67m)6(_D+N>)(^gK74F%M2NUpWpho}aq|Kxh$3
+zz#DWOmQV4L<sDJGB1~xI&#K@a<rftJ&W$tS7|})}p7LCV^RAnbsUrP_V*uhk=;!pl
+zs4zoj`KucSBFKjBcKXW*EHB;&BS$tidMG;U{H8n7wJ)AAvB2L*UBNbpb;dN7LsCrE
+zL;cL{W0B-y=uz}$?A3Z<^oG{u-AX|Svz(WP+@{ryM8&-@TzJ+nBT;gLmX|TuUS7tX
+zbu7uYkz$71L||aR32Yb{k;9>g&}`XTU41Z|P~5;wN2c?2L{a=)Xi~!m#*=22c~&AW
+zgG#yc!_p##fI&E{xQD9l#^x|9`wSyCMxXe<3^kDIkS0N>=oAz7b`@M>aT?e$IGZR;
+zS;I{gnr4cS^u$#>D(sjkh^T6_$s=*o%vNLC5+6J=HA$&0v6(Y1lm|RDn&v|^CTV{=
+zjVrg_S}WZ|k=zzp>DX08AtfT@LhW&}!rv^);ds7|mKc5^zge_Li>FTNFoA8dbk@K$
+zuuzmDQRL1leikp%m}2_`A7*7=1p2!HBlj0KjPC|W<t!gw4p)|NM)%cW9T$k`o|lfo
+zg*aR{7NSC?*?~1-ovU>T?5{_aa%}rQ+9Mqcf<RjoiaEgO6aLbf%7cdA%8(Z(Lepcg
+z;EK+)sbwoSMUuni>XI0NtjvXz1U)|H>0{6^JpHspI4MfXjV%1Tc1O!tdvd{!IpO+@
+z!nh()i-J3`AXow^MP!oVLVhVW&!CDaQxlD9b|Zsc%IzsZ@d~OfMvTFXoEQg9Nj|_L
+zI+^=(GK9!FGck+y8!KF!nzw8ZCX>?kQr=p@7EL_^;2Mlu1e7@ixfZQ#pqp<X+0Re_
+zrJ{H^$-Z@QA7ETVM2%a&#GG%~hgC@{06tyBwQZmlXSm57v9B9QX(aJLI_U;c+x!4Y
+zc@Lpfn;l;r15OkOarCAT2KT0TI&b@nuFwDm5s2$h*ySA~Ad%ZKk`|FTjsVplUIi{5
+zlFa?pIp_hLcE?CXH;$pLba~E##@hT^OvK63FoxCFx@_5ii6TR$R#n$|+i^+&#se{6
+zDr7|zkeVUxEFj8#1(pWjg_@>yCJ```(m;la2NpJNoLQR};i4E;hd+|QBL@GdQy(Cc
+zTSgZ)4O~hXj86x<7&ho5ePzDrVD`XL7{7PjjNM1|6d5>*1hFPY!E(XDMA+AS;_%E~
+z(dOs)vy29&I`5_yEw0x{8Adg%wvmoW&Q;x?5`HJFB@KtmS+o0ZFkE@f)v>YYh-z&m
+z#>ze?@JK4oE7kFRFD%MPC@x$^p{aW}*CH9Y_(oJ~St#(2)4e-b34D>VG6giMGFA83
+zpZTHM2I*c8HE}5G;?Y<M+?LyWn?03qS587BS{lq0V4R8#J8=B>7RXMA2k{Y?RxHb2
+zZFQv?!*Kr_q;jt3`{?B5Wf}_a7`roT&m1BN9{;5Vqo6JPh*gnN(gj}#=A$-F(SRJj
+zUih_ce0f%K19VL<E3HrXlqqoBf~c20@9ozE$2qZsljz1QN-PVpQS1W!)YMjSijFXX
+z{P)`?A`eAJ?oh<!djz+PC3lVbl99-ayrp8oi=_canYFfMH62C}^0hP3`X)L9+i4`Q
+zm?I7fbusV!Jv(kfxmM>Xi5(<VS*XQmy2&`ZRfWgKV9~k|yVKp~M)9<_9P`znoH<lN
+z$~@NdPe<+%!i}Jugmv9Pnb}eLR?O8Po%je^XGWy*@HH7__y8%?t*~t>VBGOFbc(YF
+zLvvOJl+W<}>_6_4O?LhD>MRGlrk;~J{S#Q;Q9F^;Cu@>EgZAH=-5fp02(VND(v#7n
+zK-`CfxEdonk!!65?3Ry(s$=|CvNV}u$5YpUf?9kZl8h@M!AMR7RG<9#=`_@qF@})d
+ztJDH>=F!5I+h!4#^DN6C$pd6^)_;0Bz7|#^edb9_qFg&eI}x{Roovml5^Yf5;=ehZ
+zGqz-x{I`J$ejkmGTFipKrUbv-+1S_Yga=)I2ZsO16_ye@!%&Op^6;#*Bm;=I^#F;?
+z27Sz-pXm4x-ykSW*3`)y4$89wy6dNOP$(@VYuPfb97XPDTY2FE{Z+{6=}LLA23mAc
+zskjZJ05>b)I7^SfVc)LnKW(&*(kP*jBnj>jtph`ZD@&30362cnQpZW8juUWcDnghc
+zy|tN1T6m?R7E8iyrL%)53`ymXX~_;#r${G`4Q(&7=m7b#jN%wdLlS0lb~r9RMdSuU
+zJ{~>>zGA5N`^QmrzaqDJ(=9y*?@HZyE!yLFONJO!8q5Up#2v>fR6CkquE$PEcvw5q
+zC8FZX!15JgSn{Gqft&>A9r0e#be^C<%<F$|nV^6m7s?pfGWrS!*h<5zg%%}lEg1TI
+z|E5UO7&eitGHgtFuU&)>)psE*nyW^e>tsc8s4Q}OIm})rOhuc{3o)g1r>Q^w5mas)
+zDlZQyjQefhl0PmH%cK05*&v{-M1QCiK=rAP%c#pdCq_StgDW}mmw$S&K6ASE=`u4+
+z5wcmtrP27nAlQCc4qazffZoFV7*l2=Va}SVJD6CgRY^=5Ul=VYLGqR7H^LHA;<kSL
+zyrh(Zd)qJDxpzjXJoFc+eRH#(kkiWb-uI_%f85g24L`FdF1fP}Kg{iZ+*Fo8ju*cl
+z3Aw1YGq0cxadL4N9aS#>H^1g}ekn=4K8SPRCT+pel*@jUXnLz+AIePjz@mUsslCN2
+z({jl?BWf&DS+FlE5Xwp%5zXC7{!C=k9oQLP5B;sLQxd`pg+B@qPRqZ6FU(k~QkQu{
+zF~5P=kLhs+D}8qqa|CQo2=cv$wkqAzBRmz_HL9(HRBj&73T@+B{(zZahlkkJ>EQmQ
+zen<iPJWnXR=;Z=9fu?|et|Rb%*gDj8sMD`ZMBMaR)@W4I!@ZJ=6-0EUr*wDEx&_hw
+zhU+|E`Yc!V0@6Vf^U<QOMIE_YSpmh%i+yFO|G~yVs99EScY@d$n{uR4Xtly{afZWj
+zO}~7A(I*J<@B|oPywvLj91a5kZfNN5H=|EF#}if+=~cl#!%<3XeHAhGPkCdLS{G`f
+z#i{^H6>p59dy+L;sSWYde!z_W+I~-+2Xnm;c;wI_wH=RTgxpMlCW@;Us*0}L74J#E
+z8XbDWJGpBscw?W$&ZxZNxUq(*DKDwNzW7_}AIw$HF6Ix|;AJ3t6lN=v(c9=?n9;Y0
+zK9A0uW4Ib9|Mp-itnzS#5in=Ny+XhGO8#(1_H4%Z6yEBciBiHfn*h;^r9gWb^$UB4
+zJtN8^++GfT`1!WfQt#3sXGi-p<~gIVdMM<#ZZ0e_kdPG%Q5s20NNt3Jj^t$(?5cJ$
+zGZ#FT(Lt>-0fP4b5V3az4_byF12k%}Spc$WsRydi&H|9H5u1RbfPC#lq=z#a9W(r1
+z!*}KST!Yhsem0tO#r!z`znSL-=NnP~f(pw-sE+Z$e7i7t9nBP^5ts1~WFmW+j+<@7
+zIh@^zKO{1%Lpx^$w8-S+T_59v;%N;<ZZyRu1Je84c8pEeE|Tu>EZtJzcfN%&@(Ux5
+z@YzX^MwbbXESD*d(&qT7-eOHD6iaH-^N>p2sVd<d@hTC>q&(`C$;?#mgBANIc5$r|
+z^A$r)@c{Z}N%sbf<VV6f)%mV{w>o?T`tTHz9-YpiMW?6>kr&W9t$Cuk{q^g1<$I~L
+zo++o2!!$;|U93cI#p4hyc!_Mv2QKXxv419}Ej#w#%N+YIBDdnn8;35!f2QZkUG?8O
+zpP47Wf9rnoI^^!9!dy~XsZ&!DU4bVTAi3Fc<9$_krGR&3TI=Az9uMgYU5dd~ksx+}
+zP+bs9y+NgEL>c@l>H1R%@>5SWg2k&@QZL(qNUI4XwDl6(=!Q^U%o984{|0e|mR$p+
+z9BcwttR#7?As?@Q{+j?K6H7R71PuiA^Dl$=f47nUKL|koCwutc_P<-m{|Al3C~o7w
+z=4S=}s5LcJFT1zjS)+10X_r$74`K78pz!nGGH%JV%w75!YSIt#hT7}}K>+@{{a+Im
+z5p#6%^X*txY?}|T17xWW*sa^?G2QHt#@tlcw0GIcy;|NR2vaCBDvn=`h)1il7E5Rx
+z%)mA4$`$OZx)NF5vXZnaJ1)*cA6ryx6Ll~t!LzhxvcTedxT;>JS&e=?-&DXUPaQ2~
+zH*69ezE`hgV{K-|0z|m~ld}=X^-Ob={wpex&}*+Rz{gx)G}gn!C_VN{UN=>^EV=Xc
+zr$-HO09cW&p4^M}V3yBjTP_xrVcc8iU_^Y-JD~(bgw*@GXGB1gYKz5DWO+O`>})|N
+zWrC)MR<YoNN@dNjcYj<b;OF){>93yA)3{&27-M)TJB6Ml3~?zZg#mYsF=#OSTaw&K
+z@hBftpt+2l@)YK@|3DvTjl(8wZtpLp<?0%pKTY3}XX{MHIljL%Fw{_Z|9d-yvblgQ
+z{!wyH{yqQi?Iie*$>9Ik!6G$CSL_idZ$Ti?R)4toe8bb)l|)lNb}?K;O2K9vyn1QG
+zd=v#y-Ld49UVkmfRU>Egc+(Y$^-;6vW;3Lcu*6~etz}0|@+b|+!UCal)DEYGLbHWJ
+zll5Wi^<vfZ?T~^`8=zPM$Z@j*S$t!Y<EhDvm+zMzHqRrjoNgJR4PlwtA%~M-7oKg-
+z@*>$Y<6@S%^y%hdjRh6&{!z1Py|lZ|q&Wub3l41uN2zEF8E&5H5?PL*&V}?*a}Lp%
+zCYi{ghjpRNT^^B+_U59No50Ghih5qn(W5`RkrsDWr{~A1dgtv{sRkH4RU2^A{jb&0
+zxVRnrm|u<;$iI;M6A>$POP)TWGU-gSjAERk*EGmVT(aw$!XUS<asJ?{P8@w6qBfov
+zI%`}^njNd1_{}A_uRkev<-TXKuoiFlFOyqT%8rk1`2%BKM5Z+~M&?E}fqqOZAZVB5
+zNS{DO+i9FHCCFSvH|Q|2xQ%x$MZhjBSt(99856FiHO!aT?oD?|(v2KHy<imYT_Zl)
+zzM{QvD-38PfU~%Cj@UhZn!-(N#6a8!Zp46^fmJDt%0~G+`{28Ol&R+}En*ZB(Ap5-
+zS3xTHV!d88{~H$@*|Xf2m9Ev~cClRLKWq-Dy`0?=Ka(0bKO7k6Ia^0ek#FeuLW^Ka
+z+29SP{BV|X`LItvfG~$^QN1DscL6_hZV#x+g@RJSzbH{*7vi&EuO^0lmWyRo%n-;p
+zrQ@enXxznWo93lX0onG|8<ExHhjsVv&yv#5$}JubQ-~k2)eX#tYEp#B=ZL)3W6xvQ
+z^tSx&3RvXN^2EDb;%<?Qv9hrD;ImRS1@Ev)+k3=jO{~2fBe<e5TLY_Vf+5&KlA(i%
+z-tx@Qc4VuOh0tKo5#`$=9<^cjcq8Ip7qpr<1+>e~7Ql-oRA54^4V(JWS6Q1mG?!vZ
+zx+pE!FEtvqr|Xrcb3oR`%LHFLmU_&{<QAAHttd1Er^!DxXsl03mv0y!k#PYpGSMeW
+zem^VXYsEEPcK*)T#s$EH8n9Tms!@q~oOuVmpZ((3>=p%mGy6MRe2Yz_5WJ8p@IgU2
+zdVvvhhQtiQkChK%*&PsiPCBL9oDOoJX8!$S(V>R}+1M}wzK*U*A{KJ`r=lM;mPrKU
+zQDqqN(W*u-5-?$(SIk<6A0E}34y&@-IVC%S!a1F4kz<3bIKjlyD)ooO_7ft<QDC;4
+zO#}hIX3cX+ou-UMWv@FumqiR;#JOI;$Lna5#MA^fv9k{O*GC+<$Nq+kGZ+M%7QHYI
+zk9IArOT7c%DRktDP2?F4i2($6s%HL>l%S_(6w`!vX&1PZ!K`@D@L6JR)6zO@Dl!<l
+z=BdWEtebJj+jz>YF{R<WP!R4PHXBT&cyt|IAe~n=dcnCOe*w5G5oS~}#&qbcuT(6I
+z-K*(&5{r9`!3B<qxqwHIOne-7;C;+8dR9=$r{8B+k8sIfec{W>Y}d3HZ7?Q5E>w=$
+ze)H_)48Ds*Ov4?zoGb2fe3}{!5Ooc|KCIni1o)(Gj+CO?`*7jsV`hIv@8J(22o4Q?
+zu?Bvi)zDG<OK;2aO}BggmGd-%r>(me?7XKeL|iF9ZRgZdT*}Ffsl62Cu;{Gv9j6dO
+zPt*H2GqC)-C`V`ceuu=tM{7!2yTEj=*5+T~5DYiZ)Hy)*PARYI6R2lZXoOj;v8M4W
+z*O-NX(7_~Q&A3>Oaw&1lBH_H%SwmISX-i3)HfHvBOeVwTT{LUM3}ZuZmg<(>)KE;d
+zbs2!0v6>J;1nQ0UJkUxnkE@Ibi~Q}M=-=Rk;hcOnxO$luOKEVxZc|!XECgex(2`}T
+z3Y;Q_6rL)e+SrOZhQj5_e}Lv>w7n*Pep$yWZNQl>ubBgb_NIWWDn3kNpn+MPQXV;8
+zV|_Ba5jsQ(w&Ey^IM|@|y!AqcJ#3m0#Q6_qvgCG~eoF#mnGmbO(;DP+bW%_aOs1R_
+z@9p#7X2UA^--#Nwx_Hvk2l1`eO{P*#j@q2UELtH|Uh6<W{C0d%;SO*X17Hg*_nhVo
+zUj8d@XC~-{FK%b15_u=5Zi$$rw|PRP{3P&%r4IFKW@%M_k3l}b-a!ZM6ZqfV-oe0z
+zHcS2@f;}*ROge~8O|p+DJW!EVo_da^QYfpcqO^~19<4~HG-T$^cIunesE=MWKhim-
+z7Goy+*ll|&6M44>hxR`h_847wIJo0=5CQQ`6it|%a-I$^&a@we1rc&*;QIu5Ck^?)
+zx*5eSd*mG#=6Hi(5!;5uUi&{HfnT1S8X-)?gE5CZ6KWoqM5|CyrULmuFBKOU8SOp*
+z{IB1$OCcq`S-k*xs;4fmhKsIGZ;GYAY*%(@875NxhM<x^qSdQMzkq<XP|<&O=Wdj5
+zG5b8jqr5|XkTRdFnfoy|e#_<2FW~3dCqmjftH}M+1ln*+nwXqXXr0NK&8fHefdP~`
+z<>q|j*m4CNLI(Vho|N|F);!E0cS5y^$H^Izje?z}oTgyr`9x9G&rlJZw&uqIoBMtz
+zzhU0(9;w02?m#0!)cFi*r+8YvooQ;(s2lLVvyLqAE%Xqe!vtWbIs!l1Bpp(FIht-Z
+zPn#CN-2C|J*GhA2fuHqYQ2mJiXlGTzD}mkr2;ia8Wp}h^;OS7+N^M<nb8{1bSa3A+
+zL8!27%|p8>w|en!1${vN6<B1T15(f#0UdAk{Wr$+OIZmA!F!Rj#Z~!T7({o*mB$j>
+z-x{8N*4UekA~`IV2&K-GzhAqau|}d*pEQ$1MH$cFi03OG^1NetZ_jW^STaEzr&Xho
+zB452St%v3ez2#TFm~`gZ<UBEKV7u<uCXTZP`7$*T39B#gt?T&`4)K;E&|ZM6WSMdG
+zebuH**%SihzOx;;CUDFI*)EgzXx=I3<*D-whBHjKN-pq1#;zw`)Wn{zX$8V;zVw$q
+zbhEvq3kJ(?s``MV!AS6_c(5D)L4tK*Aw)gIAhX&Z%n4p62=O5*U-Y5Ba)ZL6Adcrk
+z)x8`?1tz4OdUR+*taVv0tA0F%j2gu>h$vi=in+y2d!z<{OZ~Kty-5bQ;0O<LNwDnI
+zC}8-6mq`yuqDIHx`*=Y3Ma%=;%#E>=k_ESi8Nx9{*T`LJy6jqR>&|+>OZ;+=0hA04
+zE25t^sE9HG)3^<Ym7m{BQ^G!z>KKR_A5WDkqispweP9!I-@dCO&N!JrD@i{WBHnfQ
+z95o8;d$`AFnca3;N-0iX-CmbbAp5yQ!GoH;h7Cn?m{ammZJI8igP{U73lFnl2&gCs
+zqJ4(Vo~^j`{zOA<UI~9WX4R%(>zScL5B_Sm?Mjtek1d(A6X5ObcZi$;aOYy|g$}BY
+z$GEP3#i60Ju_&3SHzryH!gUFwC9-295u??cf+aYRQ1$+!rc#42YNattd6mZEFI@?C
+zqFM>6+zxEunIHDZ>{Z15u##>N(28Dw!>G(k*dB{NHvip@aP}f`@=Q;!o;zRMWo{Cx
+zo?kyzh8n7#f1g0&g>Cd>O-2g?uPwy8sy8hZbHSsXPmU;@l=HL=zm7mN(=@*|D$i+u
+zs~TllkCTvD$f&-#b9B?}#Lg*-ibK13R_a$RyoN3m5`10tdhAq{+VW)K#Bht-ra1*J
+z+n$N%V>u0rVtx`aKJDwXXrxa<i8EX06UO&LLD=n5qGhcYvn1Mgi;G^)TV4yilP*(Y
+zoKH+I4#~X)gA)B$;S;Huvs1a%d&HL})yYqqyVy1<B|Kl_6$aedKOq)GM61zpA^OQY
+zD*lN>D7nS<>$=c82v7<sDF~4nP`e39${9XIsr;e(ythhyAUnjOkWQ<YzhIcj{t&n{
+zx(8T~Ps>@KVx^S@vT;h=SZE37K>iahpx3;VDzEr9GY=2(%uaqM;^76eSP0QLzo4sI
+z>p_Eei*T$K;|qK`sq;?Hesp}(@VvX2Q4sAMYAJ}b&d$htDMC{FG-$o4k9ApECi1$a
+zXdamjiOGKHBh(4M<3(2x6n-CrmZMCknkQxdSS!qlis#I}btfX;J`JU3RlvtLdrymP
+zG0ZzrsGXVFiq+Wk1=BFay&9ZiCE#(`h~CL+c-Hs@iGTU@YxM%vlg;)`Tf~IknA^02
+zXkN#Txo6aR{j$wP5T#|UH#<s*%`(Km<n&(n-VMO61HPpba9D&s-YZ<E)NH59!I|A9
+zqN-T-CD))<D9dzh{pWi6;9v!e;Gu01;Ra@5B;qlH=@ASvlOB+p<XN`E#p(1Aq3B41
+z)+3^0JXTY<%Czvf6l;_I-72Od>5AP2{rSY8p?<egp~%*QDVvn_i1jVI<vF4YO5Wv6
+ztWwz1KFP<1kO#Hjq^e=sWVsSgwV`63V3pc#=)rascLi7{-yp$_z50Wja%IQ)>jKFv
+zG3kn3y`FaV!*Jq%m39_TQEhD>M@l*bhEPGe1{ft3q#K5AknT=F2_=T^l#ou5ln@D#
+z5Tzs(kRG@qNDa~<d^7jn_a!bDdDr)>HLNvfv7Z0g=bSlb?`QAx|Gfoni|iHJ%K0cy
+z;~Nsaa+{8HP_qrb{nj+xzkdYhSI@W4N_1`z(eSGIkbDP)!Ko|M%}Rqp(~KI2hl~eE
+zvJ!j4m6iwMgKy>fkCLC)`M$z9EV}B+sq1}}kVf$(ig0pWTY?rHz1Sm=4srTGNb^JG
+z=2$9wz-C@aZZZ2!HY#HNejqZRmE=pN(D$Kui$NpfhU`!y_s{@MIxiJdHb1|{6xb`>
+zE74_@QtgtG{4=3P1$^vn&m}7Aw8!1DnT$2thO#~44wl(N#ao8S0@t@m+Z!KD2CfK;
+z)n5DAPKV_etmH1aLDK$<bfKTSGeuYq_HlONO3C#M3PFvqt3PoSz0>?`;sL91iVt$D
+z*SG}=-LIAg(*+JON!-5ivqOMQ1S!OQUgHglDsKik&Mwg;vva523`JwQH6SRz9eTY#
+zTIi23145~kc3r1mSWC_RzD%hs$S#!pkI9!BU80jJCJcwo*FZolQG$q`8C1d9pP@ND
+zG^&-ZraIvhg_FDVSfKGwkcI=avIan%2sK4coUs~Nr8jC*&!G0#?}_^s3r-c}-uAqi
+zM-Lw>Y}I``T;IS%Y|qH;s{F*ZefM!4{I5awr!K+T@uPd*Vu*iPWI}>(-D{zxsN>LG
+z=@747a_Rb2<sth+J2Z?T^N6ka2dx@o>>q?y8xYf?dq2HM5tFO8Y5e4N;Y=xy8yAhI
+zsm>oy%R5;7)7T3V_b2%`aH^tNlsQpFxIFW<Pc_7hO>#iV#8?{6{^cGr{A0@1bA)|K
+z>MMTuZD(pd2t|7vmHtywGXb%%=)S<`OG~}U+jm#xd%H8<zV$)T@@IDRa^1+^lW~x>
+z$v8-C%F?ah3$;hn?{G3(LT!SgvCVi$vwsZssAQvUwT`Q%qSw!LSd!(<CTTRep1wpD
+z+1amWP^M+0sC8ZA)6PVj+g*a{JY^{LZp|zaB+|iUBf2HHkx&1DcY_YMj%(o)N(g~8
+zuOD62JY+Vu*^6K_|7K^R++2{-!+XRjo6R-MpFwn>I!64w1=%Sc1Mck)q1@pZ@)=SY
+zoX}d+L3-RA<kqVpViiwE2+1D(*ikr;H!OUuItq{`ksBj7b-a&@`xR$^jH(snEHH~+
+z(=1=%lU_?$?ERV8-3T`#N?ATVklfraz}x&yFwwIzZ7NQQfnqa96c>|c?G3_BQNm&(
+z!i$AZ7cI(z7q|e9VM##6T3Xorj1JG(9os$;(I$y%mBy(#8{|3l4|x*oBAQL^XhZ0g
+zy1FR1teRrpKq{uLAibTLx#n({qwjlkOvR{OdSAeT5ah4-sNN)n4Clg1T9lzF)&yj;
+zyal1%+s4n1IG;^VPWJ;#olpk8Z42Gj-tjFeQ&PlxB)`oCNoUYKj4U$AeG8rYiD{pK
+zndDf&2;2;)D|KvOZP+e7fcPU9k4M2sfhr@vC~Ly0?S-4dz)ZGAYpCsAhChgbxLd4g
+zhTrbIPkO5SEp_kD>Ha0m12h5n3s;mE8kn515&n<G5W?|M#KpzT&e--JK0@kIpJd@a
+zo$oEcM{PP18Ny#xS;1ngiAr#v&bUmbji#^iady0^<*7sdBUjhh1TZPRkf>zSf+^D=
+zyE{JnJ;43l&BH55CL<=W%CF;6iUI)V5C*6!`**KqvzR2=Fj*3Y4`HYwx}TYD445(K
+z-QtXwtL?m*(F=LVH*H4oM>dXHBW=38q_dZ-_Vr&qpEPxd9Fs95P5W~@Z|Rt+WZP6l
+zPSQ}~Dh4V?Pp1g&H<P(ih9)F<lyKeQW3i>k*Px?lm16C@X6M29Vrk%Rw@E||E-v~$
+zb_E~{z<}#8i`Mx9mkqtd#Z1lZ-E_J8I+2oumc#x1)jdvh{W76NKm6x-RYpM~v!P8$
+zw3e|YVf|}Hse9~oC@N7^j}Fi$hNpyaYnu1}bdXsD=^oI*%WKvbme|<Oza_wpW8gk;
+zu2yC)2m?TABYV?-o`?uFUCrz2#D@wpoKDwtWV7N~cyL3h>BI}$G3>smu#6y)ls|j?
+zF7Bhu9Z)j)C;3cZb+I>0stSK^WLOYV^U{pUYkgv>?+Nt^5j*CUB=eGw-CvU&40>y~
+zGoHLXxY^7k5Xgv62{iQy|5jJQuq0|LU`}lE@flQ2Z*Zn*VWcQjm4FTb>LSVox^S4q
+zLn`LfS@mrjKCmg$nb^af?d?0&$aX6#2u(JyzIJvuJ*lwPrh|0~aEnSACCTezSdG%h
+zmSQg`17j@$Iq)r1&?+eR@1nlX<hZA96|9?2Pc{<?%#({H1;$K9kGnzSr(*CLy;MCq
+z%~Qs5<0+7FZWenzFJQAz8d%>|H`<}_!?BQSF&N+QQnvEAqZe+mIFui!0V49R?|9*$
+zv!K1A01{8xq;L()Tv*Qk0-$Oj6+vCT*TUD{HvxO@3JjxBwM!4g3ydy&eaJw4CoQBF
+zJtULJ!YxgNR7_Ls%LmogyI7uIs=!B&?=MYY^yX+v;j@D_xGeZg>eZk0C;4e|HRNSi
+z6KlD9>q=3v-$4Zik&^ZDhNm1X)+7<A8tsuQP$bTVU`(p}?t_F!BJ>LCH1k!s+T3tn
+z<oekdyD0CJe2We4yeX>Un@={1U&NJLq@K?~w|(=Y<4W{ucX}F<B#7eu{_F0(M`~qI
+zEPqMc=S17TFa*Ut$xJ>dRr6pLw(l2$iK)At<eBP=<9%0^t_Ek7)YPj~HbzFdS?&Z-
+zFWq#s<_owUG*W9*3T5d3x?Z=@Xg0_}q&OpWn<UO2%6U`unYl-6@mymg@taxBjyc#}
+zd)7tZ=4f`2N^@IyGR7RJjM#l%PlXpmAf&TWaZ{@~`%NOfGu<_iX{6IZhLU^5%U~Eu
+z>%t3gYBMlJz#(K0Nqm;=K<FO+Hmo`&$bpQVtC{pgje|zpXK%6B)|FgdwTg%Nz2k)`
+z8X|UntK@qHxvr+JIl!et<9kIpEAP}K!ng>AML!&MMSNz=%k=j*zh77r34Rs37iCY`
+z=_kva_41bdrj(b=4Wc5MO0~q^z#pIWJ>)vDSgIQF=3JVJe1iDy%h)8oNy{s_r&;m`
+zL{DYKSB_5xRb9xKNOS{qAY3qv5sSXVrrf%~*q5HO|CQ&lbKMePa$M5D{vlJcoGrCZ
+zD?fKbZN$6rWwz)w7`9h4DAmh1ij2}EO|bO#A9L0_RW6l*$sPP<sv8r8rA9owl!eeR
+z1NTGO4fH_iJ$h#A4{SmcyR>UJrUbhLC75L9%W5iO$Iw5~Yut-qBeu~hF|xD7-eQ%l
+z412vpq_;t%^F*pYDk%Q35c-erK|6Ve=FxQbAv~ikZ4c9$Y4;ee#ciOD9{yRqf55Qk
+zumv}#+JciT|Gj$uFOxBUze)=?l{B}qaC0_7m`t82<$K53!4Xvi9Tr)ADp3Off?O8o
+zVDG0Yx|tfn@r((m?Nxrh(b0DGjg)$;DfO&$6uY;4&<!k&O=hr#o>F!4jnxkhP}Y3x
+zS?WFFt>=HWzqlQhffVfvM$Ta8Sg*r3j!Eo&rUOW7SCL2~lG7<+XZ;+{&8<DyiSykp
+zA7l-}(I|=ms%tNFTYkoIsuLyg?+I~Z*3Q|??RFu4_0^U6Re;X@@34fx?CAjIypLRX
+z$t)jPOy0bd<@4-yMHz0{9Y1LCV%IkRJ|jg%fPCmT)F-!8_Y#Dx3{FysRp`Q!doW+6
+zZ}IrYb2DD<Y8pA*#%c==4-8brg}Y#8wFDK<c2$i#jeUy3OkIIRUG3<@gcwUTYAl?p
+z`@7Fcaz|&cdl(`^C!Qo@F-$oXtl)ANqe_kyV5z5QcLFH5ktesECpz2i%Uy3K;o$nU
+zRHA31(@H1&5F`A#ssy`goLx2j=rBn*CE>h5g8ElI+P>>yR2U%S93NN<c)T<0U~gz;
+z>!Xhm|C682t6ysH-=o1=Bd*N*V<P)26zv@1P>lnG%l+KZFtjG`UkL;%65qn0UYQ`h
+zh0{9jDQx(`aBe7J0Aj3Z)4}`A|4OMM0a;?{j}qkYwi)~O8$9D}ITiMH2buiU>ixYp
+zhL${nwj6X($*OwmpVG`y5b6v45tX*J8?og}Qju6eJ9H}`X87iEd%BUo7<`2q(HJx+
+zMR<Pt%@%D0sbR}bR2vchjFmv@&giX(?>}d-J4oAf{V1W^a2~`M-YAdZ81<O(x-LLB
+ziYJ(IlIy^J+VaY)YgPSiQ0Us4I~n$rwJ4oe0cPBI>dd4o6NPO{cmZaAS@RS4ir#Sr
+zf<VdxlnqAnRM2AE_ghvSVwSte-XRVIyT(D^slNqE-8jf%6<nCMa`zf|$630Q?axs+
+z8-|ze)?RSqAckM?+w@&cuhDl@^|OO`O*pLVJKYxi4OohAU>FZO-VIL|VN<%nEXr2`
+z$0FK2L#8O_f1w~c@G70JrB@N}r(gJ!Vmkk6{r68w!o$qO?HrFcjeU0_3F5;*!E2%(
+zTx<?~WRM!G0a&ySR$<jsjlFDU!_cQ=rm^f3a0m@pR~S~3x#Q!vBQ8QrLR>>4?gP8w
+z1B?3UVZmz^%d_dIps>>0{cB~mp3{9U<B7u|njwlkXBz*b%D0;yhSH%?j@*Qn*llsX
+zO1Db$I4fzAEAs;fb^Hb!dP&&H(*QyAv^S{c)(B}+d64a7WNv#fMaw`2RTzNS*TvY_
+z7H6;X#FS2^bTGaO6(xFKPOPseR+?{`;POC2m5aaA&EKov%Vz!k+>oPR6uQFecVq&}
+zY{ebB?AlPAD_}(ll{fK99;Wh1cgRbnw)maD^F>*J!R}eHM*W0VYN1TADWMy9H=$00
+z5bHY${oDgwX7(W9LZw?}{!8(_{JB~Xkje6{0x4fgC4kUmpfJ+LT1DYD*TWu4#h{Y7
+zFLronmc=hS=W=j1ar3r1JNjQoWo2hMWsqW*e?TF%#&{GpsaLp}iN~$)ar+7Ti}E&X
+z-nq~+Gkp(`qF0F_4A22>VZn-x>I$?PDZSeG8h_ifoWf^DxIb5%T7UytYo3}F|4#RC
+zUHpg$=)qVqD~=m(!~?Xwocux<fMdw81nD!;t@a*4neQ(aVD(J+A2??uX#HB8h{SA^
+zdwHZPt(_kv#Cy%vSUh54y~cPXj=D^*;zTVk5y{_bC5yAz3CQA`(UWK4rS;tBXU@kM
+zdej%biGz)+Zyb}ApQWbz*^ZVHpgtmw$q*Vpwt!Q&h9PG6;&Z4L%=lGi5uP2+Iw}}%
+zRw^VYFqyiS!j*Ylw*m}O)GZr&wh(LNL_SF4+fnf#U_g+~SMcMFhbA4}sBM0v^=YW-
+z&lY;LS6yEUO8A78NCxHMrs`yWt-AgIrz<}>U1u}9qhhM7d^eqmJPi_e-!IO`*{u7A
+zbu*?L$Mbj-X9n3G2>+Kc#l`@d8}Xb9{l*IN{#<s%V4>M*d;s+3Pdr8FO$EBELR=8{
+zd?LJbSv9fI`{OqTH)5{b?WulgMb)psp+W|@cSp=jtl-&5C}9lw@*0H+gEW(}mAWNz
+zf{~U;;<ij^TC}|2a=b@Y*t)@0v1xP(v60Z1AVFC^6OFVSu>N}|wdSaphgqn<w7=w9
+zK8);m^xjJ26KBA^s+X~_;*<r_i1!(b_J^XZTX2ts<uU`4&%E_cmAS3_5^hk59|kgD
+zMLF}`MyE`hy%MFvhK6uW0T0ZwJE%ubf^cybN1t(tFSjlXmU%iNJM_KhC?w8%lwxG%
+z^l3qjQ#&r)nR&TI7eX29AQRbBd!NtWy|6g3o?g!*>H{FWUy!{y3^=AC*c?RJ5Eb<^
+zCgH_v7^axIUVmHSFL^zlj2R$zow$|y#7>%#U7d#Vp_ezcp3lefMyd5ES=q$>4pWyA
+zp_Zso^^NP~lu2=S6nD(3Z5u=Uy&B&F<ZVfpeB?A^;A;yfb|T-IdCr4F&4;vkGQ(ce
+zh3=uO>1i$J*3;3KhEkD_lgscHGR*;T;U!9vgQa(hI}oh9IzEf_PU_8F+i77t-~gDX
+z490Sb<R_L<O5Q@b5$Zq8%`yG)pr{P@%VAd&n*7r>)LyVZmf18N6w{+37$aO<2!Av0
+ztLaPOv^J<2@p{WnMiDudoghX_`luFZt_4eNU}*~cF5i%eEcNLs;D>QVIwr8mH;=dc
+z09`}JV;aaF;13<?rh<ybd3+ERtA!AF+n4vv*yO!S>@&iS(w>Jc=k~|d_1hcpM(l|O
+zu>!@}me%isTT$xT#hNUvh(ATd0wT4fbv=6htc<!_*5tIlcw;jfC)7eiH`TZ#yg33G
+z*K{nA3s&@UJ|kOpm^FmpZH!jpU$uLLL0hBd*qzwn)R|bYU?5GP?km8IK}b(Rmo(9m
+ztmUrC#OLcS1`w=qT%q{r;x6q#X*G<@Q?b$fk$PV_;x3)8-*Cma`(%rzI}~@X_mynt
+z){EdYfW}JcHE72h7O(F)3GWJ5QyDsqkV#hvVxfwA+tCRWd-}F=Z{E9X{i^#g-uA}M
+z8A};Fz|8*u<?gci0HA-zkJWo>HNEZIw9%E6wlYmwfu2{j0kh1y=$;Yf!|NldgB9ul
+zB{dbE&LfRnr8ITm@;-68wo#VV?8lG3ed&9k1}QBS3}WGV9%26?A1rBkkDR9Z3o+g+
+z)eQg8BY3y(Dh5&z?VLLNdDV`C=muUvCPpGg!oYxIgOI3^%4>5d7jTh~ni!Fg2;fhx
+z(*c%H6Je84kmQh;5tC3*l~7khLxK-e|Cz?FLh!yYe7g|*LwqU?2wv^_ZyK<Of{dhu
+zsv0|3@?TRSx1dhZz(pM4pWCNW)x%RcI9qU7{OJ?KVPb2=ae`t5N2|Np!TnR=miT6l
+z=X6%jw%pdV6l@QFlD~p?kP+pL<B%Y@NatKA$=T#KFRv!+!jsp)t11X)#&Hl3U6lMU
+zJRO~gIozN7FCmvReeSbLXwrCX?C>T$fYVkGJo@AK0$+ml?}zJeB~deT2WL1vz}dxB
+z)y??t!}%M@)u$_I<M8Xr7=Atw2=U{1NPY=Pxyvvn&o=WU(EM~W-`~1~CfLfw1<p(O
+z>yW~)6u1SttJ!awd6N5lx|xBrmyrBh>tb&D*=C+Z3nPfq$1%WgY0bY*?PZ#Hk|=xn
+zGM#0*w4CaB^y0G(J4q=;5NeM@m-P}#mv7QZNF)M!dK^w{mk_!n0`+Y3PQutu-%NBt
+zzgPXug?JLEbUL{e_dk;Vd896&yPe(hliVK!lj%5+@BKdcrEZ2Nc_*i@ve*2lB>u~{
+zFozd2FM|_0+nAGR4TLNHanQn_Oeb!Jr<ML^n#x(-lWYbAxZ^lzL{91ce=r_rMNh&3
+z5ZH&~&=xx-`k!k3r63SzRZbe5pFX5uiE~x{Yij<#VF%9Yp7eo6*ry-Is`SOWzco`o
+zD|OPe5MeBR9K!M!O8w?{d(zJiQDi%gL-lj>UcvzJ?7p9TTNB}ocO3j$7ij!li8#k6
+z@2tSd1>K03K9A#_-MIq)S;T#oE^;>U$)&}okIvDf3lm?kI{d80$>~<aBIV=g^}I;q
+zHz)SwoEc)S_BbfR&P{vn%<b8oJvk9{`Zix4ac<U&X5Y>xKUoS!%q1Pi?WpsUUt(tI
+ztjNjY*y&Rm9(S(DC2GuPHBJs@5M{RGm`c1z<6nwyN^)rMo-AS{M2$oM9|y%fM|}G~
+DHx0+F
+
+literal 0
+HcmV?d00001
+
+diff --git a/account-service/gradle/wrapper/gradle-wrapper.properties b/account-service/gradle/wrapper/gradle-wrapper.properties
+new file mode 100644
+index 0000000..a4cf193
+--- /dev/null
++++ b/account-service/gradle/wrapper/gradle-wrapper.properties
+@@ -0,0 +1,8 @@
++distributionBase=GRADLE_USER_HOME
++distributionPath=wrapper/dists
++distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
++distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
++networkTimeout=10000
++validateDistributionUrl=true
++zipStoreBase=GRADLE_USER_HOME
++zipStorePath=wrapper/dists
+diff --git a/account-service/gradlew b/account-service/gradlew
+new file mode 100755
+index 0000000..faf9300
+--- /dev/null
++++ b/account-service/gradlew
+@@ -0,0 +1,251 @@
++#!/bin/sh
++
++#
++# Copyright © 2015-2021 the original authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#      https://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++#
++# SPDX-License-Identifier: Apache-2.0
++#
++
++##############################################################################
++#
++#   Gradle start up script for POSIX generated by Gradle.
++#
++#   Important for running:
++#
++#   (1) You need a POSIX-compliant shell to run this script. If your /bin/sh is
++#       noncompliant, but you have some other compliant shell such as ksh or
++#       bash, then to run this script, type that shell name before the whole
++#       command line, like:
++#
++#           ksh Gradle
++#
++#       Busybox and similar reduced shells will NOT work, because this script
++#       requires all of these POSIX shell features:
++#         * functions;
++#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
++#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
++#         * compound commands having a testable exit status, especially «case»;
++#         * various built-in commands including «command», «set», and «ulimit».
++#
++#   Important for patching:
++#
++#   (2) This script targets any POSIX shell, so it avoids extensions provided
++#       by Bash, Ksh, etc; in particular arrays are avoided.
++#
++#       The "traditional" practice of packing multiple parameters into a
++#       space-separated string is a well documented source of bugs and security
++#       problems, so this is (mostly) avoided, by progressively accumulating
++#       options in "$@", and eventually passing that to Java.
++#
++#       Where the inherited environment variables (DEFAULT_JVM_OPTS, JAVA_OPTS,
++#       and GRADLE_OPTS) rely on word-splitting, this is performed explicitly;
++#       see the in-line comments for details.
++#
++#       There are tweaks for specific operating systems such as AIX, CygWin,
++#       Darwin, MinGW, and NonStop.
++#
++#   (3) This script is generated from the Groovy template
++#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
++#       within the Gradle project.
++#
++#       You can find Gradle at https://github.com/gradle/gradle/.
++#
++##############################################################################
++
++# Attempt to set APP_HOME
++
++# Resolve links: $0 may be a link
++app_path=$0
++
++# Need this for daisy-chained symlinks.
++while
++    APP_HOME=${app_path%"${app_path##*/}"}  # leaves a trailing /; empty if no leading path
++    [ -h "$app_path" ]
++do
++    ls=$( ls -ld "$app_path" )
++    link=${ls#*' -> '}
++    case $link in             #(
++      /*)   app_path=$link ;; #(
++      *)    app_path=$APP_HOME$link ;;
++    esac
++done
++
++# This is normally unused
++# shellcheck disable=SC2034
++APP_BASE_NAME=${0##*/}
++# Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
++APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
++
++# Use the maximum available, or set MAX_FD != -1 to use that value.
++MAX_FD=maximum
++
++warn () {
++    echo "$*"
++} >&2
++
++die () {
++    echo
++    echo "$*"
++    echo
++    exit 1
++} >&2
++
++# OS specific support (must be 'true' or 'false').
++cygwin=false
++msys=false
++darwin=false
++nonstop=false
++case "$( uname )" in                #(
++  CYGWIN* )         cygwin=true  ;; #(
++  Darwin* )         darwin=true  ;; #(
++  MSYS* | MINGW* )  msys=true    ;; #(
++  NONSTOP* )        nonstop=true ;;
++esac
++
++CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
++
++
++# Determine the Java command to use to start the JVM.
++if [ -n "$JAVA_HOME" ] ; then
++    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
++        # IBM's JDK on AIX uses strange locations for the executables
++        JAVACMD=$JAVA_HOME/jre/sh/java
++    else
++        JAVACMD=$JAVA_HOME/bin/java
++    fi
++    if [ ! -x "$JAVACMD" ] ; then
++        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
++
++Please set the JAVA_HOME variable in your environment to match the
++location of your Java installation."
++    fi
++else
++    JAVACMD=java
++    if ! command -v java >/dev/null 2>&1
++    then
++        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
++
++Please set the JAVA_HOME variable in your environment to match the
++location of your Java installation."
++    fi
++fi
++
++# Increase the maximum file descriptors if we can.
++if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
++    case $MAX_FD in #(
++      max*)
++        # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
++        # shellcheck disable=SC2039,SC3045
++        MAX_FD=$( ulimit -H -n ) ||
++            warn "Could not query maximum file descriptor limit"
++    esac
++    case $MAX_FD in  #(
++      '' | soft) :;; #(
++      *)
++        # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
++        # shellcheck disable=SC2039,SC3045
++        ulimit -n "$MAX_FD" ||
++            warn "Could not set maximum file descriptor limit to $MAX_FD"
++    esac
++fi
++
++# Collect all arguments for the java command, stacking in reverse order:
++#   * args from the command line
++#   * the main class name
++#   * -classpath
++#   * -D...appname settings
++#   * --module-path (only if needed)
++#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and GRADLE_OPTS environment variables.
++
++# For Cygwin or MSYS, switch paths to Windows format before running java
++if "$cygwin" || "$msys" ; then
++    APP_HOME=$( cygpath --path --mixed "$APP_HOME" )
++    CLASSPATH=$( cygpath --path --mixed "$CLASSPATH" )
++
++    JAVACMD=$( cygpath --unix "$JAVACMD" )
++
++    # Now convert the arguments - kludge to limit ourselves to /bin/sh
++    for arg do
++        if
++            case $arg in                                #(
++              -*)   false ;;                            # don't mess with options #(
++              /?*)  t=${arg#/} t=/${t%%/*}              # looks like a POSIX filepath
++                    [ -e "$t" ] ;;                      #(
++              *)    false ;;
++            esac
++        then
++            arg=$( cygpath --path --ignore --mixed "$arg" )
++        fi
++        # Roll the args list around exactly as many times as the number of
++        # args, so each arg winds up back in the position where it started, but
++        # possibly modified.
++        #
++        # NB: a `for` loop captures its iteration list before it begins, so
++        # changing the positional parameters here affects neither the number of
++        # iterations, nor the values presented in `arg`.
++        shift                   # remove old arg
++        set -- "$@" "$arg"      # push replacement arg
++    done
++fi
++
++
++# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
++DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
++
++# Collect all arguments for the java command:
++#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
++#     and any embedded shellness will be escaped.
++#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
++#     treated as '${Hostname}' itself on the command line.
++
++set -- \
++        "-Dorg.gradle.appname=$APP_BASE_NAME" \
++        -classpath "$CLASSPATH" \
++        org.gradle.wrapper.GradleWrapperMain \
++        "$@"
++
++# Stop when "xargs" is not available.
++if ! command -v xargs >/dev/null 2>&1
++then
++    die "xargs is not available"
++fi
++
++# Use "xargs" to parse quoted args.
++#
++# With -n1 it outputs one arg per line, with the quotes and backslashes removed.
++#
++# In Bash we could simply go:
++#
++#   readarray ARGS < <( xargs -n1 <<<"$var" ) &&
++#   set -- "${ARGS[@]}" "$@"
++#
++# but POSIX shell has neither arrays nor command substitution, so instead we
++# post-process each arg (as a line of input to sed) to backslash-escape any
++# character that might be a shell metacharacter, then use eval to reverse
++# that process (while maintaining the separation between arguments), and wrap
++# the whole thing up as a single "set" statement.
++#
++# This will of course break if any of these variables contains a newline or
++# an unmatched quote.
++#
++
++eval "set -- $(
++        printf '%s\n' "$DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS" |
++        xargs -n1 |
++        sed ' s~[^-[:alnum:]+,./:=@_]~\\&~g; ' |
++        tr '\n' ' '
++    )" '"$@"'
++
++exec "$JAVACMD" "$@"
+diff --git a/account-service/gradlew.bat b/account-service/gradlew.bat
+new file mode 100644
+index 0000000..9b42019
+--- /dev/null
++++ b/account-service/gradlew.bat
+@@ -0,0 +1,94 @@
++@rem
++@rem Copyright 2015 the original author or authors.
++@rem
++@rem Licensed under the Apache License, Version 2.0 (the "License");
++@rem you may not use this file except in compliance with the License.
++@rem You may obtain a copy of the License at
++@rem
++@rem      https://www.apache.org/licenses/LICENSE-2.0
++@rem
++@rem Unless required by applicable law or agreed to in writing, software
++@rem distributed under the License is distributed on an "AS IS" BASIS,
++@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++@rem See the License for the specific language governing permissions and
++@rem limitations under the License.
++@rem
++@rem SPDX-License-Identifier: Apache-2.0
++@rem
++
++@if "%DEBUG%"=="" @echo off
++@rem ##########################################################################
++@rem
++@rem  Gradle startup script for Windows
++@rem
++@rem ##########################################################################
++
++@rem Set local scope for the variables with windows NT shell
++if "%OS%"=="Windows_NT" setlocal
++
++set DIRNAME=%~dp0
++if "%DIRNAME%"=="" set DIRNAME=.
++@rem This is normally unused
++set APP_BASE_NAME=%~n0
++set APP_HOME=%DIRNAME%
++
++@rem Resolve any "." and ".." in APP_HOME to make it shorter.
++for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
++
++@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
++set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
++
++@rem Find java.exe
++if defined JAVA_HOME goto findJavaFromJavaHome
++
++set JAVA_EXE=java.exe
++%JAVA_EXE% -version >NUL 2>&1
++if %ERRORLEVEL% equ 0 goto execute
++
++echo. 1>&2
++echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
++echo. 1>&2
++echo Please set the JAVA_HOME variable in your environment to match the 1>&2
++echo location of your Java installation. 1>&2
++
++goto fail
++
++:findJavaFromJavaHome
++set JAVA_HOME=%JAVA_HOME:"=%
++set JAVA_EXE=%JAVA_HOME%/bin/java.exe
++
++if exist "%JAVA_EXE%" goto execute
++
++echo. 1>&2
++echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
++echo. 1>&2
++echo Please set the JAVA_HOME variable in your environment to match the 1>&2
++echo location of your Java installation. 1>&2
++
++goto fail
++
++:execute
++@rem Setup the command line
++
++set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
++
++
++@rem Execute Gradle
++"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
++
++:end
++@rem End local scope for the variables with windows NT shell
++if %ERRORLEVEL% equ 0 goto mainEnd
++
++:fail
++rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
++rem the _cmd.exe /c_ return code!
++set EXIT_CODE=%ERRORLEVEL%
++if %EXIT_CODE% equ 0 set EXIT_CODE=1
++if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
++exit /b %EXIT_CODE%
++
++:mainEnd
++if "%OS%"=="Windows_NT" endlocal
++
++:omega
 diff --git a/account-service/openapi.yaml b/account-service/openapi.yaml
 new file mode 100644
 index 0000000..a9bff85
@@ -1627,10 +2405,10 @@ index 0000000..c6269a8
 +}
 diff --git a/account-service/src/main/resources/application.properties b/account-service/src/main/resources/application.properties
 new file mode 100644
-index 0000000..dec1c7f
+index 0000000..6562def
 --- /dev/null
 +++ b/account-service/src/main/resources/application.properties
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,12 @@
 +server.port=${ACCOUNT_SERVICE_PORT:18088}
 +server.forward-headers-strategy=framework
 +
@@ -1643,7 +2421,6 @@ index 0000000..dec1c7f
 +people.service.url=${PEOPLE_SERVICE_URL:http://${PEOPLE_SERVICE_HOST:localhost}:18089}
 +
 +server.max-http-request-header-size=1000000
-+springdoc.swagger-ui.disable-swagger-default-url=true
 diff --git a/account-service/src/main/resources/test-application.properties b/account-service/src/main/resources/test-application.properties
 new file mode 100644
 index 0000000..a00ff18
@@ -1675,46 +2452,6 @@ index 0000000..a301268
 +    // smoke test
 +  }
 +}
-diff --git a/catalog/base-uncontainerized-processes.csv b/catalog/base-uncontainerized-processes.csv
-deleted file mode 100644
-index 5b3fa46..0000000
---- a/catalog/base-uncontainerized-processes.csv
-+++ /dev/null
-@@ -1,10 +0,0 @@
--order,process_id,workdir,start_cmd,port,health_hint,build_cmd
--1,database,database,./run.sh,18082,tcp://localhost:18082,./gradlew build -x test
--2,reference-data,reference-data,npm run start,18085,http://localhost:18085/stocks,[ -d node_modules ] || npm install
--3,trade-feed,trade-feed,npm run start,18086,http://localhost:18086/,[ -d node_modules ] || npm install
--4,people-service,people-service/PeopleService.WebApi,ASPNETCORE_ENVIRONMENT=Development dotnet ./bin/Debug/net9.0/PeopleService.WebApi.dll,18089,http://localhost:18089/swagger,dotnet build
--5,account-service,account-service,java -jar $(ls build/libs/*.jar | grep -v plain | head -1),18088,http://localhost:18088/account/,./gradlew build -x test
--6,position-service,position-service,java -jar $(ls build/libs/*.jar | grep -v plain | head -1),18090,http://localhost:18090/positions/22214,./gradlew build -x test
--7,trade-processor,trade-processor,java -jar $(ls build/libs/*.jar | grep -v plain | head -1),18091,http://localhost:18091/health,./gradlew build -x test
--8,trade-service,trade-service,java -jar $(ls build/libs/*.jar | grep -v plain | head -1),18092,http://localhost:18092/v3/api-docs,./gradlew build -x test
--9,web-front-end-angular,web-front-end/angular,node serve-angular-dist.js,18093,http://localhost:18093/,[ -d node_modules ] || npm install; [ -d dist ] || npm run build
-diff --git a/ci/state-metadata.json b/ci/state-metadata.json
-deleted file mode 100644
-index 10631a9..0000000
---- a/ci/state-metadata.json
-+++ /dev/null
-@@ -1,18 +0,0 @@
--{
--  "stateId": "003-agentic-harness-foundation",
--  "isConvergence": false,
--  "convergenceLevel": "none",
--  "convergenceNamespace": "",
--  "modules": {
--    "node": [],
--    "gradle": [],
--    "dotnet": [],
--    "docker": []
--  },
--  "deploy": {
--    "enabled": false,
--    "profile": "",
--    "environment": "",
--    "domainHint": ""
--  }
--}
 diff --git a/containerized-compose/README.md b/containerized-compose/README.md
 new file mode 100644
 index 0000000..ea0a7f0
@@ -1739,7 +2476,7 @@ index 0000000..ea0a7f0
 +- `http://localhost:8080`
 diff --git a/containerized-compose/docker-compose.yml b/containerized-compose/docker-compose.yml
 new file mode 100644
-index 0000000..97b46a6
+index 0000000..568e078
 --- /dev/null
 +++ b/containerized-compose/docker-compose.yml
 @@ -0,0 +1,156 @@
@@ -1766,7 +2503,7 @@ index 0000000..97b46a6
 +      dockerfile: Dockerfile.compose
 +    environment:
 +      REFERENCE_DATA_SERVICE_PORT: "18085"
-+      CORS_ALLOWED_ORIGINS: "http://localhost:8080"
++      CORS_ALLOWED_ORIGINS: "${CORS_ALLOWED_ORIGINS:-*}"
 +    ports:
 +      - "18085:18085"
 +    depends_on:
@@ -1778,7 +2515,7 @@ index 0000000..97b46a6
 +      dockerfile: Dockerfile.compose
 +    environment:
 +      TRADE_FEED_PORT: "18086"
-+      CORS_ALLOWED_ORIGINS: "http://localhost:8080"
++      CORS_ALLOWED_ORIGINS: "${CORS_ALLOWED_ORIGINS:-*}"
 +    ports:
 +      - "18086:18086"
 +
@@ -1788,7 +2525,7 @@ index 0000000..97b46a6
 +      dockerfile: Dockerfile.compose
 +    environment:
 +      PEOPLE_SERVICE_PORT: "18089"
-+      CORS_ALLOWED_ORIGINS: "http://localhost:8080"
++      CORS_ALLOWED_ORIGINS: "${CORS_ALLOWED_ORIGINS:-*}"
 +    ports:
 +      - "18089:18089"
 +
@@ -1801,7 +2538,7 @@ index 0000000..97b46a6
 +      DATABASE_TCP_HOST: "database"
 +      DATABASE_TCP_PORT: "18082"
 +      PEOPLE_SERVICE_HOST: "people-service"
-+      CORS_ALLOWED_ORIGINS: "http://localhost:8080"
++      CORS_ALLOWED_ORIGINS: "${CORS_ALLOWED_ORIGINS:-*}"
 +    ports:
 +      - "18088:18088"
 +    depends_on:
@@ -1816,7 +2553,7 @@ index 0000000..97b46a6
 +      POSITION_SERVICE_PORT: "18090"
 +      DATABASE_TCP_HOST: "database"
 +      DATABASE_TCP_PORT: "18082"
-+      CORS_ALLOWED_ORIGINS: "http://localhost:8080"
++      CORS_ALLOWED_ORIGINS: "${CORS_ALLOWED_ORIGINS:-*}"
 +    ports:
 +      - "18090:18090"
 +    depends_on:
@@ -1831,7 +2568,7 @@ index 0000000..97b46a6
 +      DATABASE_TCP_HOST: "database"
 +      DATABASE_TCP_PORT: "18082"
 +      TRADE_FEED_HOST: "trade-feed"
-+      CORS_ALLOWED_ORIGINS: "http://localhost:8080"
++      CORS_ALLOWED_ORIGINS: "${CORS_ALLOWED_ORIGINS:-*}"
 +    ports:
 +      - "18091:18091"
 +    depends_on:
@@ -1848,7 +2585,7 @@ index 0000000..97b46a6
 +      REFERENCE_DATA_HOST: "reference-data"
 +      PEOPLE_SERVICE_HOST: "people-service"
 +      TRADE_FEED_HOST: "trade-feed"
-+      CORS_ALLOWED_ORIGINS: "http://localhost:8080"
++      CORS_ALLOWED_ORIGINS: "${CORS_ALLOWED_ORIGINS:-*}"
 +    ports:
 +      - "18092:18092"
 +    depends_on:
@@ -1879,7 +2616,7 @@ index 0000000..97b46a6
 +      context: ../ingress
 +      dockerfile: Dockerfile.compose
 +    environment:
-+      NGINX_HOST: "localhost"
++      NGINX_HOST: "${TRADERX_FQDN:-localhost}"
 +      DATABASE_URL: "http://database:18084/"
 +      REFERENCE_DATA_URL: "http://reference-data:18085/"
 +      TRADE_FEED_URL: "http://trade-feed:18086/"
@@ -1947,13 +2684,13 @@ index 0000000..3e4f937
 +- Web hostname allowlist env: `DATABASE_WEB_HOSTNAMES`
 diff --git a/database/SPEC.manifest.json b/database/SPEC.manifest.json
 new file mode 100644
-index 0000000..43349fc
+index 0000000..ca1a9eb
 --- /dev/null
 +++ b/database/SPEC.manifest.json
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,33 @@
 +{
 +  "schemaVersion": "1.0.0",
-+  "generatedAtUtc": "2026-03-31T12:59:32Z",
++  "generatedAtUtc": "2026-07-22T12:27:30Z",
 +  "component": {
 +    "id": "database",
 +    "kind": "service",
@@ -1967,7 +2704,8 @@ index 0000000..43349fc
 +  "runtime": {
 +    "defaultPort": 18082,
 +    "dependsOn": [],
-+    "requiredEnv": ["DATABASE_WEB_HOSTNAMES"]
++    "requiredEnv": ["DATABASE_WEB_HOSTNAMES"],
++    "healthHint": "tcp://<host>:18082 (TCP reachability, not HTTP)"
 +  },
 +  "contracts": {
 +    "primary": null
@@ -1985,7 +2723,7 @@ index 0000000..43349fc
 +}
 diff --git a/database/build.gradle b/database/build.gradle
 new file mode 100644
-index 0000000..2b4b698
+index 0000000..a351c5a
 --- /dev/null
 +++ b/database/build.gradle
 @@ -0,0 +1,21 @@
@@ -2010,13 +2748,1149 @@ index 0000000..2b4b698
 +    configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
 +  }
 +}
+diff --git a/database/gradle/wrapper/gradle-wrapper.jar b/database/gradle/wrapper/gradle-wrapper.jar
+new file mode 100644
+index 0000000000000000000000000000000000000000..9bbc975c742b298b441bfb90dbc124400a3751b9
+GIT binary patch
+literal 43705
+zcma&Obx`DOvL%eWOXJW;<L>V64viP??$)@wHcsJ<yG!Hl?(U7dFYnCW{r1k?dA}jz
+z`Gcs6s9#i`JSR_PKBXuF4uJsz0|NsB0z&+G{=YvI5Lgg7F;yWtDS2@QSt$`Qc@;4=
+zRY(xfzuvO0rR}uJ{>68)>bJS6*&iHnskXE8MjvIPVl|FrmV}Npeql07fCw6`pw`0s
+zGauF(<*@v{3t!qoUU*=j)6;|-(yg@jvDx&fV^trtZt27?4Tkn729qrItVh@PMwG5$
+z+oXHSPM??iHZ!cVP~gYact-CwV`}~Q+R}PPNRy+T-geK+>fHrijpllon_F4N{@b-}
+z1M0=a!VbVmJM8Xk@NRv)m&aRYN}FSJ{LS;}2ArQ5baSjfy40l@T5)1r-^0fAU6f_}
+zzScst%$Nd-^ElV~H0TetQhMc%S{}Q4lssln=|;LG?Ulo}*mhg8YvBAUY7YFdXs~vv
+zv~{duzVw%C#GxkBwX=TYp1Dh*Uaum2?RmsvPaLlzO^fIJ`L?&OV?Y&kKj~^kWC`Ly
+zfL-}J^4a0Ojuz9O{jUbIS;^JatJ5+YNNHe}6nG9Yd6P-lJiK2ms)A^xq^H2fKrTF)
+zp!6=`Ece~57>^9(RA4OB9;f1FAhV%zVss%#rDq$9ZW3N2cXC7dMz;|UcRFecBm`DA
+z1pCO!#6zKp#@mx{2>Qcme8y$Qg_gnA%(`Vtg3ccwgb~D(&@y8#Jg8nNYW*-P{_M#E
+zZ|wCsQoO1(iIKd-2B9xzI}?l#Q@G5d$m1Lfh0q;iS5FDQ&9_2X-H)VDKA*fa{b(sV
+zL--krNCXibi1+*C2;4qVjb0KWUVGjjRT{A}Q*!cFmj0tRip2ra>WYJ>ZK4C|V~RYs
+z6;~+*)5F^x^aQqk9tjh)L;DOLlD8j+0<>kHc8<MT8<q;@cs^TP%TBGLJb3?hF`f1u
+zr^#HdaN9hgmYP%3&4eX^>MN|68PxQV`tJFbgxSfq-}b(_h`luA0&<H)Ks&ZC5avn$
+zblv>;Vk<@5<kF$(jU%Y1<)oJ9n#F!_Nzr$1q5g8vk%4E5n+!%&?C??!2P`6+_1%cB
+zz~CmX+0avvVR!Fm9DBz=5OYDMzyT5o=mbbC1@y!;y!`Xf(U~IBp=}v8UBCUG8>1i0
+z_cu6{_*=vlvYbKjDawLw+t^H?OV00_73Cn3goU<yjj&HS+sgjt5ulpVMAFPV!h#%(
+z;O+R^(R7duR?KDiP~~*Sz}yNf2S{i|h1xTKnI_B>5?})UYFuoSX6Xqw;TKcrsc|r#
+z$sMWYl@cs#SVopO$hpHZ)cdU-+Ui%z&Sa#lMI~zWW@vE%QDh@bTe0&V9nL>4Et9`N
+zGT8(X{l@A~loDx}BDz`m6@tLv@$mTlVJ;4MGuj!;9Y=%;;_kj#o8n5tX%@M)2I@}u
+z_{I!^7N1BxW9`g&Z+K#lZ@7_dXdsqp{W9_`)zgZ=sD~%WS5s$`7z#XR!Lfy(4se(m
+zR@a3twgMs19!-c4jh`PfpJOSU;vShBKD|I0@rmv_x|+ogqslnLLOepJpPMOxhRb*i
+zGHkw<C6i>f#?ylQ@k9QJL?!}MY4i7joSzMcEhrDKJH&?2v{-tgCqJe+Y0njl7HYff
+z{&~M;JUXVR$qM1FPucIEY(IBAuCHC@^~QG6O!dAjzQBxDOR~lJEr4KS9R*idQ^p{D
+zS#%NQADGbAH~6wAt}(1=Uff-1O#ITe)31zCL$e9~{w)gx)g>?zFE{Bc9nJT6xR!i8
+z)l)~9&~zSZTH<f>k{?iQL^MQo$wLi}`B*qnvUy+Y*jEraZMnEhuj`Fu+>b5xD1_Tp
+z)8|wedv42#3AZUL7x&G@p@&zcUvPkv<gOT$sg9nDsP`h2d9g#)Sfr@kmW^OuGVzBe
+z-mcj_6tCQbJjPpCR0_6&eS`PLDmBn1jc_}#l=&oN(1kZX%4pnohcH*OTaAUFUQR9I
+zJsE{W;L}Y`SMW2`Yxlamz6R=sERGI$HJ&wT!!xuJCXi~%#!zT5#JMaroI8+$NZU!j
+zFFo1(OoSgnZ`tOBNEeS}AJTa*w)!5g*s2NJdIyH_O<3^t7uCBd5c|%jlVJAD=GPv6
+zGy{$r4IuY4V;#IhoM9(k9N?|GBT!0wNQtL*(Wla6D)K3^HTQh9<!?y8pnvCIy%Of4
+zum(WCu{ljigy+8e*vg{OEP4h-N6?BPRwPrLau9K*^W?WW;LAPzYRy1|S<{}2ayMO6
+z8Gk5*s)+cT;R6e$f61Q!-QhR7$s`=CY0vN!#Gm}?vOh0St8%mcv%@1{x_S+@@wk7+
+zFHA$hX%gbrT2VQ8hV%{#=997-Aa7v_qGy2j`{6(KD}jjYS=X4TTgcc_#&`99oP{`1
+z+?qRA0-j~Bi$<R4kd7i0PY(>g=YJS6?1B7ZEXr4b>M+9Gli$gK-Sgh{O@>q7TUg+H
+zNJj`6q#O@>4HpPJEHvNij`sYW&u%#=215HKNg;C!0#hH1vlO<x`KH1(L52Jfzqckp
+zK+CZ7Ysjx9Ry1%Exbc$7q$%?P{F`qK)zp<pKl6?{P-tc#d(^voQM{*HzaqZ$MF6+j
+zS~SbNnOTb~v^`{pTqA`20=exoU<o^ZUk`ng!~@i!3dZcf;2^$k_C@g8WV8ec1R9H3
+z1`mCus@E!98f~!1rPz5UtUeu7G^^TU%W)2pTm^QP5I*2-sUu2=PL2Gs`-60K_$N2v
+zq}PJt3O#wc`jCA!5t<`h+K4FljR)C<HUy;}xwV&b`+VADm9(!vPCRX?^<oG+Vqeyc
+zzAmc*_iJ~=?~J-H*{$GHN4NIN0}j0yD3GR_r7^*==U{*u<)Ms-C|SiYB&zk-Wp@Y%
+zp&S*-{+zxwY`#DQ<w|BzbKuAp({yI0gR5k4q=KVfX|Z@&C2D=%htF<kWp>5+dFq9&
+zS)8{5_%hz?#D#wn&nm@aB?1_|@kpA<uzp&}l&AD1u)JhYR;ZXh9aBhZCzAtxS13Bp
+zA6Zy}vU8v^?dRy1PIC=7_PA-v<La!D;#*&-5%sU))yJ_yayZVijq+d8MU%ahLUSA$
+zb0EHFFV2D{O}X^o(5AJif==$^X=iGGhpJ4KYw@<T@0PxkDnjx1LyF6S1hcurMfQm5
+zJhtbDMr1*Q{|1EZ*mS}Qd33Qo7~2#jY)+05;Xfi)zKK9EDUF$=6E5F1W+xgADW`s2
+zH|$E3Fed+2a!z;4mZn&JN5DxUfPSaKxluwruV#d2eoAHtR&D=*wdN6FVZ6oI2g0Hw
+zOP;PSG}*`dJEr(*FvR10V<#_MSwpBkIpj_jL>@{%jYcs{K%$a4W{<UY0d}<G_tvcW
+zMNcwn<nVcftdCFzNuiwF_|8?DI$6#{zbc7GvkUvU3|!{Ax?HKf@j9mrId!xHE6!-2
+z{C)xYPtH9rOV?L9kcZN6$krD3qudB?$8^ttXzA!P2B|T6$sO-q_YsmhfI9ntr>k@F
+zPyTav?jb;F(|GaZhm6&M#g|`ckO+|mCtAU)5_(<C;Peqq9IE<_AsNiFs{{>hn&Ogd
+z9Ku}orOMu@K^Ac>eRh3+0-y^F`j^noa*OkS3p^tLV`TY$F$cPXZJ48!xz1d7%vfA(
+zUx2+sDPqHfiD-_wJDb38K^LtpN2B0w=$A10z%F9f_P2aDX63w7zDG5CekVQJGy18I
+zB!tI`6rZr7TK10L(8bpiaQ>S@b7r_u@lh^vakd0e6USWw7W%d_Ob%M!a`K>#I3r-w
+zo2^+9Y)Sb?P9)x0iA#^ns+Kp{JFF|$09jb6ZS2}_<-=$?^#IUo5;g`4ICZknr!_aJ
+zd73%QP^e-$%Xjt|28xM}ftD|V@76V_qvNu#?Mt*A-OV{E4_zC4Ymo|(cb+w^`Wv==
+z>)c%_U0w`d$^`lZQp@midD89ta_qTJW~5lRrIVwjRG_9aRiQGug%f3p@<N8PMQE{a
+zd_6w48$rsd^cXZQ7Dwk9nz}YC&*86L&Yst+a`$%*_e1yJh%kgNQXk4z5r6m?Y@2xN
+zly?J=iN07}T>;*%Y@J5uQ|#dJ+P{Omc`d2VR)DXM*=ukjVqIpkb<9gn9{*+&#p)Ek
+zN=4zwNWHF~=Gqc<UjtcOL9OLcIawlSDS7cyPainIsyG~{9o!H&xa9hYf#oyhSccci
+zt8ciEDfpw+|JDHKvIGdAID*M?Ww(Uo_>Lkd!q0p(S2_K=Q`$whZ}r@ec_cb9hhg9a
+z6CE=1n8Q;hC?;ujo0numJBSYY6)GTq^=kB~`-qE*h%*V6-ip=c4+Yqs*7C@@b4YAi
+zuLjsmD!5M7r7d5ZPe>4$;iv|zq=9=;B$lI|xuAJwi~j~^Wuv!Qj2iEPWjh<cjq`B2
+zQQyz_oTCXImfm@9L;Jg(EcYq6*mZ2Ar7Wg-A&#d%mn;}2vkz#+K|`?Os_iMQICL7M
+z%X3DlLx`B&@S70b+8_uUYlQ7Jjwqbip^{Sy&<=Xy_(h{9O0(ZA&bm55akipSI@h-P
+zouFPBu_Do|z_f_JGMu+d26M|qD0mf|&pPvU(0X6B(p676+94<iS<G;?SQn?!TsCT<
+zW`oSdht$$w66GB-l}L1v_Gel0yjn`(hShw}$Zca>9Z&#<HMI*Z2_1}T(Ag7?VQuOk
+z`{mYjKhEP<qwlCQ<3{~SgOxwbx2t!SbHzjBYU=s|B(D4sC75oIbo;F+(N+m9uUJay
+z3zRQ;6klQ`P7c#H*XA(0OTAp7rMZSXB;)Q$&ymhbN*ra}sd<0WM1I3@<CsDWXd;ki
+z&@?%;r2lEn-Rstvl;9}rizIur@q3(@kvLvHJ^t^eGQ9G#)J~{}lP*OWXqf7ze8OWy
+z5Rgs^5D>+G>lZQpZ@(xfBrhc{rlLwOC;opt<Bi<dsH_Yf{WPKs9reW6WSuhO9Lv`J
+z^%&id)VSO@jT9{?+)0RW%3gsMRWsJNqP+s@Agpg+Fbck0IbJz}ettAGj7<$cpWvte
+z6!<*<{!y4dAH~kmjKRziU~Fx|U}SB<AYx}@1F$ugwXii2ax`<XF|l<Pb2l=vceb#z
+zr8lw$I63{F=af?zmj-7-$zEDn&|(O{iskxs=4#PjtBP81^sD$wd-1XbZiaEHaTAOo
+zQD4&~nfoQEH>JZDj4Xfu3$u6rt_=YY0~lxoy~fq=*L_&RmD7dZWBUmY&12S;(Ui^y
+zBpHR0?Gk|`U&CooNm_(kkO~pK+cC%uVh^cnNn)MZjF@l{_bvn4`Jc}8QwC5_)k$zs
+zM2qW1Zda%bIgY^3NcfL)9ug`05r5c%8ck)J6{fluBQhVE>h+IA&Kb}~$55m-^c1S3
+zJMXGlOk+01qTQUFlh5Jc3xq|7McY$nCs$5=`8Y;|il#Ypb{O9}GJZD8!kYh{TKqs@
+z-mQn1K4q$yGeyMcryHQgD6Ra<6^5V(>6_qg`3uxbl|T&cJVA*M_+OC#>w(xL`RoPQ
+zf1ZCI3G%;<gu?&p>o-x>RzO!mc}K!XX{1rih0$~9XeczHgHdPfL}4IPi~5EV#ZcT9
+zdgkB3+NPbybS-d;{8%bZW^U+x@Ak+uw;a5JrZ<t9b~FAko|dNnqw@`fG4fl;gO}GN
+zja@xAhij0PWn_9yAtqa|Q~JyS@OCX>H!WbNvl<c^f{)!@kr}sV306x!m(JFK2Su#H
+zA{l>!b~r4*vs#he^bqz`W93PkZna2oYO9dBrKh2QCWt{dGOw)%Su%1bIjtp4dKjZ^
+zWfhb$M0MQiDa4)9rkip9DaH0_tv=XxNm>6MKeWv>`KNk@QVkp$Lhq_~>M6S$oliq2
+zU6i7bK;TY)m>-}X7hDTie>cc$J|`*}t=MAMfWIALRh2=O{L57{#fA_9LMnrV(HrN6
+zG0K_P5^#$eKt{J|#l~U0WN_3)p^LLY(XEqes0OvI?3)GTNY&S13X+9`6PLVFRf8K)
+z9x@c|2T72+-KOm|kZ@j4EDDec>03FdgQlJ!&FbUQQH+nU^=U3Jyrgu97&#-W4C*;_
+z(WacjhBDp@&Yon<9(BWPb;Q?Kc0gR5ZH~aRNkPAWbDY!FiYVSu!~Ss^9067|JCrZk
+z-{Rn2KEBR|Wti<xxNV#Db47^*a|{iSLoUSn+}XCk5${GR@Qb+|Eox;WbSB?b>_iy)
+zXnh2wiU5Yz2L!W{{_#LwNWXeNPHkF=jj<Oca}a<VYq$(Z)L~2{hsCZ>XmHC@n*oiz
+zIoM~Wvo^T@@t!QQW?Ujql-GBOlnB|HjN@x~K8z)c(X}%%5Zcux09vC8=@tvgY>czq
+z3D(U&FiETaN9aP}FDP3ZSIXIffq>M3{~eTB{uauL07oYiM=~K(XA{SN!rJLyXeC+Y
+zOdeebgHOc2aCIgC=8>-Q>zfuXV*=a&gp{l#E@K|{qft@YtO>xaF>O7sZz%8);e86?
+z+jJlFB{0fu6%8ew^_<+v>>%6eB8|t*_v7gb{x=vLLQYJKo;p7^o9!9A1)fZZ8i#ZU
+z<|E?bZakjkEV8xGi?n+{Xh3EgFKdM^;4D;5fHmc04PI>6oU>>WuLy6jgpPhf8$K4M
+zjJo*MbN0rZbZ!5DmoC^@hbqXiP^1l7I5;Wtp2i9Jkh+KtDJoXP0O8qmN;Sp(+%upX
+zAxXs*qlr(ck+-QG_mMx<HJPMiiyFhyvyc$BVLB{06!#fNnvcq+4(CeJ9NSp(yBP{p
+zz9+FDyloDA-5BFzU$X6O5`cUWFMHGQXtH9zX=W;Z0SMrXCMHY77EA&39fq<AIjYX_
+zL-)E@whkh@FYnG!*@-)hr`+%$^!mR-H_bvW274&&>?hQNXVV~LT{$Q$ShX+&x?Q7v
+z@8t|UDylH6@RZ?WsMVd3B0z5zf50BP6U<&X_}+y3uJ0c5OD}+J&2T8}A%2Hu#Nt_4
+zoOoTI$A!hQ<2pk5wfZDv+7Z{yo+Etqry=$!*pvYyS+kA4xnJ~3b~TBmA8Qd){w_bE
+zqDaLIjnU8m$wG#&T!}{e0qmHHipA{$j`%KN{&#_Kmjd&#X-hQN+ju$5Ms$iHj4r?)
+z&5m8tI}L$ih&95AjQ9EDfPKSmMj-@j?Q+h~C3<|Lg2zVtfKz=ft{YaQ1i6Om&EMll
+zzov%MsjSg=u^%EfnO+W}@)O<s4y0<!F*}jN{~^*=<<M!`pCE38_&X5u{wE+7HZiqx
+zG!eIObaGa4G5p`k`7da0P_t5)HNf!I6NGD^#Jcju!NjqqL7(FK$?;p8B-cTjS(f#p
+zHML@9bjCH8>6u0LwoX709h3Cxdc2Rwgjd%LLTChQvHZ+y<1q6kbJXj3_pq1&MBE{8
+zd;aFotyW>4WHB{JSD8Z9M@jBitC1RF;!B8;Rf-B4nOiVbGlh9w51(8WjL&e{_iXN(
+zAvuMDIm_>L?rJPxc>S`bqC|W$njA0MKWa?V$u6mN@PLKYqak!bR!b%c^ze(M`ec(x
+zv500337YCT4gO3+9>oVIJLv$pkf`01S(DUM+4u!HQob|IFHJHm#>eb#eB1X5;bMc|
+z>QA4Zv}$S?fWg~31?Lr(C>MKhZg>gplRm`2WZ--iw%&&YlneQYY|PXl;_4*>vkp;I
+z$VYTZq|B*(3(y17#@ud@o)XUZPYN*rStQg5U1Sm2gM}7hf_G<>*T%6ebK*tF(kbJc
+zNPH4*xMnJNgw!ff{YXrhL&V$6`ylY={qT_xg9z<NbPza#S5_;7-HDWW5RigZ=LV6*
+zC(tYTyWThzXHf4MXBa7hZbsubd?Ryu_#A)%-?VnWgzy8ET!tu|{8#c_&gaH`oCBdA
+zDZ_rb+3zi849gP{1S5P<jk#MGP++DGAy-3vwo{u^X(9-1cLI-eD^5-vRFWj~@&pA;
+zVHMOE7R0Uo3r+HxoApr;N3Ucb6+Fi&Rw>nQWw9>PlG~IbhnpsG_94Kk_(V-o&v7#F
+znra%uD-}KOX2dkak**hJnZZQyp#ERyyV^lNe!Qrg=VHiyr7*%j#PMvZMuYNE8o;JM
+zGrnDWmGGy)(UX{rLzJ*<yAEppP~EY>QEBd(VwMBXnJ@>*F8eOFy|FK*Vi0tYDw;#E
+zu#6eS;%Nm2KY+7dHGT3m{TM7sl=z8|V0e!DzEkY-RG8vTWDdSQFE|?+&FYA146@|y
+zV(JP>LWL;TSL6rao@W5fWqM1-xr$gRci#RQV2DX-x4@`w{uEUgoH4G|`J%H!N?*Qn
+zy~rjzuf(E7E!A9R2bSF|{{U(zO+;e29K_dGmC^p7MCP!=Bz<LU?&i-}KG6X?-t~{t
+z6;cwZkN#6(bfNz)LHYiZ1eLM1bF=-Y%KTGzRGb0MCjXM5S?b4b=q6Yne5@ub&Z1fi
+zwe1K(xpIl(UuqiL&9zbE3--S?_yjh~vM9{@56fnz)vH22_-yvCYe2Y7H${#(Jncbu
+zdEOFD?GkNqW$#j4@v}(bNmkD>q@}&AdF5=rt<!COJnb)nu<w2#Fc9&zR-N5X<)-uZ
+z$<fUbN+So80PB;-k3&vQQgFt#a4A~G5i7YfkwVod(g_caMdbNUgH}RSd$;2i>Cwka
+zTT1A?5o}i*sXCsRXBt)`?nOL$zxuP3i*rm<aImxvw^U@{B*fUS0^1}v7Fr7%=t{5R
+zr{ZxLLkwm{RxNy^ZS6xw>3Gmbmr6}9HCLvL*45d|(zP;q&(v%}S5yBmRVdYQQ24zh
+z6qL2<2>StU$_Ft29Iy<fP{_A}(TLFc`ulnZB85D4f`?3P{(NRH&`r%oRcE}aoRUTu
+zE?7Y|z|k@bRY%JdWY5F(IA^2{CsLJ|)7+Sk)-1LuGjdpW2<~xRpIawD7|b}pzW)Q9
+zAY5MSu{bw_VLh`wPo4Jb7n0QMsV))LK}%s$WqXQ<7NQ-5!+}@QkF+dLPzuz#x@W)<
+znhWO;3yF&C)0P|n)1lp<2aeQ_$@3&mI?kFLSzhC?s<NQdC{FP%I#bp;kORX{l<3x0
+zI8yQp7E^WBY)WEgiAkeUv{*@dstpdRH)q&jD@2v`EidG8QsD}**_mj0v08)ZlDq;v
+z=LqggR_Jz_t>F!6=!@;tW=o8vNzVy*hh}XhZhUbxa&;9~woye<_YmkUZ)S?PW{7t;
+zmr%({tBlRLx=ffLd60`e{PQR3NUniWN2W^~7Sy~MPJ>A#!6PLnlw7O0(`=PgA}JLZ
+ztqhiNcKvobCcB<yMplTfXcPqrYE+vVszVQmm@rg}2{rJGaO7?|y?`3a_S!XcQLG&V
+z?bgXaiD}w%%A$ShO3yHwQZ52?;xk}hq`az4Qz(&ZI4P8rn`^{UhqrR}d!P@Af>el2
+z-N82?4-()eGOisnWcQ9Wp23|ybG?*g!2j#>m3~0__IX1o%dG4b;VF@^B+mRgKx|ij
+zWr5G4jiRy}5n*(qu!W`y54Y*t8g`$YrjSunUmOsqykYB4-D(*(A~?QpuFWh;)A;5=
+zPl|=x+-w&H9B7EZGjUMqXT}MkcSfF}bHeRFLttu!vHD{Aq)3HVhvtZY^&-lxYb2%`
+zDXk7>V#WzPfJs6u{?ZhXpsMdm3kZscOc<^P&e&684Rc1-d=+=VOB)NR;{?0NjTl~D
+z1MXak$#X4{VNJyD$b;U~Q@;zlGoPc@ny!u7Pe;N2l4;i8Q=8>R3<TEv>H{>HU<axH
+zp`GSL-T`v+`h{A=aX;JW4CEU!(+?Uoa0aOL$De+GUOkWsAqa2ZK4FC`K3!1~Zy9HB
+zzvq?1%x_y$*Bv$0)GEimNLh#E5__f1Mpw)(hNBlqy(D20`q=1`jdMVFIk`mBE8>(z
+z%hV2?rSinAg6&wuv1DmXo<vm47<QjMysD@bzHIj93EKq|LsScFN}?1q^I)(oMd!rn
+zn|DubZt_^bCFb75g5Trh|4Qx?zo0F<A>k`5@a3@H0BrqsF~L$pRYHNEXXuRIWom0l
+zR9hrZpn1LoYc+G@q@VsFyMDNX;>_Vf%4>6$Y@j;KSK#g)TZRmjJxB!_NmUMTY(cAV
+zmew<J38CI3YanL~W|fbwxrqJqw<my@*XH*?z?)KSw#4MywnI6A#4U@pFSNEc`Lrv-
+z-S!+OS6bh_zm$&432UozL4&En7L86;ghp^8;$ppb%xO{FV^Pm{yQ`>n7H{z`M3^Z&
+z2O$pWlDuZHAQJ{xjA}B;fuojAj8WxhO}_9>qd0|p0nBXS6IIRMX|8Qa!YDD{9NYYK
+z%JZrk2!Ss(Ra@NRW<7U#%8SZdWMFDU@;q<}%F{|6n#Y|?FaBgV$7!@|=NSVox<B(`
+zIq)S_BbU4&5Y;#+zzGVxaXAWCz*U+(@Q+o!?%YbO5Lnd}NLZ#m2X87gxZsJLNwk+3
+z@~G>lJI4G-G(rn}bh|?m<PI-QoC(rF$EW8<oaZlKv17e{ZZEs5gI5rI>KkaBF$-Yr
+zA;t0r?^5Nz;u6gwxURapQ0$(-su(S+24Ffmx-aP(@8d>GhMtC5x*iEXIKthE*mk$`
+zOj!Uri|EAb4>03C1xaC#(q_I<;t}U7;1Jq<Pun#t0_d*_eJ@mw@913m0*PYiG@}tB
+ztP(s*U6EvObA-KfU!e+*)h*+A8wNY(z9PpR7|ng1RQ75YwD8Ip`2*1~IH(z=Ujxyl
+z<ntP1@(4b<498kKUoYg<(N=o2;8F4n|CejK@H@|3g8~6DMEW~D{f`P>ISVHz3tO{)
+zD(Yu@=>I9FDmDtUiWt81;BeaU{_=es^#QI7>uYl@e$$lGeZ~Q(f$?^3>$<<{n`Bn$
+zn8ba<y1J3mk7QrBkS`^06lBb%XobuZz0Uc3vJW$}oz5rqH-CVXbQ?TYcYWkt$y+%%
+zDGW6>mZlL@6r^RZHV_c5WV7m2(G6X|OI!+04eAnNA5=0v1Z3lxml2#p<Q2Hk_3rET
+z#;|JLdCr%w6PIsdU-R${5=&H%MpF|6*IQEs*~vt<`)osFM7~B}S2*^XM|R%(!bK5x
+z?B98-@YWD?D?WIa89ue2g+&}MCA&<zv{-XU9dkW^Z!-wg1^SV3v?-k+`&iNJ0Tmf1
+z6uA?;4A2J1dJC}17}snGhxuUKB>~Zo57ri;4>;#16sSXXEK#QlH>=b$inEH0`G#<_
+zvp;{+iY)BgX$R!`HmB{S&1TrS=V;*5SB$7*&%4rf_2wQS2ed2E%Wtz@y$4ecq4w<)
+z-?1vz_&u>s?BMrCQG6t9;t&gvYz;@K@$k!Zi=`tgpw*v-#U1Pxy%S9%52`uf$XMv~
+zU}7FR5L4F<#9i%$P=t29nX9VBVv)-y7S$ZW;gmMVBvT$BT8d}B#XV^@;wXErJ-W2A
+zA=Jft<sUW%eIzvD`%|;&1KUO!vBts9$jx)aLl#J~zQpxlFUxMboZ!i0c9Fc`OtVN_
+zc!Oz?NJ1z_+?YXWzG9yyn`e=Y8ro2cgXxj=V=SljU>QR<YtbUwpQ+@vL?uI{$gmcZ
+zYC3@UzzpYKLZewwpeTE~#NkBl55_$s{)OK@ziuA6Ps5h_w}$OMst5l!aNPioCjY)3
+z3|9SgY>L>vNO(!n4mcd3O27bHYZD!a0kI)6b4hzzL9)l-OqWn)a~{VP;=Uo|D~?AY
+z#8grAAASNOkFMbRDdlqVUfB;GIS-B-_YXNlT_8~a|LvRMVXf!<^uy;)d$^OR(u)!)
+zHHH=FqJF-*BXif9uP~`SXlt0pYx|W&7jQnCbjy|8b-i>NWb@!6bx;1L&$v&+!%9BZ
+z0nN-l`&}xvv|wwxmC-ZmoFT_B#BzgQZxtm|4N<cR35n#bARS74OQDTms<32~v8v=`
+z7-caF<C)1AG)W4zO)YE8SJ$Y@<CJ4$G=}`=!37S-py?UnU1Gh2h2n_6&p(Ao5Qqf6
+z=k(-OuAx!R!Y>+|;+(YW&Jtj^g!)iqPG++Z%x0LmqnF875%Ry&2QcCamx!T@FgE@H
+zN39P6e#I5y6Yl&K4eUP{^biV`u9{&CiCG#U6xgGR<Po=AznL^)f6o>Qr)zew;Z%x+
+z-gC>y%gvx<e=sLpgCWdgi6XpJK8=uXJkkm8YE@{r>|dM=OrO`N@P+h2klPtb<Ry(x
+zpu?Xm?4btAWLp$6D_`$o&fb}lDqgV$`64jZuZt*NMiKvp57y55K7Ikao<AXqBElPW
+zh~1j8oF$DxMm1(>YvjS!mNnk4yE0+I&YrSRi?F^plh}hIp_+OKd#o7ID;b;%*c0ES
+z!J))9D&YufGIvNVwT|qsGWiZAwFODugFQ$VsNS%gMi8OJ#i${a4!E3<-4Jj<9SdSY
+z<OXh$_?#e&cT#EB-U!=XwtowFV|9Uhv$sUK3q>&xe|D0V1c`dZv+$8>(}RE|zL{E3
+z-$5Anhp#7}oO(xm#}tF+W=K<zEDOn&&TBZukL{eI>E*3(xxKxhBt-uuJP}`_K#0A<
+zE%rhMg?=b$ot^i@BhE3&)bNBpt1V*O`g?8hhcsV-n#=|9wGCOYt8`^#T&H7{U`yt2
+z{l9Xl5CVsE=`)w4A^%PbIR6uG_5Ww9k`=q<@t9Bu662;o{8PTj<F}p=3(;yTV~Qyf
+zgQDdrLzMjDw7>DBzzbY#tL;$wrpjONqZ{^Ds4oanFm~uyPm#y1Ll3(H57YDWk9TlC
+zq;kebC!e=`FU&q2ojmz~GeLxaJHfs0#F%c(i+~gg$#$XOHIi@<TM;Hv2aC}$s8#Sv
+z+Dd3KT+?=#!iTV?Ms~47n*H>1mA72g2pFEdZSvp}m0zgQb5u2?tSRp#oo!bp`FP}<
+zaK4iuMpH+Jg{bb7n9N6e<k8B#=)v)d%-lnDQKtnG^2KYKtU2;<n>R*NZfgL7QiLxI
+zk6{uKr>xxJ42sR%bJ%m8QgrL|fzo9@?9eQiMW8O`j3teoO_R8cXPe_XiLnlYkE3U4
+zN!^F)Z4ZWcA8gekEPLtFqX-Q~)te`LZnJK_pgdKs)<s7#%|5P$s1t)kN+!Um>Dp50
+zdUq)JjlJeELskKg^6KY!sIou-HUnSFRsqG^lsHuRs`Z{f(Ti9eyd3cwu*Kxp?Ws7l
+z3cN>hGPXTnQK@qBgqz(n*qdJ2wbafELi?b90fK~+#XIkFGU4+Hihn<y_>Wq;{{)1J
+zv*Txl@GlnIMOjzjA1z%g?GsB2(6Zb-8fooT*8b0KF2CdsIw}~Hir$d3TdVHRx1m3c
+z4C3#h@1Xi@{t4zge-#B6jo*ChO%s-R%+9%-E|y<*4;L>$766RiygaLR?X%izyqMXA
+zb|<FVRVPIkP%(S)yIvuu+5z_83buf`qe#ezb);jn)u$oPrWvD(s&~KHbqKNL%cobC
+zN-|C-DK*$CAI~b2Ac6>N=Z-0PSFeH;W6aQ3(5VZWVC>5Ibgi&cj*c%_3=o#VyUJv*
+zM&bjyFOzlaFq;ZW(q?|yyi|_zS%oIuH^T*MZ6NNXBj;&yM3eQ7!CqXY?`7+*+GN47
+zNR#%*ZH<^x{(0@hS8l{seisY~IE*<IWx!UK-u2j(e2O!c*%v`vbRdmnwY3~F@WfqY
+z%qQlFf<s6fB4WlqklvTVl*JK;YI>)BD+R6^OJX}<2HRzo^fC$n>#yTOAZbk<pxtmH
+zJ~q1kaL=GoN56akk-6RD`q2mzV0mH8>4%=Bei=<kddu{Z(hj1<vW)@wW7M&+@6=2s
+zZD&Op_jWe#TTdH<JbSg3bLF85E$EBmVzcroiC)+RvF8h>JEe=o$jm`or0YDw*G?d>
+z=i$eEL7^}_?UI^9$;1Tn9b>$KOM@NAnvWrcru)r`?LodV%lz55O3y(%FqN;cKgj7t
+zlJ7BmLTQ*NDX#uel<G9Op(1@^PULS#3C#Zq5&eylEB%v#D2Qdisi+`5Pk=N?QpqNe
+zn3Q0BprVD+s9yvAi-Ka>GbCY>k+&H*iSK?x-{w;f5G%%!^e4QT9z<_0vHbXW^MLR}
+zeC*jezrU|{*_F`I0mi)9=sUj^G03i@MjXx@ePv@(Udt2CCXVOJhRh4yp~fpn>ssHZ
+z?k(C>2uOMWKW5FVsBo#Nk!oqYbL`?#i~#!{3w^qmCto05uS|hKkT+iPrC-}hU_nbL
+zO622#mJupB21nChpime}&M1+whF2XM?prT-Vv)|EjWYK(yGYwJLRRMCkx;nMSpu?0
+zNwa*<?h%^Uxlo#rhlXX^1ry~0-r)@+JQ4MlP_WRi_c8}Pe;l(#WnThfspZ$^3+`@%
+zmW}tS#o_f`H(V@)Qt__Qwx4kv+ooP8ZrPBV-j<==nbQ*DT}dlBw*|*N7vHSJyQH}0
+zm|S-J1_lheA!DE{g6^Xv;AA#SxCooopboet4w*f2U~sm_9-x1=xp|LI-xxj9006QY
+z1mgxK<wER;C#1B$%?%3n>{0n+Yg6=SR3-S&;<?krxZxGO!Tw^S=d_=26`yQ0@waRw
+z@SmVU&DQEaY5x6V*rbHQm)eLi0+(WkiJ>vq=-lRqN`s9~#)OOaIcy3GZ&~l4g@2h|
+zThAN#=dh{3U<aA#cPR4&ofsaO#bX_do9RRvi_^pV^V=?kpT`)pH$SJl(tC+UO9KU%
+zw*Fj&O-G3~P~VA<unl1F2&AK=52kP@qipFV?Oj1#&{KUN^>N7Xil;nb8@%)wx5t!l
+z0RSe_yJQ+_y#qEYy$B)m2yDlul^|m9V2Ia$1CKi6Q19~GTbzqk*{y4;ew=_B4V8zw
+zScDH&QedBl&M*-S+bH}@IZUSkUfleyM45G>CnYY{hx8J9q}ME?Iv%XK`#DJRNmAYt
+zk2uY?A*uyBA<BiMLU_*M#NCCxjGD{)FKf5%TR%^0(tj%ZEC|pB`lh!G8#P^_7rgl6
+zHD8H9#lPg#uyjB59dckNv=l!fBEB{M6vF+Eh;w^K5=@MUOHXMhDuV2p%rP)^5%vfh
+zn^LIqAcivg*z)=%xYv);q@8+WaMY5huI1GOD-9N$`j-dE7hH0tcwmf1#`ceO!mOHP
+zCyw-!`T<sF+;H*u*8-P5M#r^Q!nW)d+HW6<4*Bj<y{xwPJ5aVv2w6&T;_`2#jdBoY
+zJBy`lJrSwb+PH8(hrh;>=nlYjkcNPMGi*552=*Q>%l?gDK_XYh<zL<ke_eZ$ot|PF
+zZVgv}4Sq{EZ4ogcRofdp&JliroypZ_e}$4iKs?X|D!2Ac$5!nj(ZskdL0_wd=BN37
+zZG}#$eUO#D_A!-?os3(Syu!QKCTTw$pZe08wZZN8KnynfmowC;MZ_o?kig}nxLgNw
+zM?*Zz05oY7v>*Rya_c)ve{=ps`QYE0n!n!)_$TrGi_}J|>1v}(VE7I~aP-wns#?>Y
+zu+O7`5kq32zM4mAQpJ50vJsUDT_^s&^k-llQMy9!@wRnxw@~kXV6{;z_wLu3i=F3m
+z&eVsJmuauY)8(<=pNUM5!!fQ4uA6hBkJoElL1asWNkYE#qaP?a+biwWw~vB48PRS7
+zY;DSHvgbIB$)!uJU)xA!yLE*kP0owzYo`v@wfdux#~f!dv#u<u)VAl7h<(Ox?_8|-
+zieXQ0tIl#N(#Ubvm=#=RRW-l$qV+J9qkYE;+MW4sd~tDdcA{`>Nc_$SF@Qq9#3q5R
+zfuQnPPN_(z;#X#nRHTV>TWL_Q%}5N-a=PhkQ^GL+$=QYfoDr2JO-zo#j;mCsZVUQ)
+zJ96e^OqdLW6b-T@CW@eQg)EgIS9*k`xr$1yDa1NWqQ|gF^2pn#dP}3NjfRYx$pTrb
+zwGrf8=bQAjXx*8?du*?rlH2x~^pXjiEmj^XwQo{<CPx+@82|8@X@<D@6UUi%p$ehj
+zhXQlcfF2phkkCDxVFxfI?!~Bx<^Y(i{JB%4bav+Pbd2%<Y>`NMonBN=Q@Y21!H)D(
+zA~%|VhiTjaRQ%|#Q9d*K4j~JDXOa4wmHb0L)hn*;Eq#*GI}@#ux4}bt+olS(M4$>c
+z=v8x74V_5~xH$sP+LZCTrMxi)VC%(Dg!2)KvW|Wwj@pwmH6%8zd*x0rUUe$e(Z%AW
+z@Q{4LL9#(A-9QaY2*+q8Yq2P`pbk3!V3mJkh3uH~uN)+p?67d(r|Vo0CebgR#u}i?
+zBxa^w%U|7QytN%L9bKaeYhwdg7(z=AoMeP0)M3XZA)NnyqL%D_x-(jXp&tp*`%Qsx
+z6}=lGr;^m1<{;e=QQZ!FNxvLcvJVGPkJ63at5%*`W?46!6|5FHYV0qhizSMT>Zoe8
+zsJ48kb2@=*txGRe;?~KhZgr-ZZ&c0rNV7eK+h$I-UvQ=552@psVrvj#Ys@EU4p8`3
+zsNqJu-o=#@9N!Pq`}<=|((u)>^r0k^*%r<{YTMm+mOPL>EoSREuQc-e2~C#ZQ&Xve
+zZ}OUzmE4{N-7cqhJiUoO_V#(nHX11fdfVZJT>|6CJGX5RQ+Ng$Nq9xs-C86-)~`>p
+zW--X53<fjk))~(Y7xt;2-3Mp_sh^OGttxT8JXcE>J`O~vS{WWjsAuGq{K#8f#2iz`
+zzSSNIf6;?5sXrHig%X(}0q^Y=eYwvh{TWK-fT>($8Ex>!vo_oGFw#ncr{<A-F%$p&
+zc|DGKq;$_R8E0EodRv?$JW^Po<Ex>vmERi^m7lRi%8Imph})ZopLoIWt*eFWSPuBK
+zu>;Pu2B#+e_W|IZ0_Q9E9(s@0>C*1ft`V{*UWz^K<0Ispxi@4umgGXW!j%7n+NC~*
+zBDhZ~k6sS44(G}<L8r7U{uvHTXWzD_JuHzxZ-XY|N?p*qndC=U0c*Cl@BtNW7i{&R
+z-Me?NHPa(a(vIZUFSMee2{hPx14nk+e_C|^?Bd;r8#<I5LFO<RoqQ`w{VLAmJAmJ-
+zf-f}_R{!XhIih6nYvLOxM^4vM+l^NaQ|ty{<XIb6;HnNe&IB3k;~%;YB%OMx`D8+)
+z&)Zf1-i7=>*zg||X#9Weto;u*Ty;fP!+v*7be%cYG|yEOBomch#m8Np!Sw`L)q+T`
+zmrTMf2^}7j=RPwgpO9@eXfb{Q>GW#{X=+xt`AwTl!=TgYm)aS2x5*`FSUaaP_I{Xi
+zA#irF%G33Bw>t?^1YqX%czv|JF0+@Pzi%!KJ?z!u$A`Catug*tYPO`_Zho5iip0@!
+z;`rR0-|Ao!YUO3yaujlSQ+j-@*{m9dHLtve!sY1Xq_T2L3&=8N;n!!Eb8P0Z^p4PL
+zQDdZ?An2uzbIakOpC|d@=xEA}v-srucnX3Ym{~I#Ghl~JZU(a~Ppo9Gy1oZH&Wh%y
+zI=KH_s!Lm%lAY&`_KGm*Ht)j*C{-t}Nn71drvS!o|I|g>ZKjE3&Mq0TCs6}W;p>%M
+zQ(e!h*U~b;rsZ1OPigud>ej=&hRzs@b>>sq6@Yjhnw?M26YLnDH_Wt#*7S$-BtL08
+zVyIKBm$}^vp?ILpIJ<dp3ooa+cndqkSQ3UA!R3}}yC4bxfeA6S8LO9hE~vx|Yi68@
+zNr?jvc2@*eXxky?<YJ*9EIA;CdIbdqd2SQpx9uQtXD#8(J3Vt<5%NQ*o02|K+6bY0
+z;sT8vn@o8e%0|hi^#v|34DqvO58NzmQDAp!LXk*AcbC{I;vTjGcE|?=;e?ESe2XV{
+zRUgP)(rNkqS#Yhf8ziDbO6ep!K;GEwl%7iVkc_KR&%z8}O~7*V=?=DsoCZuiU?(w*
+zHV&rJy*1isBFt8he4l73U>etMkW1VtIc&7P3z0M|{y5gA!Yi5x4}UNz5C0Wdh02!h
+zNS>923}vrkzl07CX`hi)nj-B?#n?B<Q|A1|76WLZEE&m-hhR<X$5TK&X`9{ZnvFM%
+zu_h)S<XvC@S;kBiJJBt>J2Vk0zOGsF<~{Fo7OMCN_85daxhk*pO}x_8;<dX=<+?Qg
+z#r>-h>}pcw26V6CqR-=x2vRL?GB#y%tYqi;J}kvxaz}*iFO6YO0ha6!fHU9#UI2Nv
+z_(`F#QU1B+P;E!t#Lb)^KaQYYSewj4L!_w$RH%@IL-M($?DV<J?Z?(&T(jN~E*h4k
+zjT$bEE;1X$dKstuB%kL?N}i|18#(T<X%h{nQolXBTKBIbWb9u%<<*n%KAruYiv41M
+z(BV$!uq)MDNOGLcUNoFp1O|t~h!*SC05{|sLBD8s0{dGDvJFAn@fT!9#{nXqzUzhA
+ze1Wde$2)jpHttd7Vt%dJc<P1PQ_QtXhR)w~A<pGWwkJB}X>@lGj%3ZgVdHe^q>n(x
+zyd5PDpGbvR-&p*eU9$#e5#g3-W_Z@loCSz}f~{94>k6VRG`e5lI=SE0AJ7Z_+=nnE
+zTuHEW)W|a8{fJS>2<PuTj25j+DhXW(hd~r?Xh^MxKJCimxGsmwzKdi%?KCIX3{&)m
+zZ0nj+u3m}byL|gc@7el5sG0YZn703R7lHPF8j}A(O#keT{0lwVD2_|_3ZlF(l>TaX
+zuRoa=LCP~kP)kx4L+OqTjtJOtXiF=y;*eUFgCn^Y@`gtyp?n14PvWF=zhNGGsM{R-
+z^DsGx<p*94-ySu{F;3A%Gw(MuWcO5hc=1Fn6S6X-V`dR&jLKv;9Ov9;sNX7hCxxgJ
+z&)GGfI53?p5EUqj1kN{nL`cLj*Ny6Bb93QS#TWv+m?{)VTv#I?UM_EBDq&18Y1rBF
+zqj?j71ovsu1jc{FMqN`ZbtUe%y6G-sBQrAwb$+jv1%VjW_k<x<OD8=u&hN{;<-bn?
+z@rS2|Sdn<vp_N-gJ^Y{ISs}UnqwiH29Bq1>toDtx+g^hZi@E2Y(msb-hm{d<UuZ5B
+zF*RQXF90n8n5t!zMgUN!64)`l%MNqK%g0zqOLUu+a4FnHHt`Hf2k1Gsi_Mzb@Z^^=
+zxAOB&;5(e``nO6J%C~>WiHdoQvdX88EdM<JUQYg{sbyjNxshlKux2o|_*{in1UQ?k
+zIs#lx9Gw8xBIYJWRwj=B5<C|bZKqjrjCXeSc*C*6yaFuS2rWqx!(UR;j8e_%Q^I^0
+zj8p#CwJD3Wf>>^DS#f}&kCGpPFDu*KjEpv$FZtLpeT>@)mf|z#ZWEsueeW~hF78Hu
+zfY9a+Gp?<)s{Poh_qdcSATV2oZJo$OH<l8JXo;z<PcbGCYR0J9l8&nxRHHiz--^d2
+z8~J{Itr^Z$OtgTuQ6<JD;bmdLugNLaS^G}k$rEM-rW(6=U_mp(C><Q9gp1ZnUy!F0
+zwAdk5rFR<Ua`+2&K+(bk94CxMi5A;34dG4kTAucma$dNI_rA^e+RlExjm~4DcUPQV
+zUJ~3S<PG_W`@twX<bCoilw=BO0H-v<O^nbfi=xlVu&Cv1VWy=dd07F7ytH8mMU5a{
+zu#nKXVN5wbwo#QA!H4;0Ko9C5V@W}ba=cKzOSE;+-oDrv!(>~K@QzE2kCADZ@xX(;
+z)0i=kcAi%nvlsYagvUp(z0>3`39iKG9WBDu3z)h38p|hLGdD+Khk394PF3qkX!02H
+z#rNE`T~P9vwNQ_pNe0toMCRCBHuJUmNUl)KFn6Gu2je+p>{<9^oZ4Gfb!)rLZ3CR3
+z-<Jj6ofd&sk<LvELH)*PRT^`1cMjr9jc63Nl_{PuyZKn7*LCLu65p@97#0uR(E?9W
+zX`bZ}=9-Z$>o&b;Bh>51JOt=)$-9+Z!P}c@cKev_4F1ZZGs$I(A{*PoK!6j@ZJrAt
+zv2LxN#p1z2_0Ox|Q8PVblp9N${kXkpsNVa^tNWhof)8x8&VxywcJz#7&P&d8vvxn`
+zt75mu>yV=Dl#SuiV!^1BPh5R)`}k@Nr2+s8VGp?%Le>+fa{3&(XYi<NKc?C)>~{k{
+z-u4#CgYIdhp~GxLC+_wT%I*)tm4=w;ErgmAt<5i6c~)7JD2olIaK<AIVJAZuKkE<l
+z4Bm0%W2+6b=&ak;y7abRJFYhw&)H;bM_b*mAs4cDPr8CDbB=hVJk3YURR<;YVVe}i
+zH4VPi#sF`j{_5B)vN4u|e)jM(|JKI}{da==@2O^OXJqx+GG_R^W?=2&Wa0X`P-$%<
+zWMpLG<Rk~M1(^Mh#54JvEUXHm_-Lca3M)$jz5TrWVT^)HDZzq*6uqcRSEO&-H)J!v
+zox0RpNqqerD+o-nP(VP(;6Ij>8by{u-!tZWT#RQddptXRfEZxmfpt|@bs<*uh?Y_<
+zD>W09Iy4iM@@80&!e^~gj!N`3lZwosC!!ydvJtc0nH==K)v#ta_I}4Tar|;TLb|+)
+zSF(;=?$Z0?ZFdG6>Qz)6oPM}y1&zx_Mf`A&chb<i`Nr1_JKCJ^T_*s={KuqB@lhf>
+znSERvt9%wdPDBIU(07X+CY74u`J{@SSgesGy~)!Mqr#yV6$=w-dO;C`JDmv=YciTH
+zvcrN1kVvq|(3O)NNdth>X?ftc`W2X|FGnWV%s})+uV*bw>aoJ#0|$pIqK6K0Lw!@-
+z3pkPbzd`ljS=H2Bt0NYe)u+%kU%DWwWa>^vKo=lzDZHr>ruL5Ky&#q7davj-_$C6J
+z>V8D-XJ}0cL$8}Xud{T_{19#W5y}D9HT~$&YY-@=Th219U+#nT{tu=d|B)3K`pL53
+zf7`I*|L@^<akj8#_&*rXa0J-fn>dPEIDJkI3_oA9vsH7n7O}Ja<law4{uj~>R{G~8
+zfi$?kmKvu20(l`dV7=0S43VwVKvtF!7njv1Q{Ju#ysj=|dASq&iTE8ZTbd-iiu|2&
+zmll%Ee1|M?n9pf~?_tdQ<7%JA53!ulo1b^h#s|Su2S4r{TH7BRB3iIOiX5|vc^;5(
+zKfE1+ah18YA9o1EPT(AhBtve5(%GMbspXV)|1wf5VdvzeYt8GVGt0e*3|ELBhwRaO
+zE<IB-Cn|oj1SDl{xp8zad#YcCdtrs+9}i$s<*@)jbR<MzYyAq(U%KqfE2&l%Q`Tlq
+zFFOj{{w{t{I93tgk%#X+S#qY@HW9M}>|yMhl;Bm?8Ju3-;D<d0gaE$FN@5itD4g&V
+zgQbZVdU+i-wHuALtd^lmCPv@8>NnxM3Roelg`^!S%e({t)jvYtJCKPqN`LmMg^V&S
+z$9OIFLF$%Py~{l?#ReyMzpWixvm(n(Y^Am*#>atEZ8#YD&?>NUU=zLxOdSh0m6mL?
+z_twklB0SjM!3+7U^>-vV=KyQZI-6<(EZiwmNBzGy;Sjc#hQk%D;ba<AuKL_OVlNJ8
+zzJ~Op&$U`bGuaaEPGBR);C}uHL4psgioidnP6KL62R)y#$^To}F#LDexcw6-48nGH
+z&YxHT*vkPdY(F<p{z3^E)4$-vMrqU*T?nO|IF@Z74ohmQ)xMgvN&|_c7OfAIO#XAt
+zaL2E?e(>y$v#zczt%mFCHL*817X4R;E$~N5(N$1Tv{VZh7d4mhu?HgkE>O+^-C*R@
+zR0ima8PsEV*WFvz`NaB+lhX3&LUZcW<oTbF57ud5qxRCovnmT%0KJe~XJK}Gj*7_g
+z0&W(W*y&*@eIfyjN}|^Vg@Xk+l%k}&LK6+_!9US75W3aKwKA7N7eaP%(H`-gc7jx_
+zq4R52zNWM^&eZyQ!NoQEuNB3ura1z?O0n};Cx@E>WJJrG7ZjQrOWD%_jxv=)`cbCk
+zMgelcftZ%1-p9u!I-Zf_LLz{hcn5NRbxkWby@sj2XmYfAV?iw^0?hM<$&ZDctdC`;
+zsL|C-7d;w$z2Gt0@hsltNlytoPnK&$>ksr(=>!7}Vk#;)Hp)LuA7(2(Hh(y3LcxRY
+zim!`~j6`~<bW*$8$<<~?JS18Peo3DUOk=IRLX_ufFFmtupg*V26|}Y8;Di!sKr{px
+zU!wn|6erEM{4t*~C;Z!(|BF)mSIk8}_js-C0LEmZCZ+%vYv=#^U(wOd%<)qwWIx%%
+z#P)x%MYM{N-K;vs`}xdVg@cSV9;IsBd_FC#oCthSxj&+MND|t@FCnpb@*2FC0f*D2
+z?G^cWl=jPk-fVXO^6GAO{DQL0%m8{~;|J@R4tRbB$asqPCv~(P@*H}1{&>B+sRBv4
+z<mz=pCM?&uNVBoEf!$<Jl`Auv$WWg;Z6o}=Da&vNrmd(0r*Nq_WttlLt&FC;g7G}~
+zz%kSd_><#B{@38kH;sLB4eH2+8IPWklhd25r5j2VR}YK$lpZ%7eVF5CBr#~=kUp`i
+zlb+>Z%i%BJH}5dmfg1>h7U5Q(-F{1d=aHDbMv9TugohX5lq#szPAvPE|HaokMQIi_
+zTcTNsO53(oX=hg2w!XA&+qP}nwr$(C)pgG8emS@Mf7m0&*kiA!wPLS`88c=aD$niJ
+zp?3j%NI^uy|5*MzF`k4hFbsyQZ@wu!*IY+U&&9PwumdmyfL(S0#!2RFfmtzD3m9V7
+zsNOw9RQofl-XBfKBF^~~{oUVouka#r3EqRf=SnleD=r1Hm@<buigJ1Zgh}+47#N}=
+zA;FL!#2C23SP8!!apVBYzJ3fxxO$`OHLK}}G5fYfk`4&0f}B0=8mk!Hn*#TLB6~0w
+zVDX$-aLCK?dMa|C-1DpnLg1Y;dn>~`y8U7R)w16fgHvK-6?-TFth)f3WlklbZh+}0
+zx*}7oDF4U^1tX4^$qd%987I}g;+o0*$Gsd=J>~Uae~XY6UtbdF)J8TzJXoSrqHVC)
+zJ@pMgE#;zmuz?N2MIC+{&)tx=<l|D;tZlZQyALE=2ji-YLMO_Re>7A%$yq-{GAzyz
+zLzZLf=%2Jqy8wGHD;>^x57VG)sDZxU+EMfe0L{@1DtxrFOp)=zKY1i%HUf~Dro#8}
+zUw_Mj10K7iDsX}+fThqhb@&GI7PwONx!5z;`yLmB_92z0sBd#HiqTzDvAsTdx+%W{
+z2YL#U=9r!@3pNXMp_nvximh+@HV3psUaVa-lOB<kAlb5{e|+s3GRS<WGPVcKv}ufw
+zsm@L)j21fBT_PZS23MbS<jhcW_7ZmN8)9;FrTXBPApWUlG*$QXnli9;L`ce(&0uB<
+zK<7{*B6<8;LFx#98e~1Ipcz1=a?doj&-~;#cS-Pk$4@XT{MS|f&qHIFc^#?##d3%L
+zF_vTgzyFp0k4KXHb4gb>ekVuMf1RUd26~P*|MLouQrb}XM-bEw(UgQxMI6M&l3Nha
+z{MBcV=tl(b_4}oFdAo}<FNiIc;2!TENsPY_{u&vbEN_gH<2W2+zqz;HID|PS7~k-+
+z?orh+BjNq^{SNz=&lq$2>WX$~$Mj-z70FowdoB{TN|h<oa=NkAgwvViq7Zbbs20=(
+zjFf3J3IkKmvhA(1BFfTs0<}wn4tMNcYw*#d5+3#m^D7`Q>2BdYs?$imcj{IQpEf9q
+z)rzpttc0?iwop<FB}NoH|4vN8(!wS{7iPRZAtgAKfwm99$&fQSncFCAHTtkEGq%pm
+zWTY7<`y7xseX%vxnS$7Cg0<;j2&4>SmEoB&V!1aoZqEWEeO-MKMx(4iK7&Fhc(94c
+zdy}SOnSCOHX+A8q@i>gB@mQ~Anv|yiUsW!bO9hb&5JqTfDit9X6xDEz*mQEiNu$ay
+zwqkTV%WLat|Ar+xCOfYs0UQNM`sdsnn*zJr>5T=qOU4#Z(d90!IL76DaHIZeWKyE1
+zqwN%9+~lPf2d7)vN2*Q?En?DEPcM+GQwvA<#;X3v=fqsxmjYtLJpc3)A8~*g(KqFx
+zZEnqqruFDnEagXUM>TC7ngwKMjc2Gx%#Ll#=N4qkOuK|;>4%=0Xl7k`E69@QJ-*Vq
+zk9p5!+Ek#bjuPa<@Xv7ku4uiWo|_wy)6tIr`aO!)h>m5zaMS-@{HGIXJ0UilA7*I}
+z?|NZ!Tp8@o<g6{t!6GGpEZ3+xJO<~FK>-lnyde*H+@8IHME8VTQOGh96&XX3E+}OB
+zA>VLAGW+urF&J{H{9Gj3&u+Gyn?JAVW84_XBeGs1;mm?2SQm9^!3UE@(_FiMwgkJI
+zZ*caE={wMm`7>9R?z3Ewg!{PdFDrbzCmz=RF<@(yQJ<VyM+ly^hkKwrU?N(EcGTG)
+zusbNv5i$F3@Zf=?+&aeDOWDQ7$Qe9+B5{<3u0W4YeBR!LFJjuu&@SMl|F6jRfqiyz
+z{O`I${Euua!vE}0|0A#|Qib%yQO5k~F=XS~vL;+>_A6?PCd_MdUf5vv6G#9Mf)i#G
+z($OxDT~8RNZ>1R-vw|nN699a}MQN4gJE_9gA-0%>a?Q<9;f3ymgoi$O<?iymZH(Er
+zNGvX8A0}*i-nw7954=`Bwhd<ZUjO(yu}|0@?)GI5gP?*)IHp?Eg%^jP>I!=aE6Elw
+z2I`l!qe-1J$T$X&x9Zz#;3!P$I);jdOgYY1nqny-k=4|Q4F!mkqACSN`blRji>z1`
+zc8M57`~1lgL+Ha%@V9_G($HFBXH%k;Swyr>EsQvg%6rNi){Tr&+NAMga2;@85531V
+z_h+h{jdB&-l+%aY{$oy2hQfx`d{&?#psJ78iXrhrO)McOFt-o80(W^LKM{Zw93O}m
+z;}G!51qE?hi=Gk2VRUL2kYOBRuAzktql%_KYF4>944&lJKfbr+uo@)hklCHkC=i)E
+zE*%WbWr@9zoNjumq|kT<9Hm*%&ahcQ)|TCjp@uymEU!&mqqgS;d|v)QlBsE0Jw|+^
+zFi9xty2hOk?rlGYT3)Q7i4k65@$RJ-d<38o<`}3KsOR}t8sAShiVWevR8z^Si4>dS
+z)$&ILfZ9?H#H&l<RT2S~_Jj4$4(IRHJFV0?A!G0Qhg^SAVSGNU@RS<f${jo1F-$bS
+zyW`W1oDY=>umngpj7`|rKQQ`|tmMmFR+y-9PP`;-425w+#PRKKnx7o-Rw8;}*Ctyw
+zKh~1oJ5+0hNZ79!1fb(t7IqD8*O1I_hM;o*V~vd_LKqu7c_thyLalEF8Y3oAV=ODv
+z$F_m(Z>ucO(@?+g_vZ`S9+=~Msu6W-V5I-V6h7->50nQ@+TELlpl{SIfYYNvS6T6D
+z`9cq=at#zEZUmTfTiM3*vUamr!OB~g$#?9$&QiwDMbSaEmciWf3O2E<mlP_PonDwt
+zyitcRzTVrxyJMiqOZ6|7#G@nv5X=6&i;>8?oE0ApScg38hb&iN%K+kvRt#d))-tr^
+zD+%!d`<L4%gYWIkY!vD!A?&@isi9mjq}hc5uLusOi**W156CB;6jndj83!M&a=e4K
+zV{K2_%pB}vEiuAw60U0jUrMlCDCQLmYx75m`l(uEE8=2*7U?XVZesIds6ZgImrC6J
+zaSGNgykYte(u*RGC_Cdgw_=To1Sk<7c@waaCe^q4t!2!@1+<vcCZJJd`WP{XR`nxw
+zGu<m<ZH}qgdl57!HcrTLPnp>i!OOE3in0Q_HzNXE!JcZ<0;cu6P_@;_TIyMZ@Wv!J
+z)HSXAYKE%-oBk`Ye@W3S<fT|RJJ2x9j}N_gm*>hYu-bfC<JlS4ISeU0#72JEq&iV@
+z);;bzD{y$YwCJZhLJpC1#?j@p;n13~AR-U_7}H;)tO$ka&g;YU0hclMs2jggs@V)}
+z1ctUKqL*50yB=^24iD^`6e#NM3t6q_UJr0(0eheaY{0bzc8rmE8>AZ}1|J16hFnLy
+z?Bmg2_kLhlZ*?`5R8(1%Y?{O?xT)IMv{-)VWa9#<mvE`6Fsm;~;S~jwikf)Rjguu$
+z5vQddW;F{QVK_+$;)+G^5Vmb(r-Npc&G#KXM)uo^^@C#o|I{V8-x8LCrE4E&Qq(N-
+zMS66xhsVfaLJl|yc8xV__In+|p9mrG(%HWN_C^hqh)+P9$S6+nJmaAfIxP%v9WfYQ
+zL5;Uu-6T=cz->1pKH|oVRm4!lLmls=u}Lxs44@g^Zwa0Z_h>Rk<(_mHN47=Id4oba
+zQ-=qXGz^cNX(b*=NT0<^23+hpS&#OXzzVO@$Z2)D`@oS=#(s+eQ@+FSQcpXD@9npp
+zlxNC&q-PFU6|!;RiM`?o&Sj&)<4xG3#ozRyQxcW4=EE;E)wcZ&zUG*5elg;{9!j}I
+z9slay#_bb<)N!IKO16`n3^@w=Y%duKA-{8q``*!w9SW|SRbxcNl50{k&CsV@b`5Xg
+zWGZ1lX)zs_M65Yt&lO%mG0^IFxzE_CL_6$rDFc&#xX5EXEKbV8E2FOAt>Ka@e0aHQ
+zMBf>J$FLrCGL@$VgPKSbRkkqo>sOXmU!Yx+Dp7E3SRfT`v~!mjU3qj-*!!YjgI*^)
+z+*05x78FVnVwSGKr^A|FW*0B|HYgc{c;e3Ld}z4rMI7hVBKaiJRL_e$<k+t<^`D)J
+zEhcFT+>rxDW^8!nGLdJ<7ex9dFoyj|EkODflJ#Xl`j&bTO<I#P8edX2Zurtkc%j^@
+zNt6$0k5j7Tz*Hvqfi_&6#Q9+R)Fv6`GmW+`8bq@}anEonN&wkBMSbC3p65Q!BQJn9
+z($6ofVPsfai#?XWp7#{34OEeYG<ZeV`;e33{@dz|B}sgh&`J@Iq}UpnS6~gr0^_2`
+z<OPZ;lTV0rmf6o448!Uqt;aNgDOUMFk-WHp5yxc_@Pw(=_HnwV*fc`$ZOS^5Tv^Xj
+zs6|mx8FjhE6;^Q`ZD8?b*C=D)QP^dT)L|ZTke)O$7uVN>%=$v)c+gJsLK_%H3}A_}
+z6%rfG?a7+k7Bl(HW;wQ7BwY=YFMSR3J43?!;#~E&)-RV_L!|S%XEPYl&#`s!LcF>l
+zn&K8eemu&CJp2hOHJKaYU#hxEutr+O161ze&=j3w12)UKS%+LAwbjqR8sDoZH<g6`
+zeO;HbwrZ9reV{8OM|L-k?0OY=6?byB5<#Ri|6=ZM<cbTpfiMCe6D0+uuN~Snj^GI6
+zBGP94F2>nD<cul@`WjtmWkT9y3u`g7Ep4O>=m0(p62!zg<Af@s3vh7(o9SiY*ZKN>
+zxt!Sj65S<M*Zjht+%5QyX@dTS`ynS|*dw2j79o<R`%(HG^UA0FiEur$J4e>?6WPmm
+zL&U9c`6G}T`irf=NcOiZ!V)qhnvMNOPjVkyO2^CGJ+dKTnNAPa?!AxZEpO7yL_LkB
+zWpolpaDfSaO-&Uv=dj7`03^BT3_HJOAjn~X;wz-}03kNs@D^()_{*BD|0mII!J>5p
+z1h06PTyM#3BWzAz1FPewjtrQfvecWhkRR=^gKeFDe$rmaYAo!np6iuio3>$w?az$E
+zwGH|zy@OgvuXok}C)o1_&N6B3P7ZX&-yimXc1hAbXr!K&vclCL%hjVF$yHpK6i_Wa
+z*<Rda^MN8#r#%H(uhk!|+(Xdsw2E^5cUpnFp8p1^_KFVpjUj=6sF40s6^Zu$9=(bF
+zx1x^nKdB2b8!ICz8ygEJ+y4>CMg1RAH1(EuuA01@lA$sM<OVE;c)%cNQLi9uaS;hG
+z%fi;i)%@4^r8O+Wz2GPMFlZFnH;_-_U9)NAegHj_!}O-ZO`FT{#><S(uSx^)-K{gT
+zhG&r*35&meRW|1;vN}suvoTt-WY!oM-loV8;oR{IcSbtH!As;82qoT?HqV9V3*~qm
+z!SuufxJRefmX+!kF&rvO-e(?VCk%)$MRmimz$37siP-FuaN<K+5pNn#@=eC8%!@nb
+z2*5!qsZ<fp+A*NXf=8**@y(*g7NiBCiEV7bSE-BMr;5Zd;AV+}D!T7#a7AZhy$tZ}
+zBZj0LQc#mui!Lo2Q3KNe2agi@n?}tiW0Rj<VeQ<_*D6y|ViQ@=M%oDn5H>fe*s@9-
+z$jNWqM;a%d3?(>Hzp*MiOUM*?8eJ$=(0fYFis!YA;0m8s^Q=M0Hx4ai3eLn%CBm14
+zOb8lfI!^UAu_RkuHmKA-8gx8Z;##oCpZV{{NlNSe<<V1a7ju;v(TY8|0upX`)YP)i
+zhF9S0sKf|T)6o+<$QQ8snYX%z2pId%K2VdBjyrL|U&7n?j2gqBIlgc7sqRmR3rF|l
+zlUaMtZ*=q~vwXXK9=bFWx14^H@c)%dSINC6uKh#1>i;9!MfIN!&;JI-{|n{(A19|s
+z9oiGesEN<ynV})!iaH~auE<DSv%{<&k~X$kQz2b-qcNkA8P@0{SIU`uY<?@NmTQBx
+z)D?^>cLf@NN^9R0uIrgg(46r%kjR{0SbnjBqPq()wDJ@LC2{kUu_j$VR=l`#RdaRe
+zxx;b7bu+@I<Nh=^5@s63-0S!f#dfXn@}AC1>ntWaV$si1_nrQpo*IWGLBhhMS13qH
+zTy4NpK<-3aVc;M)5v(8JeksSAGQJ%6(PXGnQ-g^GQPh|xCop?zVXlFz>42%rbP@jg
+z)n<qUy~a=5h*jh6P7t^JBt^vIyENcV7ST}KUA-3{?3CB)-Fh4a#gMRWaLCBu<v>)%
+zM9anq5(R=uo4tq~W7wES$g|Ko<i2Il^N$GIC?!+;wqh32G+daBXSzA(l7+`)WY5H*
+zxN4$-v5B6xdBXsPjBQ?{pU&2{p1fGEo~A^$<7<6Ai9r_XJLEi2ERS5-WM=rJMwjp>
+z1iNIw@-{x@xKxSXAuTx@SEcw(%E49+JJCpT(y=d+n9PO0Gv1SmHkYbcxPgDHF}4iY
+zkXU4rkqkwVBz<{mcv~A0K|{zpX}aJcty9s(u-$je2&=1u(<Ijk*osoSbRG#RG2dxi
+zY2dIgjpsHFWw4YgUuLN}C3yiVDS7TfH_01AHBUEe$&x)yg`w@~!r_*o_*~bpU7c<5
+z`bmK&NU6Nw_v-jDi5@dldK4Fn1A<6r>e#Q~UA{gA!f;0EAaDzdQ=}x7g(9gWrWYe~
+zV98=VkHbI!5Rr;+SM;*#tOgYNlfr7;nLU~MD^jSdSpn@gYOa$TQPv+e8DyJ&>aInB
+zDk>JmjH=}<4H4N4z&QeFx><vCqo(8;VBNf?4{-ejyJD7h1Z5Qh!VF^s0~(Sx+W_U{
+zR};ybxF{rNR6jf3&Uli%SD1<DGAon!MxCaTjg2UoiPv{%y|HIy7wF&Vh+2it<&g@k
+z2+Wf#)mx-UNsAjpU<5>1VPY8GU&^1c&71T*@2#dINft%ibtY(bAm%<2YwPL?J0Mt{
+z7l7BR718o5=v|jB!<7PDBafdL>?cCdVmKC;)MCOobo5edt%RTWi<zJmle+?jwNYxN
+z4^6|EAjKcb86Lhb2TiEBh#*!<VO%f-!t(A33YL(fW`@*JF%L#%9n~L_x_&@iQ8p+r
+z50!J0d4(u}33+T-j40yL1x4WL)VTLI3<|eCyY3_SBtK8>ReAMaIU5X9h`@El0sR&Z
+z7Ed+F<Hz;iLDs#Hc0AY<Bv9{VG$$}Nxol9pHZ;R^PVSOq1+c`wf56t4>iyA+QAyWn
+zf7=%(8X<IsS*x5)IZjAvYsetv<jbdR10P8%td<*r6IM&L5LRrcOf|!8RQAgg6~$_=
+zBSd>pcS*C4^-L24TBUu%0;@s!Nzy{e95qjgkzE<W5xLBBDYXZDXN}?0z#DvAb||%H
+zZPS{|8~$Dai+w3|r0z;7J8SaSbF0|4F}$?B9(zK4Hfql>lf0#ou`sYng<}wG1M|L?
+zKl6ITA1X9mt6o@S(#R3B{uwJI8O$&<3{+A?T~t>Kapx6#QJDol6%?i-{b1aRu?&9B
+z*W@$T*o&IQ&5Kc*4LK_)MK-f&Ys^OJ9FfE?0SDbAPd(RB)Oju#S(LK<CirA2f_*u2
+zok`__!UM2k24u<34N&n2<rv2c5C+LG1_2&glf5C-MnxH;!hzUTv-tAoF?gV=0tG&*
+z&3NTXW=(G6=cQ0qDpT;#Hy7t96N4?Q={0R{&UH=JEWgy<75@6brLBmih;_W+NcLKU
+zn<HoD>)?EVandS1qb#KR;OP|86J?;TqI%E8`vszd&-kS%&~;1Als=NaLzRNnj4q=+
+zu5H#z<eB8n3vpKCZ_UBe2i$XZJvzC|oStL%r*N4lp0t3D`s9hT%+m%jPcLdrJAA8K
+z_Xy5FTlYi&>)BDKHo1EJTC?Cd_oq0qEqNAF8PwU7<g1n3gpVtS#>fK!-WwVEp4~4g
+z3SEmE3-$ddli))xY9KN$lxEIfyLzup@utHn=Q{OCoz9?>u%L^JjClW$M8OB`tx<B9
+zZzQvx^C^)R6f_#j34$T{qWzMIebqUHU#Mm4dIX;v?G*C~teYh!pha7{DB@cX4KxPS
+zH^Q;NkvbuF4d_@se8XmvFleR*sC@ep>g4r6Q-6UlVx3tR%%Z!VMb6#|BKRL`I))#g
+zij8#9gk|p&Iwv+4s+=XRDW7VQrI(+9>DikEq!_6vIX8$>poDjSYIPcju%=qluSS&j
+zI-~+ztl1f71O-B+s7Hf<J;>>AZ#}DNSf`7C7*)%(Xzf|ps6Dr7IOGSR417xsU=Rxb
+z1pgk9vv${17h7mZ{)*R{mc%R=!i}8EFV9pl8V=nXCZruBff`$cqN3tpB&R<?rJ^^G
+zLU#yZbVti(nuC|2|IXia=NN6mqd+?dR)7Jc*9;iC!a;f?+=#<s4C&g0_&NB8weC%l
+zS<iNL{)P(<k~BWt3Y%{Xrbk9d#iq+t;G9E%F%_rY<%%AD^lw^bplw!%%|-aF&{mk{
+z8v%Z~T)@9qJANVDtF7i6j_uAG%PQrIzYL<`zWN)?kg5G%9sC$@=vQ^>K^$yH!A8RL
+zJ5KltH$&5%xC7pLZD}6wjD2-uq3&XL8CM$@V9jqalF{mvZ)c4V<q)vM?$E(wfOg3Q
+zv%+110#sykOiRSt?0@;lgu4A3JD@U~_wpzdHgwI1fA5o$81_b21C0iEz!;O~RRRX1
+zGlEi0gdqWrOw3XkgEa2cwZ#ieSM+Bwx5supt!d$Nc0%<IFUjN0oH@W~IsyX(WZ$<d
+z|MaryZKLL%mzThJyCC#$>n?xXbvkB(q%<Z{kVQ;%LF$(<$dK2qdz`UK^3urTrD0B4
+z1&)CdFB?t|pWnGgd`vO!l5yW5V|rGsYb-Keu0g!I*6%Xh0JZtqeMa&LE(4Bo#scEB
+z2+Xh0IF3fHxOvz(nbw5~LC>xbSdjoXJXanVN@I;8I`)XlBX@6BjuQKD28Jrg<b?I+
+zxnRcDtmgY@D96{&H=|gt1$AWNvdJ3yEL}1j876RHewior=;z@yI+m%vO5~lw`>05}
+z^ImmK-Ux<q>*QMn_A|1ionE#AurP8Vi?x)7jG?v#YyVe_9^up@6^t_Zy^T1yKW*t*
+z&Z0+0Eo(==98ig=^`he&G<vo(#Q)G{9SIowKW2Tx<>^K$I!F~1l~gq}%o5#pR6?T+
+zLmZu&_ekx%^nys<^tC@)s$kD<AcM417>`^r8)1^tUazRkWEYPw0P)=%cqnyeFo3nW
+zyV$^0DXPKn5^Qi<LfvSpMIU#o(EG&Rpi2B@a5@RzAAQS3*j%A9U;6sg<98@jyPDmC
+zXKg0?&ACu)O$sr|d)+$ZH;RJR7V`iC489P}wQ3gU*M+C_X7Cw%nw^c(gNH_oV&C^!
+zc5Ja!U#d<n%*)0OuX(xIWS}X!VI4G5%&+mH^jQka0XK?`B*^+~@VtKToDTaE*!8R~
+z<nPU#JZXd+QYE>OtOi4MIX^#3wBPJjenU#2OIAgCHPKXv$OY=e;yf7+_vI7KcjKq%
+z?RVzC24ekYp2lEhIE^J$l&wNX0<}1Poir8PjM`m#zwk-AL0w6WvltT}*JN8WFmtP_
+z6#rK7$6S!nS!}PSFTG6AF7giGJw5%A%14ECde3x95(%>&W3zUF!8x5%*h-zk8b@Bz
+zh`7@ixoCVCZ&$$*YUJpur90Yg0X-P82>c~NMzDy7@Ed|6(#`;{)%t7#Yb>*DBiXC3
+zUFq<q;<NLVE3q+|RY;{7>(UDFjrgOsc%0KJ_L;WQKF0q!MINpQzSsqwv?#Wg+-NO;
+z84#4nk$+3C{2f#}TrRhin=Erdfs77TqBSvmxm0P?01Tn@V(}gI_ltHRzQKPyvQ2=M
+zX#i1-a(>FPaESNx+wZ6J{^m_q3i})1n~JG80c<%-Ky!ZdTs8cn{qWY%x%X^27-Or_
+z`KjiUE$OG9K4lWS16+?aak__C*)XA<mn7dO1IQ<7rt}jYvLS-$H~f<X5+N=(Ek`&&
+zUWHe^|Bwj1`@oeHlPUTz8D*6r?NpHjHK-@Dqy;NDtS}cg%!YayC0fs^iN;OYEP9kK
+zo5Vht9oQS7iDhR-OPXj9?q6@S&eFy#n-1R+kA`A0*{=#t%}!LRAXjjRywc~_uNoSv
+zszK4MM3XQ`!AP4Kj^Rx*7iMfV9^D$9ff(?N=BiGkohxx7DcQNG_tP#nT3_=hI7YLo
+zGAoH*rjQg^W(ap448geJyg*-Zsf^RAr9lW2dRNFv&HLWl7oARenT?<M#Z5`E1my@r
+zEvZ)*EFhV=Xn(d!ux{Tmfc~sd_)m;R7maZ)e8qGMx=q|X7Apwv&(Z7nX5hp;7Fa>{
+z6HmS*8#t_3dl}4;7ZZgn4|Tyy1lOEM1~6Qgl(|BgfQF{Mfjktc<V73_^4Y*JAxZ9&
+zk;vp)O|oP#qgjAs8&wb~jCgfwsBn#A5JV`I8M5Mt;ki^ey-B;1sC5O4oRWjC=0x>h
+zB5kc~4NeehRYO%)3Z!FFHhUVVcV@uEX$eft5Qn&V3g;}hScW_d)K_h5i)vxjKCxcf
+zL>XlZ^*pQNuX*R<VIWU<&k+#O#z05{>JQn)b6;blT3<7@Ap)55)aK3n-H08GIx65W
+zO9B%gE%`!fyT`)hKjm-&=on)l&!i-QH+mXQ&lbXg0d|F{Ac#U;6b$pqQcpqWSgAPo
+zmr$gOoE*0r#7J=cu1$5YZE%uylM!i3L{;GW{ae9uy)+EaV>GqW6QJ)*B2)-W`|kLL
+z)EeeBtpgm;79U_1;Ni5!c^0RbG8yZ0W98JiG~TC8rjFRjGc6Zi8BtoC);q1@8h7<W
+z{%QU=f~@E{*75;EPtq=QOC=`G(0Hdr_HmX;s)IO`uOsm?hi;HPRH2DMN!8p_6N*mR
+zXeVd+rX;e|)D{nmu3FxC){%4`fvkUoMM~{w*jYq7&hHz|64x(?E6&4jG;eJ*jSB0z
+zWIII4*kn~Ve25Pk+1h=4UMO&Fvq`3&FqVW1qQ})@8We8E6!Yt^Nic_&{<S5dR(OO{
+zb5!CWQqPU+0jYF<lXRIyMn^4F&DA<&TE_&-%x*k9PRqAjBu2+9eB|q?j^5xDz3>UV
+zFa&LRzYsq%6d!o5-yrqyjXi>jg&c8bu}{Bz9F2D(B%nnuVAz74zmBGv)PAdFXS2(A
+z=Z?uupM2f-ar0!A)C6l2o8a|+uT*~huH)<BklnFF@?8S@YKGOgvIkgvy?bVNlgCB_
+zoqeDw{3YNZ=l`nrK(ag;cr55JL-h60|J5N{s-NkNhFkQ*iwcZIFaTBfOzrkQWLJ*V
+zICw*3^B@Set{3BbuO`R#p?&bEzj(u;_I4rvE}iY2Q^FV4RYK^P{cWG=Da>!h3i!&$
+zr>76mt|lwexD(W_+5R{e@2SwR15lGxsnEy|gbS-s5?U}l*kcfQlfnQKo5=LZXizrL
+zM=0ty+$#f_qGGri-*t@LfGS?%7&LigUIU#JXvwEdJZvIgPCWFBTPT`@Re5z%%tRDO
+zkMlJCoqf2A=hkU7Ih=IxmPF~fEL90)u76nfFRQwe{m7b&Ww$pnk~$4Lx#s9|($Cvt
+ze|p{Xozhb^g1MNh-PqS_dLY|Fex4|rhM#lmzq&mhebD$5P>M<DmANA7)v1?A&u8?r
+zN#V^qY31R$$uOM7e!;99G3zfzxBI#kn<K!x%{#o+a5>$eqLoV|z=VQY<HWnoG0tOv
+z69l8*cSEJV=QU?Ns^-R%Uq*rJ%^Z2p;<g;km5p_x#;n0NJ&|94gMZ|Q>{)7&sR#tW
+zl(S1i!!Rrg7kv+V@EL51PGpm511he%MbX2-Jl+DtyYA(0gZyZQjPZP@`SAH{n&25@
+zd)emg(p2T3$A!Nmzo|%=z%AhLX)W4hsZNFhmd4<1l6?b3&Fg)G(Zh%J{Cf8Q;?_++
+zgO7O<(-)H|Es@QqUgcXNJEfC-BCB~#dhi6ADVZtL!)Mx|u7>ukD052z!QZ5UC-+rd
+zYXWNRpCmdM{&?M9OMa;OiN{Y#0+F>lBQ=W@M;OXq;-7v3niC$pM8p!agNmq7F04;|
+z@s-_98JJB&s`Pr6o$KZ=8}qO*7m6SMp7kVmmh$jfnG{r@O(auI7Z^jj!x}NTLS9>k
+zdo}&Qc2m4Ws3)5qFw#<$h=g%+QUKiYog33bE)e4*H~6tfd42q+|FT5+vmr6Y$6HGC
+zV!!q>B`1Ho|6E|D<2tYE;4`8WRfm2#AVBBn%_W)mi(~x@g;uyQV3_)~!#A6kmFy0p
+zY~#!R1%h5E{5;rehP%-#kjMLt*{g((o@0-9*8lKVu+t~CtnOxuaMgo2ssI6@kX09{
+zkn~q8Gx<6T)l}7tWYS#q0&~x|-3ho@l}qIr79qOJQcm&Kfr7H54=BQto0)vd1A_*V
+z)8b2{xa5O^u95~TS=HcJF5b9gMV%&M6uaj<DG%?NLS@ZBcw~|?Ph?A!$GyTtN#J(n
+z(N#33Z&MXkLNi3tlx}v1EUFXC!E2$+1Uui1Bx24YZRI7U{9C!4ye6`#_fxLyx><>E
+zPNM~qGjJ~xbg%QTy#(hPtfc46^nN=Y_GmPYY_hTL{q`W3NedZyRL<bGaMku?v;})8
+z39o7JEb=3hqE?4Vw{>^kgU@Q$_KMAjEzz*eip`3u6AhPDcWXzR=Io5EtZRPme>#K9
+z4lN&87i%YYjoCKN_z9YK+{fJu{yrriba#oGM|2l$ir017UH86Eoig3x+;bz32R*;n
+zt)Eyg#PhQbbGr^naCv0?H<=@+Poz)Xw*3Gn00qdSL|zGiyYKOA0CP%qk=rBAlt~hr
+zEvd3Z4nfW%g|c`_sfK$z8fWsXTQm@@eI-FpLGrW<^PIjYw)XC-xFk+M<6>MfG;WJr
+zuN}7b;p^`uc0j(73^=XJcw;|D4B(`)Flm|qEbB?>qBBv2V?`mWA?Q3yRdLkK7b}y&
+z+!3!JBI{+&`~;%Pj#n&&y+<;IQzw5SvqlbC<hrT)sBs!K|EW5H^76b8wi?&5jaqoB
+zdZ2NRMM|}GTQWlnULm3*Tw}|kY|0D0spF;??&YCTeOo~Duw_Bz&0>+V=kLZLAHOQb
+zS{{8E&JXy1p|B&$K!T*GKtSV^{|Uk;`oE*F;?@q1dX|>|KWb@|Dy*lbGV0Gx;gpA$
+z*N16`v*gQ?6Skw(f^|SL;;^ox6jf2AQ$Zl?gvEV&H|-ep*hIS@0TmGu1X1ZmEPY&f
+zKCrV{UgRAiNU*=+Uw%gjIQhTAC@67m)6(_D+N>)(^gK74F%M2NUpWpho}aq|Kxh$3
+zz#DWOmQV4L<sDJGB1~xI&#K@a<rftJ&W$tS7|})}p7LCV^RAnbsUrP_V*uhk=;!pl
+zs4zoj`KucSBFKjBcKXW*EHB;&BS$tidMG;U{H8n7wJ)AAvB2L*UBNbpb;dN7LsCrE
+zL;cL{W0B-y=uz}$?A3Z<^oG{u-AX|Svz(WP+@{ryM8&-@TzJ+nBT;gLmX|TuUS7tX
+zbu7uYkz$71L||aR32Yb{k;9>g&}`XTU41Z|P~5;wN2c?2L{a=)Xi~!m#*=22c~&AW
+zgG#yc!_p##fI&E{xQD9l#^x|9`wSyCMxXe<3^kDIkS0N>=oAz7b`@M>aT?e$IGZR;
+zS;I{gnr4cS^u$#>D(sjkh^T6_$s=*o%vNLC5+6J=HA$&0v6(Y1lm|RDn&v|^CTV{=
+zjVrg_S}WZ|k=zzp>DX08AtfT@LhW&}!rv^);ds7|mKc5^zge_Li>FTNFoA8dbk@K$
+zuuzmDQRL1leikp%m}2_`A7*7=1p2!HBlj0KjPC|W<t!gw4p)|NM)%cW9T$k`o|lfo
+zg*aR{7NSC?*?~1-ovU>T?5{_aa%}rQ+9Mqcf<RjoiaEgO6aLbf%7cdA%8(Z(Lepcg
+z;EK+)sbwoSMUuni>XI0NtjvXz1U)|H>0{6^JpHspI4MfXjV%1Tc1O!tdvd{!IpO+@
+z!nh()i-J3`AXow^MP!oVLVhVW&!CDaQxlD9b|Zsc%IzsZ@d~OfMvTFXoEQg9Nj|_L
+zI+^=(GK9!FGck+y8!KF!nzw8ZCX>?kQr=p@7EL_^;2Mlu1e7@ixfZQ#pqp<X+0Re_
+zrJ{H^$-Z@QA7ETVM2%a&#GG%~hgC@{06tyBwQZmlXSm57v9B9QX(aJLI_U;c+x!4Y
+zc@Lpfn;l;r15OkOarCAT2KT0TI&b@nuFwDm5s2$h*ySA~Ad%ZKk`|FTjsVplUIi{5
+zlFa?pIp_hLcE?CXH;$pLba~E##@hT^OvK63FoxCFx@_5ii6TR$R#n$|+i^+&#se{6
+zDr7|zkeVUxEFj8#1(pWjg_@>yCJ```(m;la2NpJNoLQR};i4E;hd+|QBL@GdQy(Cc
+zTSgZ)4O~hXj86x<7&ho5ePzDrVD`XL7{7PjjNM1|6d5>*1hFPY!E(XDMA+AS;_%E~
+z(dOs)vy29&I`5_yEw0x{8Adg%wvmoW&Q;x?5`HJFB@KtmS+o0ZFkE@f)v>YYh-z&m
+z#>ze?@JK4oE7kFRFD%MPC@x$^p{aW}*CH9Y_(oJ~St#(2)4e-b34D>VG6giMGFA83
+zpZTHM2I*c8HE}5G;?Y<M+?LyWn?03qS587BS{lq0V4R8#J8=B>7RXMA2k{Y?RxHb2
+zZFQv?!*Kr_q;jt3`{?B5Wf}_a7`roT&m1BN9{;5Vqo6JPh*gnN(gj}#=A$-F(SRJj
+zUih_ce0f%K19VL<E3HrXlqqoBf~c20@9ozE$2qZsljz1QN-PVpQS1W!)YMjSijFXX
+z{P)`?A`eAJ?oh<!djz+PC3lVbl99-ayrp8oi=_canYFfMH62C}^0hP3`X)L9+i4`Q
+zm?I7fbusV!Jv(kfxmM>Xi5(<VS*XQmy2&`ZRfWgKV9~k|yVKp~M)9<_9P`znoH<lN
+z$~@NdPe<+%!i}Jugmv9Pnb}eLR?O8Po%je^XGWy*@HH7__y8%?t*~t>VBGOFbc(YF
+zLvvOJl+W<}>_6_4O?LhD>MRGlrk;~J{S#Q;Q9F^;Cu@>EgZAH=-5fp02(VND(v#7n
+zK-`CfxEdonk!!65?3Ry(s$=|CvNV}u$5YpUf?9kZl8h@M!AMR7RG<9#=`_@qF@})d
+ztJDH>=F!5I+h!4#^DN6C$pd6^)_;0Bz7|#^edb9_qFg&eI}x{Roovml5^Yf5;=ehZ
+zGqz-x{I`J$ejkmGTFipKrUbv-+1S_Yga=)I2ZsO16_ye@!%&Op^6;#*Bm;=I^#F;?
+z27Sz-pXm4x-ykSW*3`)y4$89wy6dNOP$(@VYuPfb97XPDTY2FE{Z+{6=}LLA23mAc
+zskjZJ05>b)I7^SfVc)LnKW(&*(kP*jBnj>jtph`ZD@&30362cnQpZW8juUWcDnghc
+zy|tN1T6m?R7E8iyrL%)53`ymXX~_;#r${G`4Q(&7=m7b#jN%wdLlS0lb~r9RMdSuU
+zJ{~>>zGA5N`^QmrzaqDJ(=9y*?@HZyE!yLFONJO!8q5Up#2v>fR6CkquE$PEcvw5q
+zC8FZX!15JgSn{Gqft&>A9r0e#be^C<%<F$|nV^6m7s?pfGWrS!*h<5zg%%}lEg1TI
+z|E5UO7&eitGHgtFuU&)>)psE*nyW^e>tsc8s4Q}OIm})rOhuc{3o)g1r>Q^w5mas)
+zDlZQyjQefhl0PmH%cK05*&v{-M1QCiK=rAP%c#pdCq_StgDW}mmw$S&K6ASE=`u4+
+z5wcmtrP27nAlQCc4qazffZoFV7*l2=Va}SVJD6CgRY^=5Ul=VYLGqR7H^LHA;<kSL
+zyrh(Zd)qJDxpzjXJoFc+eRH#(kkiWb-uI_%f85g24L`FdF1fP}Kg{iZ+*Fo8ju*cl
+z3Aw1YGq0cxadL4N9aS#>H^1g}ekn=4K8SPRCT+pel*@jUXnLz+AIePjz@mUsslCN2
+z({jl?BWf&DS+FlE5Xwp%5zXC7{!C=k9oQLP5B;sLQxd`pg+B@qPRqZ6FU(k~QkQu{
+zF~5P=kLhs+D}8qqa|CQo2=cv$wkqAzBRmz_HL9(HRBj&73T@+B{(zZahlkkJ>EQmQ
+zen<iPJWnXR=;Z=9fu?|et|Rb%*gDj8sMD`ZMBMaR)@W4I!@ZJ=6-0EUr*wDEx&_hw
+zhU+|E`Yc!V0@6Vf^U<QOMIE_YSpmh%i+yFO|G~yVs99EScY@d$n{uR4Xtly{afZWj
+zO}~7A(I*J<@B|oPywvLj91a5kZfNN5H=|EF#}if+=~cl#!%<3XeHAhGPkCdLS{G`f
+z#i{^H6>p59dy+L;sSWYde!z_W+I~-+2Xnm;c;wI_wH=RTgxpMlCW@;Us*0}L74J#E
+z8XbDWJGpBscw?W$&ZxZNxUq(*DKDwNzW7_}AIw$HF6Ix|;AJ3t6lN=v(c9=?n9;Y0
+zK9A0uW4Ib9|Mp-itnzS#5in=Ny+XhGO8#(1_H4%Z6yEBciBiHfn*h;^r9gWb^$UB4
+zJtN8^++GfT`1!WfQt#3sXGi-p<~gIVdMM<#ZZ0e_kdPG%Q5s20NNt3Jj^t$(?5cJ$
+zGZ#FT(Lt>-0fP4b5V3az4_byF12k%}Spc$WsRydi&H|9H5u1RbfPC#lq=z#a9W(r1
+z!*}KST!Yhsem0tO#r!z`znSL-=NnP~f(pw-sE+Z$e7i7t9nBP^5ts1~WFmW+j+<@7
+zIh@^zKO{1%Lpx^$w8-S+T_59v;%N;<ZZyRu1Je84c8pEeE|Tu>EZtJzcfN%&@(Ux5
+z@YzX^MwbbXESD*d(&qT7-eOHD6iaH-^N>p2sVd<d@hTC>q&(`C$;?#mgBANIc5$r|
+z^A$r)@c{Z}N%sbf<VV6f)%mV{w>o?T`tTHz9-YpiMW?6>kr&W9t$Cuk{q^g1<$I~L
+zo++o2!!$;|U93cI#p4hyc!_Mv2QKXxv419}Ej#w#%N+YIBDdnn8;35!f2QZkUG?8O
+zpP47Wf9rnoI^^!9!dy~XsZ&!DU4bVTAi3Fc<9$_krGR&3TI=Az9uMgYU5dd~ksx+}
+zP+bs9y+NgEL>c@l>H1R%@>5SWg2k&@QZL(qNUI4XwDl6(=!Q^U%o984{|0e|mR$p+
+z9BcwttR#7?As?@Q{+j?K6H7R71PuiA^Dl$=f47nUKL|koCwutc_P<-m{|Al3C~o7w
+z=4S=}s5LcJFT1zjS)+10X_r$74`K78pz!nGGH%JV%w75!YSIt#hT7}}K>+@{{a+Im
+z5p#6%^X*txY?}|T17xWW*sa^?G2QHt#@tlcw0GIcy;|NR2vaCBDvn=`h)1il7E5Rx
+z%)mA4$`$OZx)NF5vXZnaJ1)*cA6ryx6Ll~t!LzhxvcTedxT;>JS&e=?-&DXUPaQ2~
+zH*69ezE`hgV{K-|0z|m~ld}=X^-Ob={wpex&}*+Rz{gx)G}gn!C_VN{UN=>^EV=Xc
+zr$-HO09cW&p4^M}V3yBjTP_xrVcc8iU_^Y-JD~(bgw*@GXGB1gYKz5DWO+O`>})|N
+zWrC)MR<YoNN@dNjcYj<b;OF){>93yA)3{&27-M)TJB6Ml3~?zZg#mYsF=#OSTaw&K
+z@hBftpt+2l@)YK@|3DvTjl(8wZtpLp<?0%pKTY3}XX{MHIljL%Fw{_Z|9d-yvblgQ
+z{!wyH{yqQi?Iie*$>9Ik!6G$CSL_idZ$Ti?R)4toe8bb)l|)lNb}?K;O2K9vyn1QG
+zd=v#y-Ld49UVkmfRU>Egc+(Y$^-;6vW;3Lcu*6~etz}0|@+b|+!UCal)DEYGLbHWJ
+zll5Wi^<vfZ?T~^`8=zPM$Z@j*S$t!Y<EhDvm+zMzHqRrjoNgJR4PlwtA%~M-7oKg-
+z@*>$Y<6@S%^y%hdjRh6&{!z1Py|lZ|q&Wub3l41uN2zEF8E&5H5?PL*&V}?*a}Lp%
+zCYi{ghjpRNT^^B+_U59No50Ghih5qn(W5`RkrsDWr{~A1dgtv{sRkH4RU2^A{jb&0
+zxVRnrm|u<;$iI;M6A>$POP)TWGU-gSjAERk*EGmVT(aw$!XUS<asJ?{P8@w6qBfov
+zI%`}^njNd1_{}A_uRkev<-TXKuoiFlFOyqT%8rk1`2%BKM5Z+~M&?E}fqqOZAZVB5
+zNS{DO+i9FHCCFSvH|Q|2xQ%x$MZhjBSt(99856FiHO!aT?oD?|(v2KHy<imYT_Zl)
+zzM{QvD-38PfU~%Cj@UhZn!-(N#6a8!Zp46^fmJDt%0~G+`{28Ol&R+}En*ZB(Ap5-
+zS3xTHV!d88{~H$@*|Xf2m9Ev~cClRLKWq-Dy`0?=Ka(0bKO7k6Ia^0ek#FeuLW^Ka
+z+29SP{BV|X`LItvfG~$^QN1DscL6_hZV#x+g@RJSzbH{*7vi&EuO^0lmWyRo%n-;p
+zrQ@enXxznWo93lX0onG|8<ExHhjsVv&yv#5$}JubQ-~k2)eX#tYEp#B=ZL)3W6xvQ
+z^tSx&3RvXN^2EDb;%<?Qv9hrD;ImRS1@Ev)+k3=jO{~2fBe<e5TLY_Vf+5&KlA(i%
+z-tx@Qc4VuOh0tKo5#`$=9<^cjcq8Ip7qpr<1+>e~7Ql-oRA54^4V(JWS6Q1mG?!vZ
+zx+pE!FEtvqr|Xrcb3oR`%LHFLmU_&{<QAAHttd1Er^!DxXsl03mv0y!k#PYpGSMeW
+zem^VXYsEEPcK*)T#s$EH8n9Tms!@q~oOuVmpZ((3>=p%mGy6MRe2Yz_5WJ8p@IgU2
+zdVvvhhQtiQkChK%*&PsiPCBL9oDOoJX8!$S(V>R}+1M}wzK*U*A{KJ`r=lM;mPrKU
+zQDqqN(W*u-5-?$(SIk<6A0E}34y&@-IVC%S!a1F4kz<3bIKjlyD)ooO_7ft<QDC;4
+zO#}hIX3cX+ou-UMWv@FumqiR;#JOI;$Lna5#MA^fv9k{O*GC+<$Nq+kGZ+M%7QHYI
+zk9IArOT7c%DRktDP2?F4i2($6s%HL>l%S_(6w`!vX&1PZ!K`@D@L6JR)6zO@Dl!<l
+z=BdWEtebJj+jz>YF{R<WP!R4PHXBT&cyt|IAe~n=dcnCOe*w5G5oS~}#&qbcuT(6I
+z-K*(&5{r9`!3B<qxqwHIOne-7;C;+8dR9=$r{8B+k8sIfec{W>Y}d3HZ7?Q5E>w=$
+ze)H_)48Ds*Ov4?zoGb2fe3}{!5Ooc|KCIni1o)(Gj+CO?`*7jsV`hIv@8J(22o4Q?
+zu?Bvi)zDG<OK;2aO}BggmGd-%r>(me?7XKeL|iF9ZRgZdT*}Ffsl62Cu;{Gv9j6dO
+zPt*H2GqC)-C`V`ceuu=tM{7!2yTEj=*5+T~5DYiZ)Hy)*PARYI6R2lZXoOj;v8M4W
+z*O-NX(7_~Q&A3>Oaw&1lBH_H%SwmISX-i3)HfHvBOeVwTT{LUM3}ZuZmg<(>)KE;d
+zbs2!0v6>J;1nQ0UJkUxnkE@Ibi~Q}M=-=Rk;hcOnxO$luOKEVxZc|!XECgex(2`}T
+z3Y;Q_6rL)e+SrOZhQj5_e}Lv>w7n*Pep$yWZNQl>ubBgb_NIWWDn3kNpn+MPQXV;8
+zV|_Ba5jsQ(w&Ey^IM|@|y!AqcJ#3m0#Q6_qvgCG~eoF#mnGmbO(;DP+bW%_aOs1R_
+z@9p#7X2UA^--#Nwx_Hvk2l1`eO{P*#j@q2UELtH|Uh6<W{C0d%;SO*X17Hg*_nhVo
+zUj8d@XC~-{FK%b15_u=5Zi$$rw|PRP{3P&%r4IFKW@%M_k3l}b-a!ZM6ZqfV-oe0z
+zHcS2@f;}*ROge~8O|p+DJW!EVo_da^QYfpcqO^~19<4~HG-T$^cIunesE=MWKhim-
+z7Goy+*ll|&6M44>hxR`h_847wIJo0=5CQQ`6it|%a-I$^&a@we1rc&*;QIu5Ck^?)
+zx*5eSd*mG#=6Hi(5!;5uUi&{HfnT1S8X-)?gE5CZ6KWoqM5|CyrULmuFBKOU8SOp*
+z{IB1$OCcq`S-k*xs;4fmhKsIGZ;GYAY*%(@875NxhM<x^qSdQMzkq<XP|<&O=Wdj5
+zG5b8jqr5|XkTRdFnfoy|e#_<2FW~3dCqmjftH}M+1ln*+nwXqXXr0NK&8fHefdP~`
+z<>q|j*m4CNLI(Vho|N|F);!E0cS5y^$H^Izje?z}oTgyr`9x9G&rlJZw&uqIoBMtz
+zzhU0(9;w02?m#0!)cFi*r+8YvooQ;(s2lLVvyLqAE%Xqe!vtWbIs!l1Bpp(FIht-Z
+zPn#CN-2C|J*GhA2fuHqYQ2mJiXlGTzD}mkr2;ia8Wp}h^;OS7+N^M<nb8{1bSa3A+
+zL8!27%|p8>w|en!1${vN6<B1T15(f#0UdAk{Wr$+OIZmA!F!Rj#Z~!T7({o*mB$j>
+z-x{8N*4UekA~`IV2&K-GzhAqau|}d*pEQ$1MH$cFi03OG^1NetZ_jW^STaEzr&Xho
+zB452St%v3ez2#TFm~`gZ<UBEKV7u<uCXTZP`7$*T39B#gt?T&`4)K;E&|ZM6WSMdG
+zebuH**%SihzOx;;CUDFI*)EgzXx=I3<*D-whBHjKN-pq1#;zw`)Wn{zX$8V;zVw$q
+zbhEvq3kJ(?s``MV!AS6_c(5D)L4tK*Aw)gIAhX&Z%n4p62=O5*U-Y5Ba)ZL6Adcrk
+z)x8`?1tz4OdUR+*taVv0tA0F%j2gu>h$vi=in+y2d!z<{OZ~Kty-5bQ;0O<LNwDnI
+zC}8-6mq`yuqDIHx`*=Y3Ma%=;%#E>=k_ESi8Nx9{*T`LJy6jqR>&|+>OZ;+=0hA04
+zE25t^sE9HG)3^<Ym7m{BQ^G!z>KKR_A5WDkqispweP9!I-@dCO&N!JrD@i{WBHnfQ
+z95o8;d$`AFnca3;N-0iX-CmbbAp5yQ!GoH;h7Cn?m{ammZJI8igP{U73lFnl2&gCs
+zqJ4(Vo~^j`{zOA<UI~9WX4R%(>zScL5B_Sm?Mjtek1d(A6X5ObcZi$;aOYy|g$}BY
+z$GEP3#i60Ju_&3SHzryH!gUFwC9-295u??cf+aYRQ1$+!rc#42YNattd6mZEFI@?C
+zqFM>6+zxEunIHDZ>{Z15u##>N(28Dw!>G(k*dB{NHvip@aP}f`@=Q;!o;zRMWo{Cx
+zo?kyzh8n7#f1g0&g>Cd>O-2g?uPwy8sy8hZbHSsXPmU;@l=HL=zm7mN(=@*|D$i+u
+zs~TllkCTvD$f&-#b9B?}#Lg*-ibK13R_a$RyoN3m5`10tdhAq{+VW)K#Bht-ra1*J
+z+n$N%V>u0rVtx`aKJDwXXrxa<i8EX06UO&LLD=n5qGhcYvn1Mgi;G^)TV4yilP*(Y
+zoKH+I4#~X)gA)B$;S;Huvs1a%d&HL})yYqqyVy1<B|Kl_6$aedKOq)GM61zpA^OQY
+zD*lN>D7nS<>$=c82v7<sDF~4nP`e39${9XIsr;e(ythhyAUnjOkWQ<YzhIcj{t&n{
+zx(8T~Ps>@KVx^S@vT;h=SZE37K>iahpx3;VDzEr9GY=2(%uaqM;^76eSP0QLzo4sI
+z>p_Eei*T$K;|qK`sq;?Hesp}(@VvX2Q4sAMYAJ}b&d$htDMC{FG-$o4k9ApECi1$a
+zXdamjiOGKHBh(4M<3(2x6n-CrmZMCknkQxdSS!qlis#I}btfX;J`JU3RlvtLdrymP
+zG0ZzrsGXVFiq+Wk1=BFay&9ZiCE#(`h~CL+c-Hs@iGTU@YxM%vlg;)`Tf~IknA^02
+zXkN#Txo6aR{j$wP5T#|UH#<s*%`(Km<n&(n-VMO61HPpba9D&s-YZ<E)NH59!I|A9
+zqN-T-CD))<D9dzh{pWi6;9v!e;Gu01;Ra@5B;qlH=@ASvlOB+p<XN`E#p(1Aq3B41
+z)+3^0JXTY<%Czvf6l;_I-72Od>5AP2{rSY8p?<egp~%*QDVvn_i1jVI<vF4YO5Wv6
+ztWwz1KFP<1kO#Hjq^e=sWVsSgwV`63V3pc#=)rascLi7{-yp$_z50Wja%IQ)>jKFv
+zG3kn3y`FaV!*Jq%m39_TQEhD>M@l*bhEPGe1{ft3q#K5AknT=F2_=T^l#ou5ln@D#
+z5Tzs(kRG@qNDa~<d^7jn_a!bDdDr)>HLNvfv7Z0g=bSlb?`QAx|Gfoni|iHJ%K0cy
+z;~Nsaa+{8HP_qrb{nj+xzkdYhSI@W4N_1`z(eSGIkbDP)!Ko|M%}Rqp(~KI2hl~eE
+zvJ!j4m6iwMgKy>fkCLC)`M$z9EV}B+sq1}}kVf$(ig0pWTY?rHz1Sm=4srTGNb^JG
+z=2$9wz-C@aZZZ2!HY#HNejqZRmE=pN(D$Kui$NpfhU`!y_s{@MIxiJdHb1|{6xb`>
+zE74_@QtgtG{4=3P1$^vn&m}7Aw8!1DnT$2thO#~44wl(N#ao8S0@t@m+Z!KD2CfK;
+z)n5DAPKV_etmH1aLDK$<bfKTSGeuYq_HlONO3C#M3PFvqt3PoSz0>?`;sL91iVt$D
+z*SG}=-LIAg(*+JON!-5ivqOMQ1S!OQUgHglDsKik&Mwg;vva523`JwQH6SRz9eTY#
+zTIi23145~kc3r1mSWC_RzD%hs$S#!pkI9!BU80jJCJcwo*FZolQG$q`8C1d9pP@ND
+zG^&-ZraIvhg_FDVSfKGwkcI=avIan%2sK4coUs~Nr8jC*&!G0#?}_^s3r-c}-uAqi
+zM-Lw>Y}I``T;IS%Y|qH;s{F*ZefM!4{I5awr!K+T@uPd*Vu*iPWI}>(-D{zxsN>LG
+z=@747a_Rb2<sth+J2Z?T^N6ka2dx@o>>q?y8xYf?dq2HM5tFO8Y5e4N;Y=xy8yAhI
+zsm>oy%R5;7)7T3V_b2%`aH^tNlsQpFxIFW<Pc_7hO>#iV#8?{6{^cGr{A0@1bA)|K
+z>MMTuZD(pd2t|7vmHtywGXb%%=)S<`OG~}U+jm#xd%H8<zV$)T@@IDRa^1+^lW~x>
+z$v8-C%F?ah3$;hn?{G3(LT!SgvCVi$vwsZssAQvUwT`Q%qSw!LSd!(<CTTRep1wpD
+z+1amWP^M+0sC8ZA)6PVj+g*a{JY^{LZp|zaB+|iUBf2HHkx&1DcY_YMj%(o)N(g~8
+zuOD62JY+Vu*^6K_|7K^R++2{-!+XRjo6R-MpFwn>I!64w1=%Sc1Mck)q1@pZ@)=SY
+zoX}d+L3-RA<kqVpViiwE2+1D(*ikr;H!OUuItq{`ksBj7b-a&@`xR$^jH(snEHH~+
+z(=1=%lU_?$?ERV8-3T`#N?ATVklfraz}x&yFwwIzZ7NQQfnqa96c>|c?G3_BQNm&(
+z!i$AZ7cI(z7q|e9VM##6T3Xorj1JG(9os$;(I$y%mBy(#8{|3l4|x*oBAQL^XhZ0g
+zy1FR1teRrpKq{uLAibTLx#n({qwjlkOvR{OdSAeT5ah4-sNN)n4Clg1T9lzF)&yj;
+zyal1%+s4n1IG;^VPWJ;#olpk8Z42Gj-tjFeQ&PlxB)`oCNoUYKj4U$AeG8rYiD{pK
+zndDf&2;2;)D|KvOZP+e7fcPU9k4M2sfhr@vC~Ly0?S-4dz)ZGAYpCsAhChgbxLd4g
+zhTrbIPkO5SEp_kD>Ha0m12h5n3s;mE8kn515&n<G5W?|M#KpzT&e--JK0@kIpJd@a
+zo$oEcM{PP18Ny#xS;1ngiAr#v&bUmbji#^iady0^<*7sdBUjhh1TZPRkf>zSf+^D=
+zyE{JnJ;43l&BH55CL<=W%CF;6iUI)V5C*6!`**KqvzR2=Fj*3Y4`HYwx}TYD445(K
+z-QtXwtL?m*(F=LVH*H4oM>dXHBW=38q_dZ-_Vr&qpEPxd9Fs95P5W~@Z|Rt+WZP6l
+zPSQ}~Dh4V?Pp1g&H<P(ih9)F<lyKeQW3i>k*Px?lm16C@X6M29Vrk%Rw@E||E-v~$
+zb_E~{z<}#8i`Mx9mkqtd#Z1lZ-E_J8I+2oumc#x1)jdvh{W76NKm6x-RYpM~v!P8$
+zw3e|YVf|}Hse9~oC@N7^j}Fi$hNpyaYnu1}bdXsD=^oI*%WKvbme|<Oza_wpW8gk;
+zu2yC)2m?TABYV?-o`?uFUCrz2#D@wpoKDwtWV7N~cyL3h>BI}$G3>smu#6y)ls|j?
+zF7Bhu9Z)j)C;3cZb+I>0stSK^WLOYV^U{pUYkgv>?+Nt^5j*CUB=eGw-CvU&40>y~
+zGoHLXxY^7k5Xgv62{iQy|5jJQuq0|LU`}lE@flQ2Z*Zn*VWcQjm4FTb>LSVox^S4q
+zLn`LfS@mrjKCmg$nb^af?d?0&$aX6#2u(JyzIJvuJ*lwPrh|0~aEnSACCTezSdG%h
+zmSQg`17j@$Iq)r1&?+eR@1nlX<hZA96|9?2Pc{<?%#({H1;$K9kGnzSr(*CLy;MCq
+z%~Qs5<0+7FZWenzFJQAz8d%>|H`<}_!?BQSF&N+QQnvEAqZe+mIFui!0V49R?|9*$
+zv!K1A01{8xq;L()Tv*Qk0-$Oj6+vCT*TUD{HvxO@3JjxBwM!4g3ydy&eaJw4CoQBF
+zJtULJ!YxgNR7_Ls%LmogyI7uIs=!B&?=MYY^yX+v;j@D_xGeZg>eZk0C;4e|HRNSi
+z6KlD9>q=3v-$4Zik&^ZDhNm1X)+7<A8tsuQP$bTVU`(p}?t_F!BJ>LCH1k!s+T3tn
+z<oekdyD0CJe2We4yeX>Un@={1U&NJLq@K?~w|(=Y<4W{ucX}F<B#7eu{_F0(M`~qI
+zEPqMc=S17TFa*Ut$xJ>dRr6pLw(l2$iK)At<eBP=<9%0^t_Ek7)YPj~HbzFdS?&Z-
+zFWq#s<_owUG*W9*3T5d3x?Z=@Xg0_}q&OpWn<UO2%6U`unYl-6@mymg@taxBjyc#}
+zd)7tZ=4f`2N^@IyGR7RJjM#l%PlXpmAf&TWaZ{@~`%NOfGu<_iX{6IZhLU^5%U~Eu
+z>%t3gYBMlJz#(K0Nqm;=K<FO+Hmo`&$bpQVtC{pgje|zpXK%6B)|FgdwTg%Nz2k)`
+z8X|UntK@qHxvr+JIl!et<9kIpEAP}K!ng>AML!&MMSNz=%k=j*zh77r34Rs37iCY`
+z=_kva_41bdrj(b=4Wc5MO0~q^z#pIWJ>)vDSgIQF=3JVJe1iDy%h)8oNy{s_r&;m`
+zL{DYKSB_5xRb9xKNOS{qAY3qv5sSXVrrf%~*q5HO|CQ&lbKMePa$M5D{vlJcoGrCZ
+zD?fKbZN$6rWwz)w7`9h4DAmh1ij2}EO|bO#A9L0_RW6l*$sPP<sv8r8rA9owl!eeR
+z1NTGO4fH_iJ$h#A4{SmcyR>UJrUbhLC75L9%W5iO$Iw5~Yut-qBeu~hF|xD7-eQ%l
+z412vpq_;t%^F*pYDk%Q35c-erK|6Ve=FxQbAv~ikZ4c9$Y4;ee#ciOD9{yRqf55Qk
+zumv}#+JciT|Gj$uFOxBUze)=?l{B}qaC0_7m`t82<$K53!4Xvi9Tr)ADp3Off?O8o
+zVDG0Yx|tfn@r((m?Nxrh(b0DGjg)$;DfO&$6uY;4&<!k&O=hr#o>F!4jnxkhP}Y3x
+zS?WFFt>=HWzqlQhffVfvM$Ta8Sg*r3j!Eo&rUOW7SCL2~lG7<+XZ;+{&8<DyiSykp
+zA7l-}(I|=ms%tNFTYkoIsuLyg?+I~Z*3Q|??RFu4_0^U6Re;X@@34fx?CAjIypLRX
+z$t)jPOy0bd<@4-yMHz0{9Y1LCV%IkRJ|jg%fPCmT)F-!8_Y#Dx3{FysRp`Q!doW+6
+zZ}IrYb2DD<Y8pA*#%c==4-8brg}Y#8wFDK<c2$i#jeUy3OkIIRUG3<@gcwUTYAl?p
+z`@7Fcaz|&cdl(`^C!Qo@F-$oXtl)ANqe_kyV5z5QcLFH5ktesECpz2i%Uy3K;o$nU
+zRHA31(@H1&5F`A#ssy`goLx2j=rBn*CE>h5g8ElI+P>>yR2U%S93NN<c)T<0U~gz;
+z>!Xhm|C682t6ysH-=o1=Bd*N*V<P)26zv@1P>lnG%l+KZFtjG`UkL;%65qn0UYQ`h
+zh0{9jDQx(`aBe7J0Aj3Z)4}`A|4OMM0a;?{j}qkYwi)~O8$9D}ITiMH2buiU>ixYp
+zhL${nwj6X($*OwmpVG`y5b6v45tX*J8?og}Qju6eJ9H}`X87iEd%BUo7<`2q(HJx+
+zMR<Pt%@%D0sbR}bR2vchjFmv@&giX(?>}d-J4oAf{V1W^a2~`M-YAdZ81<O(x-LLB
+ziYJ(IlIy^J+VaY)YgPSiQ0Us4I~n$rwJ4oe0cPBI>dd4o6NPO{cmZaAS@RS4ir#Sr
+zf<VdxlnqAnRM2AE_ghvSVwSte-XRVIyT(D^slNqE-8jf%6<nCMa`zf|$630Q?axs+
+z8-|ze)?RSqAckM?+w@&cuhDl@^|OO`O*pLVJKYxi4OohAU>FZO-VIL|VN<%nEXr2`
+z$0FK2L#8O_f1w~c@G70JrB@N}r(gJ!Vmkk6{r68w!o$qO?HrFcjeU0_3F5;*!E2%(
+zTx<?~WRM!G0a&ySR$<jsjlFDU!_cQ=rm^f3a0m@pR~S~3x#Q!vBQ8QrLR>>4?gP8w
+z1B?3UVZmz^%d_dIps>>0{cB~mp3{9U<B7u|njwlkXBz*b%D0;yhSH%?j@*Qn*llsX
+zO1Db$I4fzAEAs;fb^Hb!dP&&H(*QyAv^S{c)(B}+d64a7WNv#fMaw`2RTzNS*TvY_
+z7H6;X#FS2^bTGaO6(xFKPOPseR+?{`;POC2m5aaA&EKov%Vz!k+>oPR6uQFecVq&}
+zY{ebB?AlPAD_}(ll{fK99;Wh1cgRbnw)maD^F>*J!R}eHM*W0VYN1TADWMy9H=$00
+z5bHY${oDgwX7(W9LZw?}{!8(_{JB~Xkje6{0x4fgC4kUmpfJ+LT1DYD*TWu4#h{Y7
+zFLronmc=hS=W=j1ar3r1JNjQoWo2hMWsqW*e?TF%#&{GpsaLp}iN~$)ar+7Ti}E&X
+z-nq~+Gkp(`qF0F_4A22>VZn-x>I$?PDZSeG8h_ifoWf^DxIb5%T7UytYo3}F|4#RC
+zUHpg$=)qVqD~=m(!~?Xwocux<fMdw81nD!;t@a*4neQ(aVD(J+A2??uX#HB8h{SA^
+zdwHZPt(_kv#Cy%vSUh54y~cPXj=D^*;zTVk5y{_bC5yAz3CQA`(UWK4rS;tBXU@kM
+zdej%biGz)+Zyb}ApQWbz*^ZVHpgtmw$q*Vpwt!Q&h9PG6;&Z4L%=lGi5uP2+Iw}}%
+zRw^VYFqyiS!j*Ylw*m}O)GZr&wh(LNL_SF4+fnf#U_g+~SMcMFhbA4}sBM0v^=YW-
+z&lY;LS6yEUO8A78NCxHMrs`yWt-AgIrz<}>U1u}9qhhM7d^eqmJPi_e-!IO`*{u7A
+zbu*?L$Mbj-X9n3G2>+Kc#l`@d8}Xb9{l*IN{#<s%V4>M*d;s+3Pdr8FO$EBELR=8{
+zd?LJbSv9fI`{OqTH)5{b?WulgMb)psp+W|@cSp=jtl-&5C}9lw@*0H+gEW(}mAWNz
+zf{~U;;<ij^TC}|2a=b@Y*t)@0v1xP(v60Z1AVFC^6OFVSu>N}|wdSaphgqn<w7=w9
+zK8);m^xjJ26KBA^s+X~_;*<r_i1!(b_J^XZTX2ts<uU`4&%E_cmAS3_5^hk59|kgD
+zMLF}`MyE`hy%MFvhK6uW0T0ZwJE%ubf^cybN1t(tFSjlXmU%iNJM_KhC?w8%lwxG%
+z^l3qjQ#&r)nR&TI7eX29AQRbBd!NtWy|6g3o?g!*>H{FWUy!{y3^=AC*c?RJ5Eb<^
+zCgH_v7^axIUVmHSFL^zlj2R$zow$|y#7>%#U7d#Vp_ezcp3lefMyd5ES=q$>4pWyA
+zp_Zso^^NP~lu2=S6nD(3Z5u=Uy&B&F<ZVfpeB?A^;A;yfb|T-IdCr4F&4;vkGQ(ce
+zh3=uO>1i$J*3;3KhEkD_lgscHGR*;T;U!9vgQa(hI}oh9IzEf_PU_8F+i77t-~gDX
+z490Sb<R_L<O5Q@b5$Zq8%`yG)pr{P@%VAd&n*7r>)LyVZmf18N6w{+37$aO<2!Av0
+ztLaPOv^J<2@p{WnMiDudoghX_`luFZt_4eNU}*~cF5i%eEcNLs;D>QVIwr8mH;=dc
+z09`}JV;aaF;13<?rh<ybd3+ERtA!AF+n4vv*yO!S>@&iS(w>Jc=k~|d_1hcpM(l|O
+zu>!@}me%isTT$xT#hNUvh(ATd0wT4fbv=6htc<!_*5tIlcw;jfC)7eiH`TZ#yg33G
+z*K{nA3s&@UJ|kOpm^FmpZH!jpU$uLLL0hBd*qzwn)R|bYU?5GP?km8IK}b(Rmo(9m
+ztmUrC#OLcS1`w=qT%q{r;x6q#X*G<@Q?b$fk$PV_;x3)8-*Cma`(%rzI}~@X_mynt
+z){EdYfW}JcHE72h7O(F)3GWJ5QyDsqkV#hvVxfwA+tCRWd-}F=Z{E9X{i^#g-uA}M
+z8A};Fz|8*u<?gci0HA-zkJWo>HNEZIw9%E6wlYmwfu2{j0kh1y=$;Yf!|NldgB9ul
+zB{dbE&LfRnr8ITm@;-68wo#VV?8lG3ed&9k1}QBS3}WGV9%26?A1rBkkDR9Z3o+g+
+z)eQg8BY3y(Dh5&z?VLLNdDV`C=muUvCPpGg!oYxIgOI3^%4>5d7jTh~ni!Fg2;fhx
+z(*c%H6Je84kmQh;5tC3*l~7khLxK-e|Cz?FLh!yYe7g|*LwqU?2wv^_ZyK<Of{dhu
+zsv0|3@?TRSx1dhZz(pM4pWCNW)x%RcI9qU7{OJ?KVPb2=ae`t5N2|Np!TnR=miT6l
+z=X6%jw%pdV6l@QFlD~p?kP+pL<B%Y@NatKA$=T#KFRv!+!jsp)t11X)#&Hl3U6lMU
+zJRO~gIozN7FCmvReeSbLXwrCX?C>T$fYVkGJo@AK0$+ml?}zJeB~deT2WL1vz}dxB
+z)y??t!}%M@)u$_I<M8Xr7=Atw2=U{1NPY=Pxyvvn&o=WU(EM~W-`~1~CfLfw1<p(O
+z>yW~)6u1SttJ!awd6N5lx|xBrmyrBh>tb&D*=C+Z3nPfq$1%WgY0bY*?PZ#Hk|=xn
+zGM#0*w4CaB^y0G(J4q=;5NeM@m-P}#mv7QZNF)M!dK^w{mk_!n0`+Y3PQutu-%NBt
+zzgPXug?JLEbUL{e_dk;Vd896&yPe(hliVK!lj%5+@BKdcrEZ2Nc_*i@ve*2lB>u~{
+zFozd2FM|_0+nAGR4TLNHanQn_Oeb!Jr<ML^n#x(-lWYbAxZ^lzL{91ce=r_rMNh&3
+z5ZH&~&=xx-`k!k3r63SzRZbe5pFX5uiE~x{Yij<#VF%9Yp7eo6*ry-Is`SOWzco`o
+zD|OPe5MeBR9K!M!O8w?{d(zJiQDi%gL-lj>UcvzJ?7p9TTNB}ocO3j$7ij!li8#k6
+z@2tSd1>K03K9A#_-MIq)S;T#oE^;>U$)&}okIvDf3lm?kI{d80$>~<aBIV=g^}I;q
+zHz)SwoEc)S_BbfR&P{vn%<b8oJvk9{`Zix4ac<U&X5Y>xKUoS!%q1Pi?WpsUUt(tI
+ztjNjY*y&Rm9(S(DC2GuPHBJs@5M{RGm`c1z<6nwyN^)rMo-AS{M2$oM9|y%fM|}G~
+DHx0+F
+
+literal 0
+HcmV?d00001
+
+diff --git a/database/gradle/wrapper/gradle-wrapper.properties b/database/gradle/wrapper/gradle-wrapper.properties
+new file mode 100644
+index 0000000..a4cf193
+--- /dev/null
++++ b/database/gradle/wrapper/gradle-wrapper.properties
+@@ -0,0 +1,8 @@
++distributionBase=GRADLE_USER_HOME
++distributionPath=wrapper/dists
++distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
++distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
++networkTimeout=10000
++validateDistributionUrl=true
++zipStoreBase=GRADLE_USER_HOME
++zipStorePath=wrapper/dists
+diff --git a/database/gradlew b/database/gradlew
+new file mode 100755
+index 0000000..faf9300
+--- /dev/null
++++ b/database/gradlew
+@@ -0,0 +1,251 @@
++#!/bin/sh
++
++#
++# Copyright © 2015-2021 the original authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#      https://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++#
++# SPDX-License-Identifier: Apache-2.0
++#
++
++##############################################################################
++#
++#   Gradle start up script for POSIX generated by Gradle.
++#
++#   Important for running:
++#
++#   (1) You need a POSIX-compliant shell to run this script. If your /bin/sh is
++#       noncompliant, but you have some other compliant shell such as ksh or
++#       bash, then to run this script, type that shell name before the whole
++#       command line, like:
++#
++#           ksh Gradle
++#
++#       Busybox and similar reduced shells will NOT work, because this script
++#       requires all of these POSIX shell features:
++#         * functions;
++#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
++#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
++#         * compound commands having a testable exit status, especially «case»;
++#         * various built-in commands including «command», «set», and «ulimit».
++#
++#   Important for patching:
++#
++#   (2) This script targets any POSIX shell, so it avoids extensions provided
++#       by Bash, Ksh, etc; in particular arrays are avoided.
++#
++#       The "traditional" practice of packing multiple parameters into a
++#       space-separated string is a well documented source of bugs and security
++#       problems, so this is (mostly) avoided, by progressively accumulating
++#       options in "$@", and eventually passing that to Java.
++#
++#       Where the inherited environment variables (DEFAULT_JVM_OPTS, JAVA_OPTS,
++#       and GRADLE_OPTS) rely on word-splitting, this is performed explicitly;
++#       see the in-line comments for details.
++#
++#       There are tweaks for specific operating systems such as AIX, CygWin,
++#       Darwin, MinGW, and NonStop.
++#
++#   (3) This script is generated from the Groovy template
++#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
++#       within the Gradle project.
++#
++#       You can find Gradle at https://github.com/gradle/gradle/.
++#
++##############################################################################
++
++# Attempt to set APP_HOME
++
++# Resolve links: $0 may be a link
++app_path=$0
++
++# Need this for daisy-chained symlinks.
++while
++    APP_HOME=${app_path%"${app_path##*/}"}  # leaves a trailing /; empty if no leading path
++    [ -h "$app_path" ]
++do
++    ls=$( ls -ld "$app_path" )
++    link=${ls#*' -> '}
++    case $link in             #(
++      /*)   app_path=$link ;; #(
++      *)    app_path=$APP_HOME$link ;;
++    esac
++done
++
++# This is normally unused
++# shellcheck disable=SC2034
++APP_BASE_NAME=${0##*/}
++# Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
++APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
++
++# Use the maximum available, or set MAX_FD != -1 to use that value.
++MAX_FD=maximum
++
++warn () {
++    echo "$*"
++} >&2
++
++die () {
++    echo
++    echo "$*"
++    echo
++    exit 1
++} >&2
++
++# OS specific support (must be 'true' or 'false').
++cygwin=false
++msys=false
++darwin=false
++nonstop=false
++case "$( uname )" in                #(
++  CYGWIN* )         cygwin=true  ;; #(
++  Darwin* )         darwin=true  ;; #(
++  MSYS* | MINGW* )  msys=true    ;; #(
++  NONSTOP* )        nonstop=true ;;
++esac
++
++CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
++
++
++# Determine the Java command to use to start the JVM.
++if [ -n "$JAVA_HOME" ] ; then
++    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
++        # IBM's JDK on AIX uses strange locations for the executables
++        JAVACMD=$JAVA_HOME/jre/sh/java
++    else
++        JAVACMD=$JAVA_HOME/bin/java
++    fi
++    if [ ! -x "$JAVACMD" ] ; then
++        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
++
++Please set the JAVA_HOME variable in your environment to match the
++location of your Java installation."
++    fi
++else
++    JAVACMD=java
++    if ! command -v java >/dev/null 2>&1
++    then
++        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
++
++Please set the JAVA_HOME variable in your environment to match the
++location of your Java installation."
++    fi
++fi
++
++# Increase the maximum file descriptors if we can.
++if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
++    case $MAX_FD in #(
++      max*)
++        # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
++        # shellcheck disable=SC2039,SC3045
++        MAX_FD=$( ulimit -H -n ) ||
++            warn "Could not query maximum file descriptor limit"
++    esac
++    case $MAX_FD in  #(
++      '' | soft) :;; #(
++      *)
++        # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
++        # shellcheck disable=SC2039,SC3045
++        ulimit -n "$MAX_FD" ||
++            warn "Could not set maximum file descriptor limit to $MAX_FD"
++    esac
++fi
++
++# Collect all arguments for the java command, stacking in reverse order:
++#   * args from the command line
++#   * the main class name
++#   * -classpath
++#   * -D...appname settings
++#   * --module-path (only if needed)
++#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and GRADLE_OPTS environment variables.
++
++# For Cygwin or MSYS, switch paths to Windows format before running java
++if "$cygwin" || "$msys" ; then
++    APP_HOME=$( cygpath --path --mixed "$APP_HOME" )
++    CLASSPATH=$( cygpath --path --mixed "$CLASSPATH" )
++
++    JAVACMD=$( cygpath --unix "$JAVACMD" )
++
++    # Now convert the arguments - kludge to limit ourselves to /bin/sh
++    for arg do
++        if
++            case $arg in                                #(
++              -*)   false ;;                            # don't mess with options #(
++              /?*)  t=${arg#/} t=/${t%%/*}              # looks like a POSIX filepath
++                    [ -e "$t" ] ;;                      #(
++              *)    false ;;
++            esac
++        then
++            arg=$( cygpath --path --ignore --mixed "$arg" )
++        fi
++        # Roll the args list around exactly as many times as the number of
++        # args, so each arg winds up back in the position where it started, but
++        # possibly modified.
++        #
++        # NB: a `for` loop captures its iteration list before it begins, so
++        # changing the positional parameters here affects neither the number of
++        # iterations, nor the values presented in `arg`.
++        shift                   # remove old arg
++        set -- "$@" "$arg"      # push replacement arg
++    done
++fi
++
++
++# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
++DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
++
++# Collect all arguments for the java command:
++#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
++#     and any embedded shellness will be escaped.
++#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
++#     treated as '${Hostname}' itself on the command line.
++
++set -- \
++        "-Dorg.gradle.appname=$APP_BASE_NAME" \
++        -classpath "$CLASSPATH" \
++        org.gradle.wrapper.GradleWrapperMain \
++        "$@"
++
++# Stop when "xargs" is not available.
++if ! command -v xargs >/dev/null 2>&1
++then
++    die "xargs is not available"
++fi
++
++# Use "xargs" to parse quoted args.
++#
++# With -n1 it outputs one arg per line, with the quotes and backslashes removed.
++#
++# In Bash we could simply go:
++#
++#   readarray ARGS < <( xargs -n1 <<<"$var" ) &&
++#   set -- "${ARGS[@]}" "$@"
++#
++# but POSIX shell has neither arrays nor command substitution, so instead we
++# post-process each arg (as a line of input to sed) to backslash-escape any
++# character that might be a shell metacharacter, then use eval to reverse
++# that process (while maintaining the separation between arguments), and wrap
++# the whole thing up as a single "set" statement.
++#
++# This will of course break if any of these variables contains a newline or
++# an unmatched quote.
++#
++
++eval "set -- $(
++        printf '%s\n' "$DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS" |
++        xargs -n1 |
++        sed ' s~[^-[:alnum:]+,./:=@_]~\\&~g; ' |
++        tr '\n' ' '
++    )" '"$@"'
++
++exec "$JAVACMD" "$@"
+diff --git a/database/gradlew.bat b/database/gradlew.bat
+new file mode 100644
+index 0000000..9b42019
+--- /dev/null
++++ b/database/gradlew.bat
+@@ -0,0 +1,94 @@
++@rem
++@rem Copyright 2015 the original author or authors.
++@rem
++@rem Licensed under the Apache License, Version 2.0 (the "License");
++@rem you may not use this file except in compliance with the License.
++@rem You may obtain a copy of the License at
++@rem
++@rem      https://www.apache.org/licenses/LICENSE-2.0
++@rem
++@rem Unless required by applicable law or agreed to in writing, software
++@rem distributed under the License is distributed on an "AS IS" BASIS,
++@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++@rem See the License for the specific language governing permissions and
++@rem limitations under the License.
++@rem
++@rem SPDX-License-Identifier: Apache-2.0
++@rem
++
++@if "%DEBUG%"=="" @echo off
++@rem ##########################################################################
++@rem
++@rem  Gradle startup script for Windows
++@rem
++@rem ##########################################################################
++
++@rem Set local scope for the variables with windows NT shell
++if "%OS%"=="Windows_NT" setlocal
++
++set DIRNAME=%~dp0
++if "%DIRNAME%"=="" set DIRNAME=.
++@rem This is normally unused
++set APP_BASE_NAME=%~n0
++set APP_HOME=%DIRNAME%
++
++@rem Resolve any "." and ".." in APP_HOME to make it shorter.
++for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
++
++@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
++set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
++
++@rem Find java.exe
++if defined JAVA_HOME goto findJavaFromJavaHome
++
++set JAVA_EXE=java.exe
++%JAVA_EXE% -version >NUL 2>&1
++if %ERRORLEVEL% equ 0 goto execute
++
++echo. 1>&2
++echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
++echo. 1>&2
++echo Please set the JAVA_HOME variable in your environment to match the 1>&2
++echo location of your Java installation. 1>&2
++
++goto fail
++
++:findJavaFromJavaHome
++set JAVA_HOME=%JAVA_HOME:"=%
++set JAVA_EXE=%JAVA_HOME%/bin/java.exe
++
++if exist "%JAVA_EXE%" goto execute
++
++echo. 1>&2
++echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
++echo. 1>&2
++echo Please set the JAVA_HOME variable in your environment to match the 1>&2
++echo location of your Java installation. 1>&2
++
++goto fail
++
++:execute
++@rem Setup the command line
++
++set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
++
++
++@rem Execute Gradle
++"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
++
++:end
++@rem End local scope for the variables with windows NT shell
++if %ERRORLEVEL% equ 0 goto mainEnd
++
++:fail
++rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
++rem the _cmd.exe /c_ return code!
++set EXIT_CODE=%ERRORLEVEL%
++if %EXIT_CODE% equ 0 set EXIT_CODE=1
++if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
++exit /b %EXIT_CODE%
++
++:mainEnd
++if "%OS%"=="Windows_NT" endlocal
++
++:omega
 diff --git a/database/initialSchema.sql b/database/initialSchema.sql
 new file mode 100644
-index 0000000..ad8e077
+index 0000000..a339ff9
 --- /dev/null
 +++ b/database/initialSchema.sql
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,82 @@
 +Drop Table Trades IF EXISTS;
++Drop Table OrderBook IF EXISTS;
 +Drop Table AccountUsers IF EXISTS;
 +Drop Table Positions IF EXISTS;
 +Drop Table Accounts IF EXISTS;
@@ -2040,6 +3914,23 @@ index 0000000..ad8e077
 +  State VARCHAR(20) check (State in ('New', 'Processing', 'Settled', 'Cancelled'))
 +);
 +Alter Table Trades Add Foreign Key (AccountID) references Accounts(ID);
++
++CREATE TABLE OrderBook (
++  OrderId VARCHAR(32) PRIMARY KEY,
++  AccountId INTEGER NOT NULL,
++  Security VARCHAR(16) NOT NULL,
++  Side VARCHAR(16) check (Side in ('Buy','Sell')),
++  Quantity INTEGER NOT NULL check (Quantity > 0),
++  RemainingQuantity INTEGER NOT NULL check (RemainingQuantity >= 0),
++  LimitPrice DECIMAL(18,3) NOT NULL,
++  Status VARCHAR(24) check (Status in ('NEW', 'PARTIALLY_FILLED', 'FILLED', 'CANCELED', 'REJECTED')),
++  CreatedAt TIMESTAMP NOT NULL,
++  UpdatedAt TIMESTAMP NOT NULL,
++  LastExecutionPrice DECIMAL(18,3),
++  LastFillQuantity INTEGER
++);
++CREATE INDEX idx_orderbook_status ON OrderBook(Status);
++CREATE INDEX idx_orderbook_updatedat ON OrderBook(UpdatedAt);
 +
 +CREATE SEQUENCE ACCOUNTS_SEQ start with 65000 INCREMENT BY 1;
 +
@@ -2080,6 +3971,74 @@ index 0000000..ad8e077
 +
 +INSERT into Trades(ID, Created, Updated, Security, Side, Quantity, State, AccountID) VALUES('TRADE-52355-AABBCC', NOW(), NOW(), 'BAC', 'Sell', 2400, 'Settled', 52355);
 +INSERT into Positions (AccountID, Security, Updated, Quantity) VALUES(52355, 'BAC',NOW(), -2400);
+diff --git a/database/run.ps1 b/database/run.ps1
+new file mode 100644
+index 0000000..fb90566
+--- /dev/null
++++ b/database/run.ps1
+@@ -0,0 +1,62 @@
++#!/usr/bin/env pwsh
++Set-StrictMode -Version Latest
++$ErrorActionPreference = 'Stop'
++
++function Set-DefaultEnv {
++  param(
++    [Parameter(Mandatory = $true)][string]$Name,
++    [Parameter(Mandatory = $true)][string]$Value
++  )
++
++  if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($Name))) {
++    [Environment]::SetEnvironmentVariable($Name, $Value)
++  }
++}
++
++Set-DefaultEnv -Name 'DATABASE_TCP_PORT' -Value '18082'
++Set-DefaultEnv -Name 'DATABASE_PG_PORT' -Value '18083'
++Set-DefaultEnv -Name 'DATABASE_WEB_PORT' -Value '18084'
++Set-DefaultEnv -Name 'DATABASE_DBUSER' -Value 'sa'
++Set-DefaultEnv -Name 'DATABASE_DBPASS' -Value 'sa'
++Set-DefaultEnv -Name 'DATABASE_H2JAR' -Value './build/libs/database-specfirst.jar'
++Set-DefaultEnv -Name 'DATABASE_DATA_DIR' -Value './_data'
++Set-DefaultEnv -Name 'DATABASE_DBNAME' -Value 'traderx'
++
++if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('DATABASE_HOSTNAME'))) {
++  $hostName = if ([string]::IsNullOrWhiteSpace($env:HOSTNAME)) { 'localhost' } else { $env:HOSTNAME }
++  [Environment]::SetEnvironmentVariable('DATABASE_HOSTNAME', $hostName)
++}
++
++if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('DATABASE_JDBC_URL'))) {
++  [Environment]::SetEnvironmentVariable(
++    'DATABASE_JDBC_URL',
++    "jdbc:h2:tcp://$($env:DATABASE_HOSTNAME):$($env:DATABASE_TCP_PORT)/$($env:DATABASE_DBNAME)"
++  )
++}
++
++if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('DATABASE_WEB_HOSTNAMES'))) {
++  [Environment]::SetEnvironmentVariable('DATABASE_WEB_HOSTNAMES', $env:DATABASE_HOSTNAME)
++}
++
++Write-Host "Data will be located in $($env:DATABASE_DATA_DIR)"
++Write-Host "Database name is $($env:DATABASE_DBNAME)"
++Write-Host 'Running schema setup script'
++Write-Host '---------------------------------------------------------------------------'
++
++& java -cp $env:DATABASE_H2JAR org.h2.tools.RunScript `
++  -url "jdbc:h2:$($env:DATABASE_DATA_DIR)/$($env:DATABASE_DBNAME);DATABASE_TO_UPPER=TRUE;TRACE_LEVEL_SYSTEM_OUT=3" `
++  -user $env:DATABASE_DBUSER `
++  -password $env:DATABASE_DBPASS `
++  -script initialSchema.sql
++if ($LASTEXITCODE -ne 0) {
++  throw '[error] failed schema setup script'
++}
++
++Write-Host 'Starting Database Server'
++Write-Host '---------------------------------------------------------------------------'
++
++& java -jar $env:DATABASE_H2JAR `
++  -pg -pgPort $env:DATABASE_PG_PORT -pgAllowOthers -baseDir $env:DATABASE_DATA_DIR `
++  -tcp -tcpPort $env:DATABASE_TCP_PORT -tcpAllowOthers `
++  -web -webPort $env:DATABASE_WEB_PORT -webExternalNames $env:DATABASE_WEB_HOSTNAMES -webAllowOthers
++exit $LASTEXITCODE
 diff --git a/database/run.sh b/database/run.sh
 new file mode 100755
 index 0000000..0f87abf
@@ -2144,7 +4103,7 @@ index 0000000..4057097
 +- [Component Diagram](./learning/component-diagram.md)
 diff --git a/docs/learning/README.md b/docs/learning/README.md
 new file mode 100644
-index 0000000..b5c340b
+index 0000000..b437418
 --- /dev/null
 +++ b/docs/learning/README.md
 @@ -0,0 +1,16 @@
@@ -2162,8 +4121,8 @@ index 0000000..b5c340b
 +Canonical source remains SpecKit artifacts in the main authoring branch:
 +
 +- Feature pack: `specs/004-containerized-compose-runtime`
-+- Source feature pack at commit: https://github.com/finos/traderX/tree/136dbf7bf223141f406620a11f12ce44b1484d4d/specs/004-containerized-compose-runtime
-+- Source architecture model at commit: https://github.com/finos/traderX/blob/136dbf7bf223141f406620a11f12ce44b1484d4d/specs/004-containerized-compose-runtime/system/architecture.model.json
++- Source feature pack at commit: https://github.com/finos/traderX/tree/072c53d558884d7b14142168239860086c7cdee2/specs/004-containerized-compose-runtime
++- Source architecture model at commit: https://github.com/finos/traderX/blob/072c53d558884d7b14142168239860086c7cdee2/specs/004-containerized-compose-runtime/system/architecture.model.json
 diff --git a/docs/learning/component-diagram.md b/docs/learning/component-diagram.md
 new file mode 100644
 index 0000000..7896996
@@ -2367,20 +4326,12 @@ index 0000000..117f896
 +
 +- `system/docker-compose.spec.yaml`
 +- `system/ingress-nginx.conf.template`
-diff --git a/generated/code/target-generated b/generated/code/target-generated
-deleted file mode 120000
-index c25bddb..0000000
---- a/generated/code/target-generated
-+++ /dev/null
-@@ -1 +0,0 @@
--../..
-\ No newline at end of file
 diff --git a/ingress/Dockerfile.compose b/ingress/Dockerfile.compose
 new file mode 100644
-index 0000000..1abceca
+index 0000000..3779b0f
 --- /dev/null
 +++ b/ingress/Dockerfile.compose
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,35 @@
 +FROM nginx:alpine-slim
 +EXPOSE 8080
 +
@@ -2415,12 +4366,752 @@ index 0000000..1abceca
 +ENV TRADE_SERVICE_URL=${TRADE_SERVICE_URL}
 +
 +COPY nginx.traderx.conf.template /etc/nginx/templates/default.conf.template
++COPY api-explorer/ /usr/share/nginx/html/api-docs/
+diff --git a/ingress/api-explorer/catalog.json b/ingress/api-explorer/catalog.json
+new file mode 100644
+index 0000000..08165d6
+--- /dev/null
++++ b/ingress/api-explorer/catalog.json
+@@ -0,0 +1,63 @@
++{
++  "generatedAtUtc": "2026-06-21T08:47:39.222Z",
++  "stateId": "004-containerized-compose-runtime",
++  "mountPath": "/api/docs",
++  "pubSubInspectorEnabled": false,
++  "services": [
++    {
++      "id": "account-service",
++      "name": "Account Service",
++      "specUrl": "/account-service/v3/api-docs",
++      "runtimeSpecPath": "/account-service/v3/api-docs",
++      "runtimeBasePath": "/account-service",
++      "contractUrl": "/api/docs/contracts/account-service-openapi.yaml",
++      "interactive": true
++    },
++    {
++      "id": "people-service",
++      "name": "People Service",
++      "specUrl": "/people-service/swagger/v1/swagger.json",
++      "runtimeSpecPath": "/people-service/swagger/v1/swagger.json",
++      "runtimeBasePath": "/people-service",
++      "contractUrl": "/api/docs/contracts/people-service-openapi.yaml",
++      "interactive": true
++    },
++    {
++      "id": "position-service",
++      "name": "Position Service",
++      "specUrl": "/position-service/v3/api-docs",
++      "runtimeSpecPath": "/position-service/v3/api-docs",
++      "runtimeBasePath": "/position-service",
++      "contractUrl": "/api/docs/contracts/position-service-openapi.yaml",
++      "interactive": true
++    },
++    {
++      "id": "reference-data",
++      "name": "Reference Data",
++      "specUrl": "/api/docs/contracts/reference-data-openapi.yaml",
++      "runtimeSpecPath": null,
++      "runtimeBasePath": null,
++      "contractUrl": "/api/docs/contracts/reference-data-openapi.yaml",
++      "interactive": false
++    },
++    {
++      "id": "trade-processor",
++      "name": "Trade Processor",
++      "specUrl": "/trade-processor/v3/api-docs",
++      "runtimeSpecPath": "/trade-processor/v3/api-docs",
++      "runtimeBasePath": "/trade-processor",
++      "contractUrl": "/api/docs/contracts/trade-processor-openapi.yaml",
++      "interactive": true
++    },
++    {
++      "id": "trade-service",
++      "name": "Trade Service",
++      "specUrl": "/trade-service/v3/api-docs",
++      "runtimeSpecPath": "/trade-service/v3/api-docs",
++      "runtimeBasePath": "/trade-service",
++      "contractUrl": "/api/docs/contracts/trade-service-openapi.yaml",
++      "interactive": true
++    }
++  ],
++  "messagingSubjects": []
++}
+diff --git a/ingress/api-explorer/contracts/account-service-openapi.yaml b/ingress/api-explorer/contracts/account-service-openapi.yaml
+new file mode 100644
+index 0000000..a9bff85
+--- /dev/null
++++ b/ingress/api-explorer/contracts/account-service-openapi.yaml
+@@ -0,0 +1,75 @@
++openapi: 3.0.1
++info:
++  title: "Account Service - TraderX Spec-First"
++  version: "1.0"
++paths:
++  /account/:
++    get:
++      operationId: listAccounts
++      summary: List all accounts
++      responses:
++        "200":
++          description: OK
++    post:
++      operationId: createAccount
++      summary: Create account
++      responses:
++        "200":
++          description: OK
++    put:
++      operationId: updateAccount
++      summary: Update account
++      responses:
++        "200":
++          description: OK
++  /account/{id}:
++    get:
++      operationId: getAccountById
++      summary: Get account by id
++      parameters:
++        - name: id
++          in: path
++          required: true
++          schema:
++            type: integer
++      responses:
++        "200":
++          description: OK
++        "404":
++          description: Not found
++  /accountuser/:
++    get:
++      operationId: listAccountUsers
++      summary: List all account-user mappings
++      responses:
++        "200":
++          description: OK
++    post:
++      operationId: createAccountUser
++      summary: Add account-user mapping
++      responses:
++        "200":
++          description: OK
++        "404":
++          description: Person not found
++    put:
++      operationId: updateAccountUser
++      summary: Update account-user mapping
++      responses:
++        "200":
++          description: OK
++  /accountuser/{id}:
++    get:
++      operationId: getAccountUsersByAccountId
++      summary: Get account-user mappings by account id
++      parameters:
++        - name: id
++          in: path
++          required: true
++          schema:
++            type: integer
++      responses:
++        "200":
++          description: OK
++        "404":
++          description: Not found
+diff --git a/ingress/api-explorer/contracts/people-service-openapi.yaml b/ingress/api-explorer/contracts/people-service-openapi.yaml
+new file mode 100644
+index 0000000..0a0961f
+--- /dev/null
++++ b/ingress/api-explorer/contracts/people-service-openapi.yaml
+@@ -0,0 +1,109 @@
++openapi: 3.0.1
++info:
++  title: TraderSpec PeopleService.WebApi
++  version: v1
++paths:
++  /People/GetPerson:
++    get:
++      summary: Get a person from directory by logon or employee ID
++      parameters:
++        - name: LogonId
++          in: query
++          schema:
++            type: string
++            nullable: true
++        - name: EmployeeId
++          in: query
++          schema:
++            type: string
++            nullable: true
++      responses:
++        "200":
++          description: Person found
++          content:
++            application/json:
++              schema:
++                $ref: "#/components/schemas/Person"
++        "400":
++          description: Invalid request
++        "404":
++          description: Person not found
++  /People/GetMatchingPeople:
++    get:
++      summary: Get people where logonId or fullName contains search text
++      parameters:
++        - name: SearchText
++          in: query
++          schema:
++            type: string
++        - name: Take
++          in: query
++          schema:
++            type: integer
++            format: int32
++            default: 10
++      responses:
++        "200":
++          description: Matching people
++          content:
++            application/json:
++              schema:
++                $ref: "#/components/schemas/GetMatchingPeopleResponse"
++        "400":
++          description: Invalid request
++        "404":
++          description: No matches
++  /People/ValidatePerson:
++    get:
++      summary: Validate person identity by logon or employee ID
++      parameters:
++        - name: LogonId
++          in: query
++          schema:
++            type: string
++            nullable: true
++        - name: EmployeeId
++          in: query
++          schema:
++            type: string
++            nullable: true
++      responses:
++        "200":
++          description: Person is valid
++        "400":
++          description: Invalid request
++        "404":
++          description: Person not found
++components:
++  schemas:
++    Person:
++      type: object
++      required:
++        - logonId
++        - fullName
++        - email
++        - employeeId
++        - department
++        - photoUrl
++      properties:
++        logonId:
++          type: string
++        fullName:
++          type: string
++        email:
++          type: string
++        employeeId:
++          type: string
++        department:
++          type: string
++        photoUrl:
++          type: string
++    GetMatchingPeopleResponse:
++      type: object
++      required:
++        - people
++      properties:
++        people:
++          type: array
++          items:
++            $ref: "#/components/schemas/Person"
+diff --git a/ingress/api-explorer/contracts/position-service-openapi.yaml b/ingress/api-explorer/contracts/position-service-openapi.yaml
+new file mode 100644
+index 0000000..9c78a47
+--- /dev/null
++++ b/ingress/api-explorer/contracts/position-service-openapi.yaml
+@@ -0,0 +1,59 @@
++openapi: 3.0.1
++info:
++  title: FINOS TraderX Position Service (Spec-First)
++  version: 0.1.0
++paths:
++  /trades/{accountId}:
++    get:
++      operationId: getTradesByAccountId
++      summary: Get trades for account
++      parameters:
++        - name: accountId
++          in: path
++          required: true
++          schema:
++            type: integer
++      responses:
++        "200":
++          description: OK
++  /trades/:
++    get:
++      operationId: getAllTrades
++      summary: Get all trades
++      responses:
++        "200":
++          description: OK
++  /positions/{accountId}:
++    get:
++      operationId: getPositionsByAccountId
++      summary: Get positions for account
++      parameters:
++        - name: accountId
++          in: path
++          required: true
++          schema:
++            type: integer
++      responses:
++        "200":
++          description: OK
++  /positions/:
++    get:
++      operationId: getAllPositions
++      summary: Get all positions
++      responses:
++        "200":
++          description: OK
++  /health/ready:
++    get:
++      operationId: healthReady
++      summary: Readiness health probe
++      responses:
++        "200":
++          description: OK
++  /health/alive:
++    get:
++      operationId: healthAlive
++      summary: Liveness health probe
++      responses:
++        "200":
++          description: OK
+diff --git a/ingress/api-explorer/contracts/reference-data-openapi.yaml b/ingress/api-explorer/contracts/reference-data-openapi.yaml
+new file mode 100644
+index 0000000..c98ad8b
+--- /dev/null
++++ b/ingress/api-explorer/contracts/reference-data-openapi.yaml
+@@ -0,0 +1,67 @@
++openapi: 3.0.0
++info:
++  title: TraderSpec Reference Data Service
++  version: "1.0.0"
++paths:
++  /health:
++    get:
++      summary: Health check
++      responses:
++        "200":
++          description: Service is healthy
++          content:
++            application/json:
++              schema:
++                $ref: "#/components/schemas/Health"
++  /stocks:
++    get:
++      summary: List all stocks
++      responses:
++        "200":
++          description: Stock list
++          content:
++            application/json:
++              schema:
++                type: array
++                items:
++                  $ref: "#/components/schemas/Security"
++  /stocks/{ticker}:
++    get:
++      summary: Find stock by ticker
++      parameters:
++      - name: ticker
++        in: path
++        required: true
++        schema:
++          type: string
++      responses:
++        "200":
++          description: Stock found
++          content:
++            application/json:
++              schema:
++                $ref: "#/components/schemas/Security"
++        "404":
++          description: Not found
++components:
++  schemas:
++    Security:
++      type: object
++      required:
++      - ticker
++      - companyName
++      properties:
++        ticker:
++          type: string
++          example: AAPL
++        companyName:
++          type: string
++          example: Apple Inc.
++    Health:
++      type: object
++      required:
++      - status
++      properties:
++        status:
++          type: string
++          example: ok
+diff --git a/ingress/api-explorer/contracts/trade-processor-openapi.yaml b/ingress/api-explorer/contracts/trade-processor-openapi.yaml
+new file mode 100644
+index 0000000..a3b5fcc
+--- /dev/null
++++ b/ingress/api-explorer/contracts/trade-processor-openapi.yaml
+@@ -0,0 +1,69 @@
++openapi: 3.0.1
++info:
++  title: "Trade Processor - TraderX"
++  version: "1.0"
++paths:
++  /tradeservice/order:
++    post:
++      operationId: processOrder
++      responses:
++        '200':
++          description: Trade booking result
++  /:
++    get:
++      operationId: docsRoot
++      responses:
++        '302':
++          description: Redirect to OpenAPI docs
++components:
++  schemas:
++    TradeOrder:
++      type: object
++      properties:
++        id:
++          type: string
++        accountId:
++          type: integer
++          format: int32
++        security:
++          type: string
++        side:
++          type: string
++        quantity:
++          type: integer
++          format: int32
++    Position:
++      type: object
++      properties:
++        accountId:
++          type: integer
++          format: int32
++        security:
++          type: string
++        quantity:
++          type: integer
++          format: int32
++    Trade:
++      type: object
++      properties:
++        id:
++          type: string
++        accountId:
++          type: integer
++          format: int32
++        security:
++          type: string
++        side:
++          type: string
++        state:
++          type: string
++        quantity:
++          type: integer
++          format: int32
++    TradeBookingResult:
++      type: object
++      properties:
++        trade:
++          $ref: '#/components/schemas/Trade'
++        position:
++          $ref: '#/components/schemas/Position'
+diff --git a/ingress/api-explorer/contracts/trade-service-openapi.yaml b/ingress/api-explorer/contracts/trade-service-openapi.yaml
+new file mode 100644
+index 0000000..34cff6d
+--- /dev/null
++++ b/ingress/api-explorer/contracts/trade-service-openapi.yaml
+@@ -0,0 +1,58 @@
++openapi: 3.0.1
++info:
++  title: FINOS TraderX Trade Service
++  version: 0.1.0
++servers:
++  - url: ''
++paths:
++  /trade/:
++    post:
++      tags:
++        - trade-order-controller
++      operationId: createTradeOrder
++      requestBody:
++        content:
++          application/json:
++            schema:
++              $ref: '#/components/schemas/TradeOrder'
++        required: true
++      responses:
++        '200':
++          description: OK
++          content:
++            application/json:
++              schema:
++                $ref: '#/components/schemas/TradeOrder'
++        '404':
++          description: Unknown account or ticker
++components:
++  schemas:
++    TradeOrder:
++      type: object
++      properties:
++        id:
++          type: string
++          example: 'ABC-123-XYZ'
++        state:
++          type: string
++          example: 'New'
++        security:
++          type: string
++          example: 'ADBE'
++        quantity:
++          type: integer
++          format: int32
++          example: 100
++        accountId:
++          type: integer
++          format: int32
++          example: 22214
++        accountID:
++          type: integer
++          format: int32
++          example: 22214
++        side:
++          type: string
++          enum:
++            - Buy
++            - Sell
+diff --git a/ingress/api-explorer/index.html b/ingress/api-explorer/index.html
+new file mode 100644
+index 0000000..470f1d0
+--- /dev/null
++++ b/ingress/api-explorer/index.html
+@@ -0,0 +1,191 @@
++<!doctype html>
++<html lang="en">
++  <head>
++    <meta charset="utf-8" />
++    <meta name="viewport" content="width=device-width, initial-scale=1" />
++    <title>TraderX API Docs</title>
++    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
++    <style>
++      body { margin: 0; background: #f5f7fb; }
++      .topbar {
++        background: #0b233a;
++        color: #fff;
++        padding: 12px 16px;
++        font-family: sans-serif;
++        display: flex;
++        align-items: center;
++        justify-content: space-between;
++        gap: 12px;
++      }
++      .topbar small { opacity: 0.8; }
++      .topbar a {
++        color: #9fd0ff;
++        font-size: 14px;
++        text-decoration: none;
++        border: 1px solid rgba(159, 208, 255, 0.55);
++        border-radius: 6px;
++        padding: 6px 10px;
++        white-space: nowrap;
++      }
++      .topbar-links {
++        align-items: center;
++        display: inline-flex;
++        gap: 8px;
++      }
++      .topbar a:hover {
++        background: rgba(159, 208, 255, 0.18);
++      }
++      #swagger-ui { max-width: 1300px; margin: 0 auto; }
++    </style>
++  </head>
++  <body>
++    <div class="topbar">
++      <div>
++        TraderX API Docs
++        <small id="state-label"></small>
++      </div>
++      <div class="topbar-links">
++        <a href="/">Back to App</a>
++        
++      </div>
++    </div>
++    <div id="swagger-ui"></div>
++    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
++    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-standalone-preset.js"></script>
++    <script>
++      function deriveRuntimeBasePath(service) {
++        if (!service || !service.runtimeSpecPath) {
++          return null;
++        }
++
++        const explicit = typeof service.runtimeBasePath === 'string' ? service.runtimeBasePath.trim() : '';
++        if (explicit) {
++          return explicit.startsWith('/') ? explicit : `/${explicit}`;
++        }
++
++        if (!service.runtimeSpecPath.startsWith('/')) {
++          return null;
++        }
++
++        const segments = service.runtimeSpecPath.split('/').filter(Boolean);
++        if (segments.length < 2) {
++          return null;
++        }
++        return `/${segments[0]}`;
++      }
++
++      function resolveSpecKey(specUrl) {
++        if (!specUrl || typeof specUrl !== 'string') {
++          return null;
++        }
++        try {
++          return new URL(specUrl, window.location.origin).toString();
++        } catch (_error) {
++          return null;
++        }
++      }
++
++      function selectedSpecUrl(ui) {
++        if (!ui || !ui.specSelectors || typeof ui.specSelectors.url !== 'function') {
++          return null;
++        }
++        const raw = ui.specSelectors.url();
++        if (!raw) {
++          return null;
++        }
++        if (typeof raw === 'string') {
++          return raw;
++        }
++        if (typeof raw.toJS === 'function') {
++          return raw.toJS();
++        }
++        return String(raw);
++      }
++
++      async function bootstrap() {
++        const response = await fetch('./catalog.json', { cache: 'no-cache' });
++        if (!response.ok) {
++          throw new Error('failed to load API catalog');
++        }
++
++        const catalog = await response.json();
++        const services = Array.isArray(catalog.services) ? catalog.services : [];
++        if (services.length === 0) {
++          throw new Error('API catalog is empty');
++        }
++
++        const urls = services.map((service) => ({ name: service.name, url: service.specUrl }));
++        const knownPrefixes = [];
++        const serviceBySpec = new Map();
++        for (const service of services) {
++          const specKey = resolveSpecKey(service.specUrl);
++          const runtimeBasePath = deriveRuntimeBasePath(service);
++          if (runtimeBasePath) {
++            knownPrefixes.push(runtimeBasePath);
++          }
++          if (specKey) {
++            serviceBySpec.set(specKey, {
++              ...service,
++              runtimeBasePath,
++            });
++          }
++        }
++
++        const stateLabel = document.getElementById('state-label');
++        if (stateLabel && catalog.stateId) {
++          stateLabel.textContent = ` - state ${catalog.stateId}`;
++        }
++        window.ui = SwaggerUIBundle({
++          dom_id: '#swagger-ui',
++          urls,
++          deepLinking: true,
++          defaultModelsExpandDepth: -1,
++          displayRequestDuration: true,
++          docExpansion: 'list',
++          filter: true,
++          layout: 'StandaloneLayout',
++          persistAuthorization: true,
++          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
++          requestInterceptor: (request) => {
++            if (!request || !request.url) {
++              return request;
++            }
++
++            const activeSpec = selectedSpecUrl(window.ui);
++            const activeSpecKey = resolveSpecKey(activeSpec);
++            const service = activeSpecKey ? serviceBySpec.get(activeSpecKey) : null;
++            if (!service || !service.runtimeBasePath) {
++              return request;
++            }
++
++            let parsed;
++            try {
++              parsed = new URL(request.url, window.location.origin);
++            } catch (_error) {
++              return request;
++            }
++
++            const hasKnownPrefix = knownPrefixes.some((prefix) =>
++              parsed.pathname === prefix || parsed.pathname.startsWith(`${prefix}/`));
++            if (hasKnownPrefix) {
++              return request;
++            }
++
++            const normalizedPath = parsed.pathname.startsWith('/') ? parsed.pathname : `/${parsed.pathname}`;
++            parsed.pathname = `${service.runtimeBasePath}${normalizedPath}`.replace(/\/{2,}/g, '/');
++            parsed.host = window.location.host;
++            parsed.protocol = window.location.protocol;
++            request.url = parsed.toString();
++            return request;
++          },
++        });
++      }
++
++      bootstrap().catch((error) => {
++        const el = document.getElementById('swagger-ui');
++        if (!el) return;
++        el.innerHTML = `<pre style="padding:16px;color:#a40000;">${String(error)}</pre>`;
++      });
++    </script>
++  </body>
++</html>
 diff --git a/ingress/nginx.traderx.conf.template b/ingress/nginx.traderx.conf.template
 new file mode 100644
-index 0000000..7272725
+index 0000000..565d298
 --- /dev/null
 +++ b/ingress/nginx.traderx.conf.template
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,101 @@
 +server {
 +    listen 8080;
 +    server_name ${NGINX_HOST};
@@ -2506,6 +5197,16 @@ index 0000000..7272725
 +        proxy_set_header X-Forwarded-Proto $scheme;
 +        proxy_set_header X-Forwarded-Prefix /trade-processor;
 +        proxy_pass ${TRADE_PROCESSOR_URL};
++    }
++
++    location = /api/docs {
++        return 301 /api/docs/;
++    }
++
++    location /api/docs/ {
++        alias /usr/share/nginx/html/api-docs/;
++        index index.html;
++        try_files $uri $uri/ /api/docs/index.html;
 +    }
 +
 +    location / {
@@ -2951,13 +5652,13 @@ index 0000000..f71f48b
 +- Data source: `PeopleJsonFilePath` in `appsettings.json`
 diff --git a/people-service/SPEC.manifest.json b/people-service/SPEC.manifest.json
 new file mode 100644
-index 0000000..8f8f53b
+index 0000000..5ea1aca
 --- /dev/null
 +++ b/people-service/SPEC.manifest.json
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,33 @@
 +{
 +  "schemaVersion": "1.0.0",
-+  "generatedAtUtc": "2026-03-31T12:59:32Z",
++  "generatedAtUtc": "2026-07-22T12:27:30Z",
 +  "component": {
 +    "id": "people-service",
 +    "kind": "service",
@@ -2971,7 +5672,8 @@ index 0000000..8f8f53b
 +  "runtime": {
 +    "defaultPort": 18089,
 +    "dependsOn": [],
-+    "requiredEnv": ["PEOPLE_SERVICE_PORT","CORS_ALLOWED_ORIGINS"]
++    "requiredEnv": ["PEOPLE_SERVICE_PORT","CORS_ALLOWED_ORIGINS"],
++    "healthHint": "http://<host>:18089/swagger"
 +  },
 +  "contracts": {
 +    "primary": "specs/001-baseline-uncontainerized-parity/contracts/people-service/openapi.yaml"
@@ -3157,13 +5859,13 @@ index 0000000..e33f4c7
 +- CORS allowlist: `CORS_ALLOWED_ORIGINS` (default `*`)
 diff --git a/position-service/SPEC.manifest.json b/position-service/SPEC.manifest.json
 new file mode 100644
-index 0000000..948f7d9
+index 0000000..6b42c56
 --- /dev/null
 +++ b/position-service/SPEC.manifest.json
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,33 @@
 +{
 +  "schemaVersion": "1.0.0",
-+  "generatedAtUtc": "2026-03-31T12:59:32Z",
++  "generatedAtUtc": "2026-07-22T12:27:30Z",
 +  "component": {
 +    "id": "position-service",
 +    "kind": "service",
@@ -3177,7 +5879,8 @@ index 0000000..948f7d9
 +  "runtime": {
 +    "defaultPort": 18090,
 +    "dependsOn": ["database"],
-+    "requiredEnv": ["POSITION_SERVICE_PORT","DATABASE_TCP_HOST","DATABASE_TCP_PORT","DATABASE_NAME","DATABASE_DBUSER","DATABASE_DBPASS","CORS_ALLOWED_ORIGINS"]
++    "requiredEnv": ["POSITION_SERVICE_PORT","DATABASE_TCP_HOST","DATABASE_TCP_PORT","DATABASE_NAME","DATABASE_DBUSER","DATABASE_DBPASS","CORS_ALLOWED_ORIGINS"],
++    "healthHint": "http://<host>:18090/positions/22214"
 +  },
 +  "contracts": {
 +    "primary": "specs/001-baseline-uncontainerized-parity/contracts/position-service/openapi.yaml"
@@ -3195,17 +5898,18 @@ index 0000000..948f7d9
 +}
 diff --git a/position-service/build.gradle b/position-service/build.gradle
 new file mode 100644
-index 0000000..0d06b87
+index 0000000..5d22c03
 --- /dev/null
 +++ b/position-service/build.gradle
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,40 @@
 +plugins {
 +  id 'java'
-+  id 'org.springframework.boot' version '3.5.15'
++  id 'org.springframework.boot' version '3.5.16'
 +  id 'io.spring.dependency-management' version '1.1.7'
 +}
 +
-+ext['tomcat.version'] = '10.1.55'
++ext['jackson-bom.version'] = '2.22.1'
++ext['tomcat.version'] = '10.1.57'
 +
 +group = 'finos.traderx.position-service-specfirst'
 +version = '0.1.0'
@@ -3223,13 +5927,13 @@ index 0000000..0d06b87
 +  implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 +  implementation 'com.h2database:h2:2.4.240'
 +  implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.17'
++  implementation 'org.apache.logging.log4j:log4j-api:2.26.1'
++  implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.26.1'
 +
 +  implementation ('ch.qos.logback:logback-core:1.5.34') {
-+    because 'version brought in by spring boot 3.5.15 affected by CVE-2024-12798'
++    because 'version brought in by spring boot affected by CVE-2024-12798'
 +  }
 +  implementation 'ch.qos.logback:logback-classic:1.5.34'
-+  implementation 'org.apache.logging.log4j:log4j-api:2.26.0'
-+  implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.26.0'
 +  implementation 'org.apache.commons:commons-lang3:3.20.0'
 +
 +  testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -3238,6 +5942,1141 @@ index 0000000..0d06b87
 +tasks.withType(Test).configureEach {
 +  useJUnitPlatform()
 +}
+diff --git a/position-service/gradle/wrapper/gradle-wrapper.jar b/position-service/gradle/wrapper/gradle-wrapper.jar
+new file mode 100644
+index 0000000000000000000000000000000000000000..9bbc975c742b298b441bfb90dbc124400a3751b9
+GIT binary patch
+literal 43705
+zcma&Obx`DOvL%eWOXJW;<L>V64viP??$)@wHcsJ<yG!Hl?(U7dFYnCW{r1k?dA}jz
+z`Gcs6s9#i`JSR_PKBXuF4uJsz0|NsB0z&+G{=YvI5Lgg7F;yWtDS2@QSt$`Qc@;4=
+zRY(xfzuvO0rR}uJ{>68)>bJS6*&iHnskXE8MjvIPVl|FrmV}Npeql07fCw6`pw`0s
+zGauF(<*@v{3t!qoUU*=j)6;|-(yg@jvDx&fV^trtZt27?4Tkn729qrItVh@PMwG5$
+z+oXHSPM??iHZ!cVP~gYact-CwV`}~Q+R}PPNRy+T-geK+>fHrijpllon_F4N{@b-}
+z1M0=a!VbVmJM8Xk@NRv)m&aRYN}FSJ{LS;}2ArQ5baSjfy40l@T5)1r-^0fAU6f_}
+zzScst%$Nd-^ElV~H0TetQhMc%S{}Q4lssln=|;LG?Ulo}*mhg8YvBAUY7YFdXs~vv
+zv~{duzVw%C#GxkBwX=TYp1Dh*Uaum2?RmsvPaLlzO^fIJ`L?&OV?Y&kKj~^kWC`Ly
+zfL-}J^4a0Ojuz9O{jUbIS;^JatJ5+YNNHe}6nG9Yd6P-lJiK2ms)A^xq^H2fKrTF)
+zp!6=`Ece~57>^9(RA4OB9;f1FAhV%zVss%#rDq$9ZW3N2cXC7dMz;|UcRFecBm`DA
+z1pCO!#6zKp#@mx{2>Qcme8y$Qg_gnA%(`Vtg3ccwgb~D(&@y8#Jg8nNYW*-P{_M#E
+zZ|wCsQoO1(iIKd-2B9xzI}?l#Q@G5d$m1Lfh0q;iS5FDQ&9_2X-H)VDKA*fa{b(sV
+zL--krNCXibi1+*C2;4qVjb0KWUVGjjRT{A}Q*!cFmj0tRip2ra>WYJ>ZK4C|V~RYs
+z6;~+*)5F^x^aQqk9tjh)L;DOLlD8j+0<>kHc8<MT8<q;@cs^TP%TBGLJb3?hF`f1u
+zr^#HdaN9hgmYP%3&4eX^>MN|68PxQV`tJFbgxSfq-}b(_h`luA0&<H)Ks&ZC5avn$
+zblv>;Vk<@5<kF$(jU%Y1<)oJ9n#F!_Nzr$1q5g8vk%4E5n+!%&?C??!2P`6+_1%cB
+zz~CmX+0avvVR!Fm9DBz=5OYDMzyT5o=mbbC1@y!;y!`Xf(U~IBp=}v8UBCUG8>1i0
+z_cu6{_*=vlvYbKjDawLw+t^H?OV00_73Cn3goU<yjj&HS+sgjt5ulpVMAFPV!h#%(
+z;O+R^(R7duR?KDiP~~*Sz}yNf2S{i|h1xTKnI_B>5?})UYFuoSX6Xqw;TKcrsc|r#
+z$sMWYl@cs#SVopO$hpHZ)cdU-+Ui%z&Sa#lMI~zWW@vE%QDh@bTe0&V9nL>4Et9`N
+zGT8(X{l@A~loDx}BDz`m6@tLv@$mTlVJ;4MGuj!;9Y=%;;_kj#o8n5tX%@M)2I@}u
+z_{I!^7N1BxW9`g&Z+K#lZ@7_dXdsqp{W9_`)zgZ=sD~%WS5s$`7z#XR!Lfy(4se(m
+zR@a3twgMs19!-c4jh`PfpJOSU;vShBKD|I0@rmv_x|+ogqslnLLOepJpPMOxhRb*i
+zGHkw<C6i>f#?ylQ@k9QJL?!}MY4i7joSzMcEhrDKJH&?2v{-tgCqJe+Y0njl7HYff
+z{&~M;JUXVR$qM1FPucIEY(IBAuCHC@^~QG6O!dAjzQBxDOR~lJEr4KS9R*idQ^p{D
+zS#%NQADGbAH~6wAt}(1=Uff-1O#ITe)31zCL$e9~{w)gx)g>?zFE{Bc9nJT6xR!i8
+z)l)~9&~zSZTH<f>k{?iQL^MQo$wLi}`B*qnvUy+Y*jEraZMnEhuj`Fu+>b5xD1_Tp
+z)8|wedv42#3AZUL7x&G@p@&zcUvPkv<gOT$sg9nDsP`h2d9g#)Sfr@kmW^OuGVzBe
+z-mcj_6tCQbJjPpCR0_6&eS`PLDmBn1jc_}#l=&oN(1kZX%4pnohcH*OTaAUFUQR9I
+zJsE{W;L}Y`SMW2`Yxlamz6R=sERGI$HJ&wT!!xuJCXi~%#!zT5#JMaroI8+$NZU!j
+zFFo1(OoSgnZ`tOBNEeS}AJTa*w)!5g*s2NJdIyH_O<3^t7uCBd5c|%jlVJAD=GPv6
+zGy{$r4IuY4V;#IhoM9(k9N?|GBT!0wNQtL*(Wla6D)K3^HTQh9<!?y8pnvCIy%Of4
+zum(WCu{ljigy+8e*vg{OEP4h-N6?BPRwPrLau9K*^W?WW;LAPzYRy1|S<{}2ayMO6
+z8Gk5*s)+cT;R6e$f61Q!-QhR7$s`=CY0vN!#Gm}?vOh0St8%mcv%@1{x_S+@@wk7+
+zFHA$hX%gbrT2VQ8hV%{#=997-Aa7v_qGy2j`{6(KD}jjYS=X4TTgcc_#&`99oP{`1
+z+?qRA0-j~Bi$<R4kd7i0PY(>g=YJS6?1B7ZEXr4b>M+9Gli$gK-Sgh{O@>q7TUg+H
+zNJj`6q#O@>4HpPJEHvNij`sYW&u%#=215HKNg;C!0#hH1vlO<x`KH1(L52Jfzqckp
+zK+CZ7Ysjx9Ry1%Exbc$7q$%?P{F`qK)zp<pKl6?{P-tc#d(^voQM{*HzaqZ$MF6+j
+zS~SbNnOTb~v^`{pTqA`20=exoU<o^ZUk`ng!~@i!3dZcf;2^$k_C@g8WV8ec1R9H3
+z1`mCus@E!98f~!1rPz5UtUeu7G^^TU%W)2pTm^QP5I*2-sUu2=PL2Gs`-60K_$N2v
+zq}PJt3O#wc`jCA!5t<`h+K4FljR)C<HUy;}xwV&b`+VADm9(!vPCRX?^<oG+Vqeyc
+zzAmc*_iJ~=?~J-H*{$GHN4NIN0}j0yD3GR_r7^*==U{*u<)Ms-C|SiYB&zk-Wp@Y%
+zp&S*-{+zxwY`#DQ<w|BzbKuAp({yI0gR5k4q=KVfX|Z@&C2D=%htF<kWp>5+dFq9&
+zS)8{5_%hz?#D#wn&nm@aB?1_|@kpA<uzp&}l&AD1u)JhYR;ZXh9aBhZCzAtxS13Bp
+zA6Zy}vU8v^?dRy1PIC=7_PA-v<La!D;#*&-5%sU))yJ_yayZVijq+d8MU%ahLUSA$
+zb0EHFFV2D{O}X^o(5AJif==$^X=iGGhpJ4KYw@<T@0PxkDnjx1LyF6S1hcurMfQm5
+zJhtbDMr1*Q{|1EZ*mS}Qd33Qo7~2#jY)+05;Xfi)zKK9EDUF$=6E5F1W+xgADW`s2
+zH|$E3Fed+2a!z;4mZn&JN5DxUfPSaKxluwruV#d2eoAHtR&D=*wdN6FVZ6oI2g0Hw
+zOP;PSG}*`dJEr(*FvR10V<#_MSwpBkIpj_jL>@{%jYcs{K%$a4W{<UY0d}<G_tvcW
+zMNcwn<nVcftdCFzNuiwF_|8?DI$6#{zbc7GvkUvU3|!{Ax?HKf@j9mrId!xHE6!-2
+z{C)xYPtH9rOV?L9kcZN6$krD3qudB?$8^ttXzA!P2B|T6$sO-q_YsmhfI9ntr>k@F
+zPyTav?jb;F(|GaZhm6&M#g|`ckO+|mCtAU)5_(<C;Peqq9IE<_AsNiFs{{>hn&Ogd
+z9Ku}orOMu@K^Ac>eRh3+0-y^F`j^noa*OkS3p^tLV`TY$F$cPXZJ48!xz1d7%vfA(
+zUx2+sDPqHfiD-_wJDb38K^LtpN2B0w=$A10z%F9f_P2aDX63w7zDG5CekVQJGy18I
+zB!tI`6rZr7TK10L(8bpiaQ>S@b7r_u@lh^vakd0e6USWw7W%d_Ob%M!a`K>#I3r-w
+zo2^+9Y)Sb?P9)x0iA#^ns+Kp{JFF|$09jb6ZS2}_<-=$?^#IUo5;g`4ICZknr!_aJ
+zd73%QP^e-$%Xjt|28xM}ftD|V@76V_qvNu#?Mt*A-OV{E4_zC4Ymo|(cb+w^`Wv==
+z>)c%_U0w`d$^`lZQp@midD89ta_qTJW~5lRrIVwjRG_9aRiQGug%f3p@<N8PMQE{a
+zd_6w48$rsd^cXZQ7Dwk9nz}YC&*86L&Yst+a`$%*_e1yJh%kgNQXk4z5r6m?Y@2xN
+zly?J=iN07}T>;*%Y@J5uQ|#dJ+P{Omc`d2VR)DXM*=ukjVqIpkb<9gn9{*+&#p)Ek
+zN=4zwNWHF~=Gqc<UjtcOL9OLcIawlSDS7cyPainIsyG~{9o!H&xa9hYf#oyhSccci
+zt8ciEDfpw+|JDHKvIGdAID*M?Ww(Uo_>Lkd!q0p(S2_K=Q`$whZ}r@ec_cb9hhg9a
+z6CE=1n8Q;hC?;ujo0numJBSYY6)GTq^=kB~`-qE*h%*V6-ip=c4+Yqs*7C@@b4YAi
+zuLjsmD!5M7r7d5ZPe>4$;iv|zq=9=;B$lI|xuAJwi~j~^Wuv!Qj2iEPWjh<cjq`B2
+zQQyz_oTCXImfm@9L;Jg(EcYq6*mZ2Ar7Wg-A&#d%mn;}2vkz#+K|`?Os_iMQICL7M
+z%X3DlLx`B&@S70b+8_uUYlQ7Jjwqbip^{Sy&<=Xy_(h{9O0(ZA&bm55akipSI@h-P
+zouFPBu_Do|z_f_JGMu+d26M|qD0mf|&pPvU(0X6B(p676+94<iS<G;?SQn?!TsCT<
+zW`oSdht$$w66GB-l}L1v_Gel0yjn`(hShw}$Zca>9Z&#<HMI*Z2_1}T(Ag7?VQuOk
+z`{mYjKhEP<qwlCQ<3{~SgOxwbx2t!SbHzjBYU=s|B(D4sC75oIbo;F+(N+m9uUJay
+z3zRQ;6klQ`P7c#H*XA(0OTAp7rMZSXB;)Q$&ymhbN*ra}sd<0WM1I3@<CsDWXd;ki
+z&@?%;r2lEn-Rstvl;9}rizIur@q3(@kvLvHJ^t^eGQ9G#)J~{}lP*OWXqf7ze8OWy
+z5Rgs^5D>+G>lZQpZ@(xfBrhc{rlLwOC;opt<Bi<dsH_Yf{WPKs9reW6WSuhO9Lv`J
+z^%&id)VSO@jT9{?+)0RW%3gsMRWsJNqP+s@Agpg+Fbck0IbJz}ettAGj7<$cpWvte
+z6!<*<{!y4dAH~kmjKRziU~Fx|U}SB<AYx}@1F$ugwXii2ax`<XF|l<Pb2l=vceb#z
+zr8lw$I63{F=af?zmj-7-$zEDn&|(O{iskxs=4#PjtBP81^sD$wd-1XbZiaEHaTAOo
+zQD4&~nfoQEH>JZDj4Xfu3$u6rt_=YY0~lxoy~fq=*L_&RmD7dZWBUmY&12S;(Ui^y
+zBpHR0?Gk|`U&CooNm_(kkO~pK+cC%uVh^cnNn)MZjF@l{_bvn4`Jc}8QwC5_)k$zs
+zM2qW1Zda%bIgY^3NcfL)9ug`05r5c%8ck)J6{fluBQhVE>h+IA&Kb}~$55m-^c1S3
+zJMXGlOk+01qTQUFlh5Jc3xq|7McY$nCs$5=`8Y;|il#Ypb{O9}GJZD8!kYh{TKqs@
+z-mQn1K4q$yGeyMcryHQgD6Ra<6^5V(>6_qg`3uxbl|T&cJVA*M_+OC#>w(xL`RoPQ
+zf1ZCI3G%;<gu?&p>o-x>RzO!mc}K!XX{1rih0$~9XeczHgHdPfL}4IPi~5EV#ZcT9
+zdgkB3+NPbybS-d;{8%bZW^U+x@Ak+uw;a5JrZ<t9b~FAko|dNnqw@`fG4fl;gO}GN
+zja@xAhij0PWn_9yAtqa|Q~JyS@OCX>H!WbNvl<c^f{)!@kr}sV306x!m(JFK2Su#H
+zA{l>!b~r4*vs#he^bqz`W93PkZna2oYO9dBrKh2QCWt{dGOw)%Su%1bIjtp4dKjZ^
+zWfhb$M0MQiDa4)9rkip9DaH0_tv=XxNm>6MKeWv>`KNk@QVkp$Lhq_~>M6S$oliq2
+zU6i7bK;TY)m>-}X7hDTie>cc$J|`*}t=MAMfWIALRh2=O{L57{#fA_9LMnrV(HrN6
+zG0K_P5^#$eKt{J|#l~U0WN_3)p^LLY(XEqes0OvI?3)GTNY&S13X+9`6PLVFRf8K)
+z9x@c|2T72+-KOm|kZ@j4EDDec>03FdgQlJ!&FbUQQH+nU^=U3Jyrgu97&#-W4C*;_
+z(WacjhBDp@&Yon<9(BWPb;Q?Kc0gR5ZH~aRNkPAWbDY!FiYVSu!~Ss^9067|JCrZk
+z-{Rn2KEBR|Wti<xxNV#Db47^*a|{iSLoUSn+}XCk5${GR@Qb+|Eox;WbSB?b>_iy)
+zXnh2wiU5Yz2L!W{{_#LwNWXeNPHkF=jj<Oca}a<VYq$(Z)L~2{hsCZ>XmHC@n*oiz
+zIoM~Wvo^T@@t!QQW?Ujql-GBOlnB|HjN@x~K8z)c(X}%%5Zcux09vC8=@tvgY>czq
+z3D(U&FiETaN9aP}FDP3ZSIXIffq>M3{~eTB{uauL07oYiM=~K(XA{SN!rJLyXeC+Y
+zOdeebgHOc2aCIgC=8>-Q>zfuXV*=a&gp{l#E@K|{qft@YtO>xaF>O7sZz%8);e86?
+z+jJlFB{0fu6%8ew^_<+v>>%6eB8|t*_v7gb{x=vLLQYJKo;p7^o9!9A1)fZZ8i#ZU
+z<|E?bZakjkEV8xGi?n+{Xh3EgFKdM^;4D;5fHmc04PI>6oU>>WuLy6jgpPhf8$K4M
+zjJo*MbN0rZbZ!5DmoC^@hbqXiP^1l7I5;Wtp2i9Jkh+KtDJoXP0O8qmN;Sp(+%upX
+zAxXs*qlr(ck+-QG_mMx<HJPMiiyFhyvyc$BVLB{06!#fNnvcq+4(CeJ9NSp(yBP{p
+zz9+FDyloDA-5BFzU$X6O5`cUWFMHGQXtH9zX=W;Z0SMrXCMHY77EA&39fq<AIjYX_
+zL-)E@whkh@FYnG!*@-)hr`+%$^!mR-H_bvW274&&>?hQNXVV~LT{$Q$ShX+&x?Q7v
+z@8t|UDylH6@RZ?WsMVd3B0z5zf50BP6U<&X_}+y3uJ0c5OD}+J&2T8}A%2Hu#Nt_4
+zoOoTI$A!hQ<2pk5wfZDv+7Z{yo+Etqry=$!*pvYyS+kA4xnJ~3b~TBmA8Qd){w_bE
+zqDaLIjnU8m$wG#&T!}{e0qmHHipA{$j`%KN{&#_Kmjd&#X-hQN+ju$5Ms$iHj4r?)
+z&5m8tI}L$ih&95AjQ9EDfPKSmMj-@j?Q+h~C3<|Lg2zVtfKz=ft{YaQ1i6Om&EMll
+zzov%MsjSg=u^%EfnO+W}@)O<s4y0<!F*}jN{~^*=<<M!`pCE38_&X5u{wE+7HZiqx
+zG!eIObaGa4G5p`k`7da0P_t5)HNf!I6NGD^#Jcju!NjqqL7(FK$?;p8B-cTjS(f#p
+zHML@9bjCH8>6u0LwoX709h3Cxdc2Rwgjd%LLTChQvHZ+y<1q6kbJXj3_pq1&MBE{8
+zd;aFotyW>4WHB{JSD8Z9M@jBitC1RF;!B8;Rf-B4nOiVbGlh9w51(8WjL&e{_iXN(
+zAvuMDIm_>L?rJPxc>S`bqC|W$njA0MKWa?V$u6mN@PLKYqak!bR!b%c^ze(M`ec(x
+zv500337YCT4gO3+9>oVIJLv$pkf`01S(DUM+4u!HQob|IFHJHm#>eb#eB1X5;bMc|
+z>QA4Zv}$S?fWg~31?Lr(C>MKhZg>gplRm`2WZ--iw%&&YlneQYY|PXl;_4*>vkp;I
+z$VYTZq|B*(3(y17#@ud@o)XUZPYN*rStQg5U1Sm2gM}7hf_G<>*T%6ebK*tF(kbJc
+zNPH4*xMnJNgw!ff{YXrhL&V$6`ylY={qT_xg9z<NbPza#S5_;7-HDWW5RigZ=LV6*
+zC(tYTyWThzXHf4MXBa7hZbsubd?Ryu_#A)%-?VnWgzy8ET!tu|{8#c_&gaH`oCBdA
+zDZ_rb+3zi849gP{1S5P<jk#MGP++DGAy-3vwo{u^X(9-1cLI-eD^5-vRFWj~@&pA;
+zVHMOE7R0Uo3r+HxoApr;N3Ucb6+Fi&Rw>nQWw9>PlG~IbhnpsG_94Kk_(V-o&v7#F
+znra%uD-}KOX2dkak**hJnZZQyp#ERyyV^lNe!Qrg=VHiyr7*%j#PMvZMuYNE8o;JM
+zGrnDWmGGy)(UX{rLzJ*<yAEppP~EY>QEBd(VwMBXnJ@>*F8eOFy|FK*Vi0tYDw;#E
+zu#6eS;%Nm2KY+7dHGT3m{TM7sl=z8|V0e!DzEkY-RG8vTWDdSQFE|?+&FYA146@|y
+zV(JP>LWL;TSL6rao@W5fWqM1-xr$gRci#RQV2DX-x4@`w{uEUgoH4G|`J%H!N?*Qn
+zy~rjzuf(E7E!A9R2bSF|{{U(zO+;e29K_dGmC^p7MCP!=Bz<LU?&i-}KG6X?-t~{t
+z6;cwZkN#6(bfNz)LHYiZ1eLM1bF=-Y%KTGzRGb0MCjXM5S?b4b=q6Yne5@ub&Z1fi
+zwe1K(xpIl(UuqiL&9zbE3--S?_yjh~vM9{@56fnz)vH22_-yvCYe2Y7H${#(Jncbu
+zdEOFD?GkNqW$#j4@v}(bNmkD>q@}&AdF5=rt<!COJnb)nu<w2#Fc9&zR-N5X<)-uZ
+z$<fUbN+So80PB;-k3&vQQgFt#a4A~G5i7YfkwVod(g_caMdbNUgH}RSd$;2i>Cwka
+zTT1A?5o}i*sXCsRXBt)`?nOL$zxuP3i*rm<aImxvw^U@{B*fUS0^1}v7Fr7%=t{5R
+zr{ZxLLkwm{RxNy^ZS6xw>3Gmbmr6}9HCLvL*45d|(zP;q&(v%}S5yBmRVdYQQ24zh
+z6qL2<2>StU$_Ft29Iy<fP{_A}(TLFc`ulnZB85D4f`?3P{(NRH&`r%oRcE}aoRUTu
+zE?7Y|z|k@bRY%JdWY5F(IA^2{CsLJ|)7+Sk)-1LuGjdpW2<~xRpIawD7|b}pzW)Q9
+zAY5MSu{bw_VLh`wPo4Jb7n0QMsV))LK}%s$WqXQ<7NQ-5!+}@QkF+dLPzuz#x@W)<
+znhWO;3yF&C)0P|n)1lp<2aeQ_$@3&mI?kFLSzhC?s<NQdC{FP%I#bp;kORX{l<3x0
+zI8yQp7E^WBY)WEgiAkeUv{*@dstpdRH)q&jD@2v`EidG8QsD}**_mj0v08)ZlDq;v
+z=LqggR_Jz_t>F!6=!@;tW=o8vNzVy*hh}XhZhUbxa&;9~woye<_YmkUZ)S?PW{7t;
+zmr%({tBlRLx=ffLd60`e{PQR3NUniWN2W^~7Sy~MPJ>A#!6PLnlw7O0(`=PgA}JLZ
+ztqhiNcKvobCcB<yMplTfXcPqrYE+vVszVQmm@rg}2{rJGaO7?|y?`3a_S!XcQLG&V
+z?bgXaiD}w%%A$ShO3yHwQZ52?;xk}hq`az4Qz(&ZI4P8rn`^{UhqrR}d!P@Af>el2
+z-N82?4-()eGOisnWcQ9Wp23|ybG?*g!2j#>m3~0__IX1o%dG4b;VF@^B+mRgKx|ij
+zWr5G4jiRy}5n*(qu!W`y54Y*t8g`$YrjSunUmOsqykYB4-D(*(A~?QpuFWh;)A;5=
+zPl|=x+-w&H9B7EZGjUMqXT}MkcSfF}bHeRFLttu!vHD{Aq)3HVhvtZY^&-lxYb2%`
+zDXk7>V#WzPfJs6u{?ZhXpsMdm3kZscOc<^P&e&684Rc1-d=+=VOB)NR;{?0NjTl~D
+z1MXak$#X4{VNJyD$b;U~Q@;zlGoPc@ny!u7Pe;N2l4;i8Q=8>R3<TEv>H{>HU<axH
+zp`GSL-T`v+`h{A=aX;JW4CEU!(+?Uoa0aOL$De+GUOkWsAqa2ZK4FC`K3!1~Zy9HB
+zzvq?1%x_y$*Bv$0)GEimNLh#E5__f1Mpw)(hNBlqy(D20`q=1`jdMVFIk`mBE8>(z
+z%hV2?rSinAg6&wuv1DmXo<vm47<QjMysD@bzHIj93EKq|LsScFN}?1q^I)(oMd!rn
+zn|DubZt_^bCFb75g5Trh|4Qx?zo0F<A>k`5@a3@H0BrqsF~L$pRYHNEXXuRIWom0l
+zR9hrZpn1LoYc+G@q@VsFyMDNX;>_Vf%4>6$Y@j;KSK#g)TZRmjJxB!_NmUMTY(cAV
+zmew<J38CI3YanL~W|fbwxrqJqw<my@*XH*?z?)KSw#4MywnI6A#4U@pFSNEc`Lrv-
+z-S!+OS6bh_zm$&432UozL4&En7L86;ghp^8;$ppb%xO{FV^Pm{yQ`>n7H{z`M3^Z&
+z2O$pWlDuZHAQJ{xjA}B;fuojAj8WxhO}_9>qd0|p0nBXS6IIRMX|8Qa!YDD{9NYYK
+z%JZrk2!Ss(Ra@NRW<7U#%8SZdWMFDU@;q<}%F{|6n#Y|?FaBgV$7!@|=NSVox<B(`
+zIq)S_BbU4&5Y;#+zzGVxaXAWCz*U+(@Q+o!?%YbO5Lnd}NLZ#m2X87gxZsJLNwk+3
+z@~G>lJI4G-G(rn}bh|?m<PI-QoC(rF$EW8<oaZlKv17e{ZZEs5gI5rI>KkaBF$-Yr
+zA;t0r?^5Nz;u6gwxURapQ0$(-su(S+24Ffmx-aP(@8d>GhMtC5x*iEXIKthE*mk$`
+zOj!Uri|EAb4>03C1xaC#(q_I<;t}U7;1Jq<Pun#t0_d*_eJ@mw@913m0*PYiG@}tB
+ztP(s*U6EvObA-KfU!e+*)h*+A8wNY(z9PpR7|ng1RQ75YwD8Ip`2*1~IH(z=Ujxyl
+z<ntP1@(4b<498kKUoYg<(N=o2;8F4n|CejK@H@|3g8~6DMEW~D{f`P>ISVHz3tO{)
+zD(Yu@=>I9FDmDtUiWt81;BeaU{_=es^#QI7>uYl@e$$lGeZ~Q(f$?^3>$<<{n`Bn$
+zn8ba<y1J3mk7QrBkS`^06lBb%XobuZz0Uc3vJW$}oz5rqH-CVXbQ?TYcYWkt$y+%%
+zDGW6>mZlL@6r^RZHV_c5WV7m2(G6X|OI!+04eAnNA5=0v1Z3lxml2#p<Q2Hk_3rET
+z#;|JLdCr%w6PIsdU-R${5=&H%MpF|6*IQEs*~vt<`)osFM7~B}S2*^XM|R%(!bK5x
+z?B98-@YWD?D?WIa89ue2g+&}MCA&<zv{-XU9dkW^Z!-wg1^SV3v?-k+`&iNJ0Tmf1
+z6uA?;4A2J1dJC}17}snGhxuUKB>~Zo57ri;4>;#16sSXXEK#QlH>=b$inEH0`G#<_
+zvp;{+iY)BgX$R!`HmB{S&1TrS=V;*5SB$7*&%4rf_2wQS2ed2E%Wtz@y$4ecq4w<)
+z-?1vz_&u>s?BMrCQG6t9;t&gvYz;@K@$k!Zi=`tgpw*v-#U1Pxy%S9%52`uf$XMv~
+zU}7FR5L4F<#9i%$P=t29nX9VBVv)-y7S$ZW;gmMVBvT$BT8d}B#XV^@;wXErJ-W2A
+zA=Jft<sUW%eIzvD`%|;&1KUO!vBts9$jx)aLl#J~zQpxlFUxMboZ!i0c9Fc`OtVN_
+zc!Oz?NJ1z_+?YXWzG9yyn`e=Y8ro2cgXxj=V=SljU>QR<YtbUwpQ+@vL?uI{$gmcZ
+zYC3@UzzpYKLZewwpeTE~#NkBl55_$s{)OK@ziuA6Ps5h_w}$OMst5l!aNPioCjY)3
+z3|9SgY>L>vNO(!n4mcd3O27bHYZD!a0kI)6b4hzzL9)l-OqWn)a~{VP;=Uo|D~?AY
+z#8grAAASNOkFMbRDdlqVUfB;GIS-B-_YXNlT_8~a|LvRMVXf!<^uy;)d$^OR(u)!)
+zHHH=FqJF-*BXif9uP~`SXlt0pYx|W&7jQnCbjy|8b-i>NWb@!6bx;1L&$v&+!%9BZ
+z0nN-l`&}xvv|wwxmC-ZmoFT_B#BzgQZxtm|4N<cR35n#bARS74OQDTms<32~v8v=`
+z7-caF<C)1AG)W4zO)YE8SJ$Y@<CJ4$G=}`=!37S-py?UnU1Gh2h2n_6&p(Ao5Qqf6
+z=k(-OuAx!R!Y>+|;+(YW&Jtj^g!)iqPG++Z%x0LmqnF875%Ry&2QcCamx!T@FgE@H
+zN39P6e#I5y6Yl&K4eUP{^biV`u9{&CiCG#U6xgGR<Po=AznL^)f6o>Qr)zew;Z%x+
+z-gC>y%gvx<e=sLpgCWdgi6XpJK8=uXJkkm8YE@{r>|dM=OrO`N@P+h2klPtb<Ry(x
+zpu?Xm?4btAWLp$6D_`$o&fb}lDqgV$`64jZuZt*NMiKvp57y55K7Ikao<AXqBElPW
+zh~1j8oF$DxMm1(>YvjS!mNnk4yE0+I&YrSRi?F^plh}hIp_+OKd#o7ID;b;%*c0ES
+z!J))9D&YufGIvNVwT|qsGWiZAwFODugFQ$VsNS%gMi8OJ#i${a4!E3<-4Jj<9SdSY
+z<OXh$_?#e&cT#EB-U!=XwtowFV|9Uhv$sUK3q>&xe|D0V1c`dZv+$8>(}RE|zL{E3
+z-$5Anhp#7}oO(xm#}tF+W=K<zEDOn&&TBZukL{eI>E*3(xxKxhBt-uuJP}`_K#0A<
+zE%rhMg?=b$ot^i@BhE3&)bNBpt1V*O`g?8hhcsV-n#=|9wGCOYt8`^#T&H7{U`yt2
+z{l9Xl5CVsE=`)w4A^%PbIR6uG_5Ww9k`=q<@t9Bu662;o{8PTj<F}p=3(;yTV~Qyf
+zgQDdrLzMjDw7>DBzzbY#tL;$wrpjONqZ{^Ds4oanFm~uyPm#y1Ll3(H57YDWk9TlC
+zq;kebC!e=`FU&q2ojmz~GeLxaJHfs0#F%c(i+~gg$#$XOHIi@<TM;Hv2aC}$s8#Sv
+z+Dd3KT+?=#!iTV?Ms~47n*H>1mA72g2pFEdZSvp}m0zgQb5u2?tSRp#oo!bp`FP}<
+zaK4iuMpH+Jg{bb7n9N6e<k8B#=)v)d%-lnDQKtnG^2KYKtU2;<n>R*NZfgL7QiLxI
+zk6{uKr>xxJ42sR%bJ%m8QgrL|fzo9@?9eQiMW8O`j3teoO_R8cXPe_XiLnlYkE3U4
+zN!^F)Z4ZWcA8gekEPLtFqX-Q~)te`LZnJK_pgdKs)<s7#%|5P$s1t)kN+!Um>Dp50
+zdUq)JjlJeELskKg^6KY!sIou-HUnSFRsqG^lsHuRs`Z{f(Ti9eyd3cwu*Kxp?Ws7l
+z3cN>hGPXTnQK@qBgqz(n*qdJ2wbafELi?b90fK~+#XIkFGU4+Hihn<y_>Wq;{{)1J
+zv*Txl@GlnIMOjzjA1z%g?GsB2(6Zb-8fooT*8b0KF2CdsIw}~Hir$d3TdVHRx1m3c
+z4C3#h@1Xi@{t4zge-#B6jo*ChO%s-R%+9%-E|y<*4;L>$766RiygaLR?X%izyqMXA
+zb|<FVRVPIkP%(S)yIvuu+5z_83buf`qe#ezb);jn)u$oPrWvD(s&~KHbqKNL%cobC
+zN-|C-DK*$CAI~b2Ac6>N=Z-0PSFeH;W6aQ3(5VZWVC>5Ibgi&cj*c%_3=o#VyUJv*
+zM&bjyFOzlaFq;ZW(q?|yyi|_zS%oIuH^T*MZ6NNXBj;&yM3eQ7!CqXY?`7+*+GN47
+zNR#%*ZH<^x{(0@hS8l{seisY~IE*<IWx!UK-u2j(e2O!c*%v`vbRdmnwY3~F@WfqY
+z%qQlFf<s6fB4WlqklvTVl*JK;YI>)BD+R6^OJX}<2HRzo^fC$n>#yTOAZbk<pxtmH
+zJ~q1kaL=GoN56akk-6RD`q2mzV0mH8>4%=Bei=<kddu{Z(hj1<vW)@wW7M&+@6=2s
+zZD&Op_jWe#TTdH<JbSg3bLF85E$EBmVzcroiC)+RvF8h>JEe=o$jm`or0YDw*G?d>
+z=i$eEL7^}_?UI^9$;1Tn9b>$KOM@NAnvWrcru)r`?LodV%lz55O3y(%FqN;cKgj7t
+zlJ7BmLTQ*NDX#uel<G9Op(1@^PULS#3C#Zq5&eylEB%v#D2Qdisi+`5Pk=N?QpqNe
+zn3Q0BprVD+s9yvAi-Ka>GbCY>k+&H*iSK?x-{w;f5G%%!^e4QT9z<_0vHbXW^MLR}
+zeC*jezrU|{*_F`I0mi)9=sUj^G03i@MjXx@ePv@(Udt2CCXVOJhRh4yp~fpn>ssHZ
+z?k(C>2uOMWKW5FVsBo#Nk!oqYbL`?#i~#!{3w^qmCto05uS|hKkT+iPrC-}hU_nbL
+zO622#mJupB21nChpime}&M1+whF2XM?prT-Vv)|EjWYK(yGYwJLRRMCkx;nMSpu?0
+zNwa*<?h%^Uxlo#rhlXX^1ry~0-r)@+JQ4MlP_WRi_c8}Pe;l(#WnThfspZ$^3+`@%
+zmW}tS#o_f`H(V@)Qt__Qwx4kv+ooP8ZrPBV-j<==nbQ*DT}dlBw*|*N7vHSJyQH}0
+zm|S-J1_lheA!DE{g6^Xv;AA#SxCooopboet4w*f2U~sm_9-x1=xp|LI-xxj9006QY
+z1mgxK<wER;C#1B$%?%3n>{0n+Yg6=SR3-S&;<?krxZxGO!Tw^S=d_=26`yQ0@waRw
+z@SmVU&DQEaY5x6V*rbHQm)eLi0+(WkiJ>vq=-lRqN`s9~#)OOaIcy3GZ&~l4g@2h|
+zThAN#=dh{3U<aA#cPR4&ofsaO#bX_do9RRvi_^pV^V=?kpT`)pH$SJl(tC+UO9KU%
+zw*Fj&O-G3~P~VA<unl1F2&AK=52kP@qipFV?Oj1#&{KUN^>N7Xil;nb8@%)wx5t!l
+z0RSe_yJQ+_y#qEYy$B)m2yDlul^|m9V2Ia$1CKi6Q19~GTbzqk*{y4;ew=_B4V8zw
+zScDH&QedBl&M*-S+bH}@IZUSkUfleyM45G>CnYY{hx8J9q}ME?Iv%XK`#DJRNmAYt
+zk2uY?A*uyBA<BiMLU_*M#NCCxjGD{)FKf5%TR%^0(tj%ZEC|pB`lh!G8#P^_7rgl6
+zHD8H9#lPg#uyjB59dckNv=l!fBEB{M6vF+Eh;w^K5=@MUOHXMhDuV2p%rP)^5%vfh
+zn^LIqAcivg*z)=%xYv);q@8+WaMY5huI1GOD-9N$`j-dE7hH0tcwmf1#`ceO!mOHP
+zCyw-!`T<sF+;H*u*8-P5M#r^Q!nW)d+HW6<4*Bj<y{xwPJ5aVv2w6&T;_`2#jdBoY
+zJBy`lJrSwb+PH8(hrh;>=nlYjkcNPMGi*552=*Q>%l?gDK_XYh<zL<ke_eZ$ot|PF
+zZVgv}4Sq{EZ4ogcRofdp&JliroypZ_e}$4iKs?X|D!2Ac$5!nj(ZskdL0_wd=BN37
+zZG}#$eUO#D_A!-?os3(Syu!QKCTTw$pZe08wZZN8KnynfmowC;MZ_o?kig}nxLgNw
+zM?*Zz05oY7v>*Rya_c)ve{=ps`QYE0n!n!)_$TrGi_}J|>1v}(VE7I~aP-wns#?>Y
+zu+O7`5kq32zM4mAQpJ50vJsUDT_^s&^k-llQMy9!@wRnxw@~kXV6{;z_wLu3i=F3m
+z&eVsJmuauY)8(<=pNUM5!!fQ4uA6hBkJoElL1asWNkYE#qaP?a+biwWw~vB48PRS7
+zY;DSHvgbIB$)!uJU)xA!yLE*kP0owzYo`v@wfdux#~f!dv#u<u)VAl7h<(Ox?_8|-
+zieXQ0tIl#N(#Ubvm=#=RRW-l$qV+J9qkYE;+MW4sd~tDdcA{`>Nc_$SF@Qq9#3q5R
+zfuQnPPN_(z;#X#nRHTV>TWL_Q%}5N-a=PhkQ^GL+$=QYfoDr2JO-zo#j;mCsZVUQ)
+zJ96e^OqdLW6b-T@CW@eQg)EgIS9*k`xr$1yDa1NWqQ|gF^2pn#dP}3NjfRYx$pTrb
+zwGrf8=bQAjXx*8?du*?rlH2x~^pXjiEmj^XwQo{<CPx+@82|8@X@<D@6UUi%p$ehj
+zhXQlcfF2phkkCDxVFxfI?!~Bx<^Y(i{JB%4bav+Pbd2%<Y>`NMonBN=Q@Y21!H)D(
+zA~%|VhiTjaRQ%|#Q9d*K4j~JDXOa4wmHb0L)hn*;Eq#*GI}@#ux4}bt+olS(M4$>c
+z=v8x74V_5~xH$sP+LZCTrMxi)VC%(Dg!2)KvW|Wwj@pwmH6%8zd*x0rUUe$e(Z%AW
+z@Q{4LL9#(A-9QaY2*+q8Yq2P`pbk3!V3mJkh3uH~uN)+p?67d(r|Vo0CebgR#u}i?
+zBxa^w%U|7QytN%L9bKaeYhwdg7(z=AoMeP0)M3XZA)NnyqL%D_x-(jXp&tp*`%Qsx
+z6}=lGr;^m1<{;e=QQZ!FNxvLcvJVGPkJ63at5%*`W?46!6|5FHYV0qhizSMT>Zoe8
+zsJ48kb2@=*txGRe;?~KhZgr-ZZ&c0rNV7eK+h$I-UvQ=552@psVrvj#Ys@EU4p8`3
+zsNqJu-o=#@9N!Pq`}<=|((u)>^r0k^*%r<{YTMm+mOPL>EoSREuQc-e2~C#ZQ&Xve
+zZ}OUzmE4{N-7cqhJiUoO_V#(nHX11fdfVZJT>|6CJGX5RQ+Ng$Nq9xs-C86-)~`>p
+zW--X53<fjk))~(Y7xt;2-3Mp_sh^OGttxT8JXcE>J`O~vS{WWjsAuGq{K#8f#2iz`
+zzSSNIf6;?5sXrHig%X(}0q^Y=eYwvh{TWK-fT>($8Ex>!vo_oGFw#ncr{<A-F%$p&
+zc|DGKq;$_R8E0EodRv?$JW^Po<Ex>vmERi^m7lRi%8Imph})ZopLoIWt*eFWSPuBK
+zu>;Pu2B#+e_W|IZ0_Q9E9(s@0>C*1ft`V{*UWz^K<0Ispxi@4umgGXW!j%7n+NC~*
+zBDhZ~k6sS44(G}<L8r7U{uvHTXWzD_JuHzxZ-XY|N?p*qndC=U0c*Cl@BtNW7i{&R
+z-Me?NHPa(a(vIZUFSMee2{hPx14nk+e_C|^?Bd;r8#<I5LFO<RoqQ`w{VLAmJAmJ-
+zf-f}_R{!XhIih6nYvLOxM^4vM+l^NaQ|ty{<XIb6;HnNe&IB3k;~%;YB%OMx`D8+)
+z&)Zf1-i7=>*zg||X#9Weto;u*Ty;fP!+v*7be%cYG|yEOBomch#m8Np!Sw`L)q+T`
+zmrTMf2^}7j=RPwgpO9@eXfb{Q>GW#{X=+xt`AwTl!=TgYm)aS2x5*`FSUaaP_I{Xi
+zA#irF%G33Bw>t?^1YqX%czv|JF0+@Pzi%!KJ?z!u$A`Catug*tYPO`_Zho5iip0@!
+z;`rR0-|Ao!YUO3yaujlSQ+j-@*{m9dHLtve!sY1Xq_T2L3&=8N;n!!Eb8P0Z^p4PL
+zQDdZ?An2uzbIakOpC|d@=xEA}v-srucnX3Ym{~I#Ghl~JZU(a~Ppo9Gy1oZH&Wh%y
+zI=KH_s!Lm%lAY&`_KGm*Ht)j*C{-t}Nn71drvS!o|I|g>ZKjE3&Mq0TCs6}W;p>%M
+zQ(e!h*U~b;rsZ1OPigud>ej=&hRzs@b>>sq6@Yjhnw?M26YLnDH_Wt#*7S$-BtL08
+zVyIKBm$}^vp?ILpIJ<dp3ooa+cndqkSQ3UA!R3}}yC4bxfeA6S8LO9hE~vx|Yi68@
+zNr?jvc2@*eXxky?<YJ*9EIA;CdIbdqd2SQpx9uQtXD#8(J3Vt<5%NQ*o02|K+6bY0
+z;sT8vn@o8e%0|hi^#v|34DqvO58NzmQDAp!LXk*AcbC{I;vTjGcE|?=;e?ESe2XV{
+zRUgP)(rNkqS#Yhf8ziDbO6ep!K;GEwl%7iVkc_KR&%z8}O~7*V=?=DsoCZuiU?(w*
+zHV&rJy*1isBFt8he4l73U>etMkW1VtIc&7P3z0M|{y5gA!Yi5x4}UNz5C0Wdh02!h
+zNS>923}vrkzl07CX`hi)nj-B?#n?B<Q|A1|76WLZEE&m-hhR<X$5TK&X`9{ZnvFM%
+zu_h)S<XvC@S;kBiJJBt>J2Vk0zOGsF<~{Fo7OMCN_85daxhk*pO}x_8;<dX=<+?Qg
+z#r>-h>}pcw26V6CqR-=x2vRL?GB#y%tYqi;J}kvxaz}*iFO6YO0ha6!fHU9#UI2Nv
+z_(`F#QU1B+P;E!t#Lb)^KaQYYSewj4L!_w$RH%@IL-M($?DV<J?Z?(&T(jN~E*h4k
+zjT$bEE;1X$dKstuB%kL?N}i|18#(T<X%h{nQolXBTKBIbWb9u%<<*n%KAruYiv41M
+z(BV$!uq)MDNOGLcUNoFp1O|t~h!*SC05{|sLBD8s0{dGDvJFAn@fT!9#{nXqzUzhA
+ze1Wde$2)jpHttd7Vt%dJc<P1PQ_QtXhR)w~A<pGWwkJB}X>@lGj%3ZgVdHe^q>n(x
+zyd5PDpGbvR-&p*eU9$#e5#g3-W_Z@loCSz}f~{94>k6VRG`e5lI=SE0AJ7Z_+=nnE
+zTuHEW)W|a8{fJS>2<PuTj25j+DhXW(hd~r?Xh^MxKJCimxGsmwzKdi%?KCIX3{&)m
+zZ0nj+u3m}byL|gc@7el5sG0YZn703R7lHPF8j}A(O#keT{0lwVD2_|_3ZlF(l>TaX
+zuRoa=LCP~kP)kx4L+OqTjtJOtXiF=y;*eUFgCn^Y@`gtyp?n14PvWF=zhNGGsM{R-
+z^DsGx<p*94-ySu{F;3A%Gw(MuWcO5hc=1Fn6S6X-V`dR&jLKv;9Ov9;sNX7hCxxgJ
+z&)GGfI53?p5EUqj1kN{nL`cLj*Ny6Bb93QS#TWv+m?{)VTv#I?UM_EBDq&18Y1rBF
+zqj?j71ovsu1jc{FMqN`ZbtUe%y6G-sBQrAwb$+jv1%VjW_k<x<OD8=u&hN{;<-bn?
+z@rS2|Sdn<vp_N-gJ^Y{ISs}UnqwiH29Bq1>toDtx+g^hZi@E2Y(msb-hm{d<UuZ5B
+zF*RQXF90n8n5t!zMgUN!64)`l%MNqK%g0zqOLUu+a4FnHHt`Hf2k1Gsi_Mzb@Z^^=
+zxAOB&;5(e``nO6J%C~>WiHdoQvdX88EdM<JUQYg{sbyjNxshlKux2o|_*{in1UQ?k
+zIs#lx9Gw8xBIYJWRwj=B5<C|bZKqjrjCXeSc*C*6yaFuS2rWqx!(UR;j8e_%Q^I^0
+zj8p#CwJD3Wf>>^DS#f}&kCGpPFDu*KjEpv$FZtLpeT>@)mf|z#ZWEsueeW~hF78Hu
+zfY9a+Gp?<)s{Poh_qdcSATV2oZJo$OH<l8JXo;z<PcbGCYR0J9l8&nxRHHiz--^d2
+z8~J{Itr^Z$OtgTuQ6<JD;bmdLugNLaS^G}k$rEM-rW(6=U_mp(C><Q9gp1ZnUy!F0
+zwAdk5rFR<Ua`+2&K+(bk94CxMi5A;34dG4kTAucma$dNI_rA^e+RlExjm~4DcUPQV
+zUJ~3S<PG_W`@twX<bCoilw=BO0H-v<O^nbfi=xlVu&Cv1VWy=dd07F7ytH8mMU5a{
+zu#nKXVN5wbwo#QA!H4;0Ko9C5V@W}ba=cKzOSE;+-oDrv!(>~K@QzE2kCADZ@xX(;
+z)0i=kcAi%nvlsYagvUp(z0>3`39iKG9WBDu3z)h38p|hLGdD+Khk394PF3qkX!02H
+z#rNE`T~P9vwNQ_pNe0toMCRCBHuJUmNUl)KFn6Gu2je+p>{<9^oZ4Gfb!)rLZ3CR3
+z-<Jj6ofd&sk<LvELH)*PRT^`1cMjr9jc63Nl_{PuyZKn7*LCLu65p@97#0uR(E?9W
+zX`bZ}=9-Z$>o&b;Bh>51JOt=)$-9+Z!P}c@cKev_4F1ZZGs$I(A{*PoK!6j@ZJrAt
+zv2LxN#p1z2_0Ox|Q8PVblp9N${kXkpsNVa^tNWhof)8x8&VxywcJz#7&P&d8vvxn`
+zt75mu>yV=Dl#SuiV!^1BPh5R)`}k@Nr2+s8VGp?%Le>+fa{3&(XYi<NKc?C)>~{k{
+z-u4#CgYIdhp~GxLC+_wT%I*)tm4=w;ErgmAt<5i6c~)7JD2olIaK<AIVJAZuKkE<l
+z4Bm0%W2+6b=&ak;y7abRJFYhw&)H;bM_b*mAs4cDPr8CDbB=hVJk3YURR<;YVVe}i
+zH4VPi#sF`j{_5B)vN4u|e)jM(|JKI}{da==@2O^OXJqx+GG_R^W?=2&Wa0X`P-$%<
+zWMpLG<Rk~M1(^Mh#54JvEUXHm_-Lca3M)$jz5TrWVT^)HDZzq*6uqcRSEO&-H)J!v
+zox0RpNqqerD+o-nP(VP(;6Ij>8by{u-!tZWT#RQddptXRfEZxmfpt|@bs<*uh?Y_<
+zD>W09Iy4iM@@80&!e^~gj!N`3lZwosC!!ydvJtc0nH==K)v#ta_I}4Tar|;TLb|+)
+zSF(;=?$Z0?ZFdG6>Qz)6oPM}y1&zx_Mf`A&chb<i`Nr1_JKCJ^T_*s={KuqB@lhf>
+znSERvt9%wdPDBIU(07X+CY74u`J{@SSgesGy~)!Mqr#yV6$=w-dO;C`JDmv=YciTH
+zvcrN1kVvq|(3O)NNdth>X?ftc`W2X|FGnWV%s})+uV*bw>aoJ#0|$pIqK6K0Lw!@-
+z3pkPbzd`ljS=H2Bt0NYe)u+%kU%DWwWa>^vKo=lzDZHr>ruL5Ky&#q7davj-_$C6J
+z>V8D-XJ}0cL$8}Xud{T_{19#W5y}D9HT~$&YY-@=Th219U+#nT{tu=d|B)3K`pL53
+zf7`I*|L@^<akj8#_&*rXa0J-fn>dPEIDJkI3_oA9vsH7n7O}Ja<law4{uj~>R{G~8
+zfi$?kmKvu20(l`dV7=0S43VwVKvtF!7njv1Q{Ju#ysj=|dASq&iTE8ZTbd-iiu|2&
+zmll%Ee1|M?n9pf~?_tdQ<7%JA53!ulo1b^h#s|Su2S4r{TH7BRB3iIOiX5|vc^;5(
+zKfE1+ah18YA9o1EPT(AhBtve5(%GMbspXV)|1wf5VdvzeYt8GVGt0e*3|ELBhwRaO
+zE<IB-Cn|oj1SDl{xp8zad#YcCdtrs+9}i$s<*@)jbR<MzYyAq(U%KqfE2&l%Q`Tlq
+zFFOj{{w{t{I93tgk%#X+S#qY@HW9M}>|yMhl;Bm?8Ju3-;D<d0gaE$FN@5itD4g&V
+zgQbZVdU+i-wHuALtd^lmCPv@8>NnxM3Roelg`^!S%e({t)jvYtJCKPqN`LmMg^V&S
+z$9OIFLF$%Py~{l?#ReyMzpWixvm(n(Y^Am*#>atEZ8#YD&?>NUU=zLxOdSh0m6mL?
+z_twklB0SjM!3+7U^>-vV=KyQZI-6<(EZiwmNBzGy;Sjc#hQk%D;ba<AuKL_OVlNJ8
+zzJ~Op&$U`bGuaaEPGBR);C}uHL4psgioidnP6KL62R)y#$^To}F#LDexcw6-48nGH
+z&YxHT*vkPdY(F<p{z3^E)4$-vMrqU*T?nO|IF@Z74ohmQ)xMgvN&|_c7OfAIO#XAt
+zaL2E?e(>y$v#zczt%mFCHL*817X4R;E$~N5(N$1Tv{VZh7d4mhu?HgkE>O+^-C*R@
+zR0ima8PsEV*WFvz`NaB+lhX3&LUZcW<oTbF57ud5qxRCovnmT%0KJe~XJK}Gj*7_g
+z0&W(W*y&*@eIfyjN}|^Vg@Xk+l%k}&LK6+_!9US75W3aKwKA7N7eaP%(H`-gc7jx_
+zq4R52zNWM^&eZyQ!NoQEuNB3ura1z?O0n};Cx@E>WJJrG7ZjQrOWD%_jxv=)`cbCk
+zMgelcftZ%1-p9u!I-Zf_LLz{hcn5NRbxkWby@sj2XmYfAV?iw^0?hM<$&ZDctdC`;
+zsL|C-7d;w$z2Gt0@hsltNlytoPnK&$>ksr(=>!7}Vk#;)Hp)LuA7(2(Hh(y3LcxRY
+zim!`~j6`~<bW*$8$<<~?JS18Peo3DUOk=IRLX_ufFFmtupg*V26|}Y8;Di!sKr{px
+zU!wn|6erEM{4t*~C;Z!(|BF)mSIk8}_js-C0LEmZCZ+%vYv=#^U(wOd%<)qwWIx%%
+z#P)x%MYM{N-K;vs`}xdVg@cSV9;IsBd_FC#oCthSxj&+MND|t@FCnpb@*2FC0f*D2
+z?G^cWl=jPk-fVXO^6GAO{DQL0%m8{~;|J@R4tRbB$asqPCv~(P@*H}1{&>B+sRBv4
+z<mz=pCM?&uNVBoEf!$<Jl`Auv$WWg;Z6o}=Da&vNrmd(0r*Nq_WttlLt&FC;g7G}~
+zz%kSd_><#B{@38kH;sLB4eH2+8IPWklhd25r5j2VR}YK$lpZ%7eVF5CBr#~=kUp`i
+zlb+>Z%i%BJH}5dmfg1>h7U5Q(-F{1d=aHDbMv9TugohX5lq#szPAvPE|HaokMQIi_
+zTcTNsO53(oX=hg2w!XA&+qP}nwr$(C)pgG8emS@Mf7m0&*kiA!wPLS`88c=aD$niJ
+zp?3j%NI^uy|5*MzF`k4hFbsyQZ@wu!*IY+U&&9PwumdmyfL(S0#!2RFfmtzD3m9V7
+zsNOw9RQofl-XBfKBF^~~{oUVouka#r3EqRf=SnleD=r1Hm@<buigJ1Zgh}+47#N}=
+zA;FL!#2C23SP8!!apVBYzJ3fxxO$`OHLK}}G5fYfk`4&0f}B0=8mk!Hn*#TLB6~0w
+zVDX$-aLCK?dMa|C-1DpnLg1Y;dn>~`y8U7R)w16fgHvK-6?-TFth)f3WlklbZh+}0
+zx*}7oDF4U^1tX4^$qd%987I}g;+o0*$Gsd=J>~Uae~XY6UtbdF)J8TzJXoSrqHVC)
+zJ@pMgE#;zmuz?N2MIC+{&)tx=<l|D;tZlZQyALE=2ji-YLMO_Re>7A%$yq-{GAzyz
+zLzZLf=%2Jqy8wGHD;>^x57VG)sDZxU+EMfe0L{@1DtxrFOp)=zKY1i%HUf~Dro#8}
+zUw_Mj10K7iDsX}+fThqhb@&GI7PwONx!5z;`yLmB_92z0sBd#HiqTzDvAsTdx+%W{
+z2YL#U=9r!@3pNXMp_nvximh+@HV3psUaVa-lOB<kAlb5{e|+s3GRS<WGPVcKv}ufw
+zsm@L)j21fBT_PZS23MbS<jhcW_7ZmN8)9;FrTXBPApWUlG*$QXnli9;L`ce(&0uB<
+zK<7{*B6<8;LFx#98e~1Ipcz1=a?doj&-~;#cS-Pk$4@XT{MS|f&qHIFc^#?##d3%L
+zF_vTgzyFp0k4KXHb4gb>ekVuMf1RUd26~P*|MLouQrb}XM-bEw(UgQxMI6M&l3Nha
+z{MBcV=tl(b_4}oFdAo}<FNiIc;2!TENsPY_{u&vbEN_gH<2W2+zqz;HID|PS7~k-+
+z?orh+BjNq^{SNz=&lq$2>WX$~$Mj-z70FowdoB{TN|h<oa=NkAgwvViq7Zbbs20=(
+zjFf3J3IkKmvhA(1BFfTs0<}wn4tMNcYw*#d5+3#m^D7`Q>2BdYs?$imcj{IQpEf9q
+z)rzpttc0?iwop<FB}NoH|4vN8(!wS{7iPRZAtgAKfwm99$&fQSncFCAHTtkEGq%pm
+zWTY7<`y7xseX%vxnS$7Cg0<;j2&4>SmEoB&V!1aoZqEWEeO-MKMx(4iK7&Fhc(94c
+zdy}SOnSCOHX+A8q@i>gB@mQ~Anv|yiUsW!bO9hb&5JqTfDit9X6xDEz*mQEiNu$ay
+zwqkTV%WLat|Ar+xCOfYs0UQNM`sdsnn*zJr>5T=qOU4#Z(d90!IL76DaHIZeWKyE1
+zqwN%9+~lPf2d7)vN2*Q?En?DEPcM+GQwvA<#;X3v=fqsxmjYtLJpc3)A8~*g(KqFx
+zZEnqqruFDnEagXUM>TC7ngwKMjc2Gx%#Ll#=N4qkOuK|;>4%=0Xl7k`E69@QJ-*Vq
+zk9p5!+Ek#bjuPa<@Xv7ku4uiWo|_wy)6tIr`aO!)h>m5zaMS-@{HGIXJ0UilA7*I}
+z?|NZ!Tp8@o<g6{t!6GGpEZ3+xJO<~FK>-lnyde*H+@8IHME8VTQOGh96&XX3E+}OB
+zA>VLAGW+urF&J{H{9Gj3&u+Gyn?JAVW84_XBeGs1;mm?2SQm9^!3UE@(_FiMwgkJI
+zZ*caE={wMm`7>9R?z3Ewg!{PdFDrbzCmz=RF<@(yQJ<VyM+ly^hkKwrU?N(EcGTG)
+zusbNv5i$F3@Zf=?+&aeDOWDQ7$Qe9+B5{<3u0W4YeBR!LFJjuu&@SMl|F6jRfqiyz
+z{O`I${Euua!vE}0|0A#|Qib%yQO5k~F=XS~vL;+>_A6?PCd_MdUf5vv6G#9Mf)i#G
+z($OxDT~8RNZ>1R-vw|nN699a}MQN4gJE_9gA-0%>a?Q<9;f3ymgoi$O<?iymZH(Er
+zNGvX8A0}*i-nw7954=`Bwhd<ZUjO(yu}|0@?)GI5gP?*)IHp?Eg%^jP>I!=aE6Elw
+z2I`l!qe-1J$T$X&x9Zz#;3!P$I);jdOgYY1nqny-k=4|Q4F!mkqACSN`blRji>z1`
+zc8M57`~1lgL+Ha%@V9_G($HFBXH%k;Swyr>EsQvg%6rNi){Tr&+NAMga2;@85531V
+z_h+h{jdB&-l+%aY{$oy2hQfx`d{&?#psJ78iXrhrO)McOFt-o80(W^LKM{Zw93O}m
+z;}G!51qE?hi=Gk2VRUL2kYOBRuAzktql%_KYF4>944&lJKfbr+uo@)hklCHkC=i)E
+zE*%WbWr@9zoNjumq|kT<9Hm*%&ahcQ)|TCjp@uymEU!&mqqgS;d|v)QlBsE0Jw|+^
+zFi9xty2hOk?rlGYT3)Q7i4k65@$RJ-d<38o<`}3KsOR}t8sAShiVWevR8z^Si4>dS
+z)$&ILfZ9?H#H&l<RT2S~_Jj4$4(IRHJFV0?A!G0Qhg^SAVSGNU@RS<f${jo1F-$bS
+zyW`W1oDY=>umngpj7`|rKQQ`|tmMmFR+y-9PP`;-425w+#PRKKnx7o-Rw8;}*Ctyw
+zKh~1oJ5+0hNZ79!1fb(t7IqD8*O1I_hM;o*V~vd_LKqu7c_thyLalEF8Y3oAV=ODv
+z$F_m(Z>ucO(@?+g_vZ`S9+=~Msu6W-V5I-V6h7->50nQ@+TELlpl{SIfYYNvS6T6D
+z`9cq=at#zEZUmTfTiM3*vUamr!OB~g$#?9$&QiwDMbSaEmciWf3O2E<mlP_PonDwt
+zyitcRzTVrxyJMiqOZ6|7#G@nv5X=6&i;>8?oE0ApScg38hb&iN%K+kvRt#d))-tr^
+zD+%!d`<L4%gYWIkY!vD!A?&@isi9mjq}hc5uLusOi**W156CB;6jndj83!M&a=e4K
+zV{K2_%pB}vEiuAw60U0jUrMlCDCQLmYx75m`l(uEE8=2*7U?XVZesIds6ZgImrC6J
+zaSGNgykYte(u*RGC_Cdgw_=To1Sk<7c@waaCe^q4t!2!@1+<vcCZJJd`WP{XR`nxw
+zGu<m<ZH}qgdl57!HcrTLPnp>i!OOE3in0Q_HzNXE!JcZ<0;cu6P_@;_TIyMZ@Wv!J
+z)HSXAYKE%-oBk`Ye@W3S<fT|RJJ2x9j}N_gm*>hYu-bfC<JlS4ISeU0#72JEq&iV@
+z);;bzD{y$YwCJZhLJpC1#?j@p;n13~AR-U_7}H;)tO$ka&g;YU0hclMs2jggs@V)}
+z1ctUKqL*50yB=^24iD^`6e#NM3t6q_UJr0(0eheaY{0bzc8rmE8>AZ}1|J16hFnLy
+z?Bmg2_kLhlZ*?`5R8(1%Y?{O?xT)IMv{-)VWa9#<mvE`6Fsm;~;S~jwikf)Rjguu$
+z5vQddW;F{QVK_+$;)+G^5Vmb(r-Npc&G#KXM)uo^^@C#o|I{V8-x8LCrE4E&Qq(N-
+zMS66xhsVfaLJl|yc8xV__In+|p9mrG(%HWN_C^hqh)+P9$S6+nJmaAfIxP%v9WfYQ
+zL5;Uu-6T=cz->1pKH|oVRm4!lLmls=u}Lxs44@g^Zwa0Z_h>Rk<(_mHN47=Id4oba
+zQ-=qXGz^cNX(b*=NT0<^23+hpS&#OXzzVO@$Z2)D`@oS=#(s+eQ@+FSQcpXD@9npp
+zlxNC&q-PFU6|!;RiM`?o&Sj&)<4xG3#ozRyQxcW4=EE;E)wcZ&zUG*5elg;{9!j}I
+z9slay#_bb<)N!IKO16`n3^@w=Y%duKA-{8q``*!w9SW|SRbxcNl50{k&CsV@b`5Xg
+zWGZ1lX)zs_M65Yt&lO%mG0^IFxzE_CL_6$rDFc&#xX5EXEKbV8E2FOAt>Ka@e0aHQ
+zMBf>J$FLrCGL@$VgPKSbRkkqo>sOXmU!Yx+Dp7E3SRfT`v~!mjU3qj-*!!YjgI*^)
+z+*05x78FVnVwSGKr^A|FW*0B|HYgc{c;e3Ld}z4rMI7hVBKaiJRL_e$<k+t<^`D)J
+zEhcFT+>rxDW^8!nGLdJ<7ex9dFoyj|EkODflJ#Xl`j&bTO<I#P8edX2Zurtkc%j^@
+zNt6$0k5j7Tz*Hvqfi_&6#Q9+R)Fv6`GmW+`8bq@}anEonN&wkBMSbC3p65Q!BQJn9
+z($6ofVPsfai#?XWp7#{34OEeYG<ZeV`;e33{@dz|B}sgh&`J@Iq}UpnS6~gr0^_2`
+z<OPZ;lTV0rmf6o448!Uqt;aNgDOUMFk-WHp5yxc_@Pw(=_HnwV*fc`$ZOS^5Tv^Xj
+zs6|mx8FjhE6;^Q`ZD8?b*C=D)QP^dT)L|ZTke)O$7uVN>%=$v)c+gJsLK_%H3}A_}
+z6%rfG?a7+k7Bl(HW;wQ7BwY=YFMSR3J43?!;#~E&)-RV_L!|S%XEPYl&#`s!LcF>l
+zn&K8eemu&CJp2hOHJKaYU#hxEutr+O161ze&=j3w12)UKS%+LAwbjqR8sDoZH<g6`
+zeO;HbwrZ9reV{8OM|L-k?0OY=6?byB5<#Ri|6=ZM<cbTpfiMCe6D0+uuN~Snj^GI6
+zBGP94F2>nD<cul@`WjtmWkT9y3u`g7Ep4O>=m0(p62!zg<Af@s3vh7(o9SiY*ZKN>
+zxt!Sj65S<M*Zjht+%5QyX@dTS`ynS|*dw2j79o<R`%(HG^UA0FiEur$J4e>?6WPmm
+zL&U9c`6G}T`irf=NcOiZ!V)qhnvMNOPjVkyO2^CGJ+dKTnNAPa?!AxZEpO7yL_LkB
+zWpolpaDfSaO-&Uv=dj7`03^BT3_HJOAjn~X;wz-}03kNs@D^()_{*BD|0mII!J>5p
+z1h06PTyM#3BWzAz1FPewjtrQfvecWhkRR=^gKeFDe$rmaYAo!np6iuio3>$w?az$E
+zwGH|zy@OgvuXok}C)o1_&N6B3P7ZX&-yimXc1hAbXr!K&vclCL%hjVF$yHpK6i_Wa
+z*<Rda^MN8#r#%H(uhk!|+(Xdsw2E^5cUpnFp8p1^_KFVpjUj=6sF40s6^Zu$9=(bF
+zx1x^nKdB2b8!ICz8ygEJ+y4>CMg1RAH1(EuuA01@lA$sM<OVE;c)%cNQLi9uaS;hG
+z%fi;i)%@4^r8O+Wz2GPMFlZFnH;_-_U9)NAegHj_!}O-ZO`FT{#><S(uSx^)-K{gT
+zhG&r*35&meRW|1;vN}suvoTt-WY!oM-loV8;oR{IcSbtH!As;82qoT?HqV9V3*~qm
+z!SuufxJRefmX+!kF&rvO-e(?VCk%)$MRmimz$37siP-FuaN<K+5pNn#@=eC8%!@nb
+z2*5!qsZ<fp+A*NXf=8**@y(*g7NiBCiEV7bSE-BMr;5Zd;AV+}D!T7#a7AZhy$tZ}
+zBZj0LQc#mui!Lo2Q3KNe2agi@n?}tiW0Rj<VeQ<_*D6y|ViQ@=M%oDn5H>fe*s@9-
+z$jNWqM;a%d3?(>Hzp*MiOUM*?8eJ$=(0fYFis!YA;0m8s^Q=M0Hx4ai3eLn%CBm14
+zOb8lfI!^UAu_RkuHmKA-8gx8Z;##oCpZV{{NlNSe<<V1a7ju;v(TY8|0upX`)YP)i
+zhF9S0sKf|T)6o+<$QQ8snYX%z2pId%K2VdBjyrL|U&7n?j2gqBIlgc7sqRmR3rF|l
+zlUaMtZ*=q~vwXXK9=bFWx14^H@c)%dSINC6uKh#1>i;9!MfIN!&;JI-{|n{(A19|s
+z9oiGesEN<ynV})!iaH~auE<DSv%{<&k~X$kQz2b-qcNkA8P@0{SIU`uY<?@NmTQBx
+z)D?^>cLf@NN^9R0uIrgg(46r%kjR{0SbnjBqPq()wDJ@LC2{kUu_j$VR=l`#RdaRe
+zxx;b7bu+@I<Nh=^5@s63-0S!f#dfXn@}AC1>ntWaV$si1_nrQpo*IWGLBhhMS13qH
+zTy4NpK<-3aVc;M)5v(8JeksSAGQJ%6(PXGnQ-g^GQPh|xCop?zVXlFz>42%rbP@jg
+z)n<qUy~a=5h*jh6P7t^JBt^vIyENcV7ST}KUA-3{?3CB)-Fh4a#gMRWaLCBu<v>)%
+zM9anq5(R=uo4tq~W7wES$g|Ko<i2Il^N$GIC?!+;wqh32G+daBXSzA(l7+`)WY5H*
+zxN4$-v5B6xdBXsPjBQ?{pU&2{p1fGEo~A^$<7<6Ai9r_XJLEi2ERS5-WM=rJMwjp>
+z1iNIw@-{x@xKxSXAuTx@SEcw(%E49+JJCpT(y=d+n9PO0Gv1SmHkYbcxPgDHF}4iY
+zkXU4rkqkwVBz<{mcv~A0K|{zpX}aJcty9s(u-$je2&=1u(<Ijk*osoSbRG#RG2dxi
+zY2dIgjpsHFWw4YgUuLN}C3yiVDS7TfH_01AHBUEe$&x)yg`w@~!r_*o_*~bpU7c<5
+z`bmK&NU6Nw_v-jDi5@dldK4Fn1A<6r>e#Q~UA{gA!f;0EAaDzdQ=}x7g(9gWrWYe~
+zV98=VkHbI!5Rr;+SM;*#tOgYNlfr7;nLU~MD^jSdSpn@gYOa$TQPv+e8DyJ&>aInB
+zDk>JmjH=}<4H4N4z&QeFx><vCqo(8;VBNf?4{-ejyJD7h1Z5Qh!VF^s0~(Sx+W_U{
+zR};ybxF{rNR6jf3&Uli%SD1<DGAon!MxCaTjg2UoiPv{%y|HIy7wF&Vh+2it<&g@k
+z2+Wf#)mx-UNsAjpU<5>1VPY8GU&^1c&71T*@2#dINft%ibtY(bAm%<2YwPL?J0Mt{
+z7l7BR718o5=v|jB!<7PDBafdL>?cCdVmKC;)MCOobo5edt%RTWi<zJmle+?jwNYxN
+z4^6|EAjKcb86Lhb2TiEBh#*!<VO%f-!t(A33YL(fW`@*JF%L#%9n~L_x_&@iQ8p+r
+z50!J0d4(u}33+T-j40yL1x4WL)VTLI3<|eCyY3_SBtK8>ReAMaIU5X9h`@El0sR&Z
+z7Ed+F<Hz;iLDs#Hc0AY<Bv9{VG$$}Nxol9pHZ;R^PVSOq1+c`wf56t4>iyA+QAyWn
+zf7=%(8X<IsS*x5)IZjAvYsetv<jbdR10P8%td<*r6IM&L5LRrcOf|!8RQAgg6~$_=
+zBSd>pcS*C4^-L24TBUu%0;@s!Nzy{e95qjgkzE<W5xLBBDYXZDXN}?0z#DvAb||%H
+zZPS{|8~$Dai+w3|r0z;7J8SaSbF0|4F}$?B9(zK4Hfql>lf0#ou`sYng<}wG1M|L?
+zKl6ITA1X9mt6o@S(#R3B{uwJI8O$&<3{+A?T~t>Kapx6#QJDol6%?i-{b1aRu?&9B
+z*W@$T*o&IQ&5Kc*4LK_)MK-f&Ys^OJ9FfE?0SDbAPd(RB)Oju#S(LK<CirA2f_*u2
+zok`__!UM2k24u<34N&n2<rv2c5C+LG1_2&glf5C-MnxH;!hzUTv-tAoF?gV=0tG&*
+z&3NTXW=(G6=cQ0qDpT;#Hy7t96N4?Q={0R{&UH=JEWgy<75@6brLBmih;_W+NcLKU
+zn<HoD>)?EVandS1qb#KR;OP|86J?;TqI%E8`vszd&-kS%&~;1Als=NaLzRNnj4q=+
+zu5H#z<eB8n3vpKCZ_UBe2i$XZJvzC|oStL%r*N4lp0t3D`s9hT%+m%jPcLdrJAA8K
+z_Xy5FTlYi&>)BDKHo1EJTC?Cd_oq0qEqNAF8PwU7<g1n3gpVtS#>fK!-WwVEp4~4g
+z3SEmE3-$ddli))xY9KN$lxEIfyLzup@utHn=Q{OCoz9?>u%L^JjClW$M8OB`tx<B9
+zZzQvx^C^)R6f_#j34$T{qWzMIebqUHU#Mm4dIX;v?G*C~teYh!pha7{DB@cX4KxPS
+zH^Q;NkvbuF4d_@se8XmvFleR*sC@ep>g4r6Q-6UlVx3tR%%Z!VMb6#|BKRL`I))#g
+zij8#9gk|p&Iwv+4s+=XRDW7VQrI(+9>DikEq!_6vIX8$>poDjSYIPcju%=qluSS&j
+zI-~+ztl1f71O-B+s7Hf<J;>>AZ#}DNSf`7C7*)%(Xzf|ps6Dr7IOGSR417xsU=Rxb
+z1pgk9vv${17h7mZ{)*R{mc%R=!i}8EFV9pl8V=nXCZruBff`$cqN3tpB&R<?rJ^^G
+zLU#yZbVti(nuC|2|IXia=NN6mqd+?dR)7Jc*9;iC!a;f?+=#<s4C&g0_&NB8weC%l
+zS<iNL{)P(<k~BWt3Y%{Xrbk9d#iq+t;G9E%F%_rY<%%AD^lw^bplw!%%|-aF&{mk{
+z8v%Z~T)@9qJANVDtF7i6j_uAG%PQrIzYL<`zWN)?kg5G%9sC$@=vQ^>K^$yH!A8RL
+zJ5KltH$&5%xC7pLZD}6wjD2-uq3&XL8CM$@V9jqalF{mvZ)c4V<q)vM?$E(wfOg3Q
+zv%+110#sykOiRSt?0@;lgu4A3JD@U~_wpzdHgwI1fA5o$81_b21C0iEz!;O~RRRX1
+zGlEi0gdqWrOw3XkgEa2cwZ#ieSM+Bwx5supt!d$Nc0%<IFUjN0oH@W~IsyX(WZ$<d
+z|MaryZKLL%mzThJyCC#$>n?xXbvkB(q%<Z{kVQ;%LF$(<$dK2qdz`UK^3urTrD0B4
+z1&)CdFB?t|pWnGgd`vO!l5yW5V|rGsYb-Keu0g!I*6%Xh0JZtqeMa&LE(4Bo#scEB
+z2+Xh0IF3fHxOvz(nbw5~LC>xbSdjoXJXanVN@I;8I`)XlBX@6BjuQKD28Jrg<b?I+
+zxnRcDtmgY@D96{&H=|gt1$AWNvdJ3yEL}1j876RHewior=;z@yI+m%vO5~lw`>05}
+z^ImmK-Ux<q>*QMn_A|1ionE#AurP8Vi?x)7jG?v#YyVe_9^up@6^t_Zy^T1yKW*t*
+z&Z0+0Eo(==98ig=^`he&G<vo(#Q)G{9SIowKW2Tx<>^K$I!F~1l~gq}%o5#pR6?T+
+zLmZu&_ekx%^nys<^tC@)s$kD<AcM417>`^r8)1^tUazRkWEYPw0P)=%cqnyeFo3nW
+zyV$^0DXPKn5^Qi<LfvSpMIU#o(EG&Rpi2B@a5@RzAAQS3*j%A9U;6sg<98@jyPDmC
+zXKg0?&ACu)O$sr|d)+$ZH;RJR7V`iC489P}wQ3gU*M+C_X7Cw%nw^c(gNH_oV&C^!
+zc5Ja!U#d<n%*)0OuX(xIWS}X!VI4G5%&+mH^jQka0XK?`B*^+~@VtKToDTaE*!8R~
+z<nPU#JZXd+QYE>OtOi4MIX^#3wBPJjenU#2OIAgCHPKXv$OY=e;yf7+_vI7KcjKq%
+z?RVzC24ekYp2lEhIE^J$l&wNX0<}1Poir8PjM`m#zwk-AL0w6WvltT}*JN8WFmtP_
+z6#rK7$6S!nS!}PSFTG6AF7giGJw5%A%14ECde3x95(%>&W3zUF!8x5%*h-zk8b@Bz
+zh`7@ixoCVCZ&$$*YUJpur90Yg0X-P82>c~NMzDy7@Ed|6(#`;{)%t7#Yb>*DBiXC3
+zUFq<q;<NLVE3q+|RY;{7>(UDFjrgOsc%0KJ_L;WQKF0q!MINpQzSsqwv?#Wg+-NO;
+z84#4nk$+3C{2f#}TrRhin=Erdfs77TqBSvmxm0P?01Tn@V(}gI_ltHRzQKPyvQ2=M
+zX#i1-a(>FPaESNx+wZ6J{^m_q3i})1n~JG80c<%-Ky!ZdTs8cn{qWY%x%X^27-Or_
+z`KjiUE$OG9K4lWS16+?aak__C*)XA<mn7dO1IQ<7rt}jYvLS-$H~f<X5+N=(Ek`&&
+zUWHe^|Bwj1`@oeHlPUTz8D*6r?NpHjHK-@Dqy;NDtS}cg%!YayC0fs^iN;OYEP9kK
+zo5Vht9oQS7iDhR-OPXj9?q6@S&eFy#n-1R+kA`A0*{=#t%}!LRAXjjRywc~_uNoSv
+zszK4MM3XQ`!AP4Kj^Rx*7iMfV9^D$9ff(?N=BiGkohxx7DcQNG_tP#nT3_=hI7YLo
+zGAoH*rjQg^W(ap448geJyg*-Zsf^RAr9lW2dRNFv&HLWl7oARenT?<M#Z5`E1my@r
+zEvZ)*EFhV=Xn(d!ux{Tmfc~sd_)m;R7maZ)e8qGMx=q|X7Apwv&(Z7nX5hp;7Fa>{
+z6HmS*8#t_3dl}4;7ZZgn4|Tyy1lOEM1~6Qgl(|BgfQF{Mfjktc<V73_^4Y*JAxZ9&
+zk;vp)O|oP#qgjAs8&wb~jCgfwsBn#A5JV`I8M5Mt;ki^ey-B;1sC5O4oRWjC=0x>h
+zB5kc~4NeehRYO%)3Z!FFHhUVVcV@uEX$eft5Qn&V3g;}hScW_d)K_h5i)vxjKCxcf
+zL>XlZ^*pQNuX*R<VIWU<&k+#O#z05{>JQn)b6;blT3<7@Ap)55)aK3n-H08GIx65W
+zO9B%gE%`!fyT`)hKjm-&=on)l&!i-QH+mXQ&lbXg0d|F{Ac#U;6b$pqQcpqWSgAPo
+zmr$gOoE*0r#7J=cu1$5YZE%uylM!i3L{;GW{ae9uy)+EaV>GqW6QJ)*B2)-W`|kLL
+z)EeeBtpgm;79U_1;Ni5!c^0RbG8yZ0W98JiG~TC8rjFRjGc6Zi8BtoC);q1@8h7<W
+z{%QU=f~@E{*75;EPtq=QOC=`G(0Hdr_HmX;s)IO`uOsm?hi;HPRH2DMN!8p_6N*mR
+zXeVd+rX;e|)D{nmu3FxC){%4`fvkUoMM~{w*jYq7&hHz|64x(?E6&4jG;eJ*jSB0z
+zWIII4*kn~Ve25Pk+1h=4UMO&Fvq`3&FqVW1qQ})@8We8E6!Yt^Nic_&{<S5dR(OO{
+zb5!CWQqPU+0jYF<lXRIyMn^4F&DA<&TE_&-%x*k9PRqAjBu2+9eB|q?j^5xDz3>UV
+zFa&LRzYsq%6d!o5-yrqyjXi>jg&c8bu}{Bz9F2D(B%nnuVAz74zmBGv)PAdFXS2(A
+z=Z?uupM2f-ar0!A)C6l2o8a|+uT*~huH)<BklnFF@?8S@YKGOgvIkgvy?bVNlgCB_
+zoqeDw{3YNZ=l`nrK(ag;cr55JL-h60|J5N{s-NkNhFkQ*iwcZIFaTBfOzrkQWLJ*V
+zICw*3^B@Set{3BbuO`R#p?&bEzj(u;_I4rvE}iY2Q^FV4RYK^P{cWG=Da>!h3i!&$
+zr>76mt|lwexD(W_+5R{e@2SwR15lGxsnEy|gbS-s5?U}l*kcfQlfnQKo5=LZXizrL
+zM=0ty+$#f_qGGri-*t@LfGS?%7&LigUIU#JXvwEdJZvIgPCWFBTPT`@Re5z%%tRDO
+zkMlJCoqf2A=hkU7Ih=IxmPF~fEL90)u76nfFRQwe{m7b&Ww$pnk~$4Lx#s9|($Cvt
+ze|p{Xozhb^g1MNh-PqS_dLY|Fex4|rhM#lmzq&mhebD$5P>M<DmANA7)v1?A&u8?r
+zN#V^qY31R$$uOM7e!;99G3zfzxBI#kn<K!x%{#o+a5>$eqLoV|z=VQY<HWnoG0tOv
+z69l8*cSEJV=QU?Ns^-R%Uq*rJ%^Z2p;<g;km5p_x#;n0NJ&|94gMZ|Q>{)7&sR#tW
+zl(S1i!!Rrg7kv+V@EL51PGpm511he%MbX2-Jl+DtyYA(0gZyZQjPZP@`SAH{n&25@
+zd)emg(p2T3$A!Nmzo|%=z%AhLX)W4hsZNFhmd4<1l6?b3&Fg)G(Zh%J{Cf8Q;?_++
+zgO7O<(-)H|Es@QqUgcXNJEfC-BCB~#dhi6ADVZtL!)Mx|u7>ukD052z!QZ5UC-+rd
+zYXWNRpCmdM{&?M9OMa;OiN{Y#0+F>lBQ=W@M;OXq;-7v3niC$pM8p!agNmq7F04;|
+z@s-_98JJB&s`Pr6o$KZ=8}qO*7m6SMp7kVmmh$jfnG{r@O(auI7Z^jj!x}NTLS9>k
+zdo}&Qc2m4Ws3)5qFw#<$h=g%+QUKiYog33bE)e4*H~6tfd42q+|FT5+vmr6Y$6HGC
+zV!!q>B`1Ho|6E|D<2tYE;4`8WRfm2#AVBBn%_W)mi(~x@g;uyQV3_)~!#A6kmFy0p
+zY~#!R1%h5E{5;rehP%-#kjMLt*{g((o@0-9*8lKVu+t~CtnOxuaMgo2ssI6@kX09{
+zkn~q8Gx<6T)l}7tWYS#q0&~x|-3ho@l}qIr79qOJQcm&Kfr7H54=BQto0)vd1A_*V
+z)8b2{xa5O^u95~TS=HcJF5b9gMV%&M6uaj<DG%?NLS@ZBcw~|?Ph?A!$GyTtN#J(n
+z(N#33Z&MXkLNi3tlx}v1EUFXC!E2$+1Uui1Bx24YZRI7U{9C!4ye6`#_fxLyx><>E
+zPNM~qGjJ~xbg%QTy#(hPtfc46^nN=Y_GmPYY_hTL{q`W3NedZyRL<bGaMku?v;})8
+z39o7JEb=3hqE?4Vw{>^kgU@Q$_KMAjEzz*eip`3u6AhPDcWXzR=Io5EtZRPme>#K9
+z4lN&87i%YYjoCKN_z9YK+{fJu{yrriba#oGM|2l$ir017UH86Eoig3x+;bz32R*;n
+zt)Eyg#PhQbbGr^naCv0?H<=@+Poz)Xw*3Gn00qdSL|zGiyYKOA0CP%qk=rBAlt~hr
+zEvd3Z4nfW%g|c`_sfK$z8fWsXTQm@@eI-FpLGrW<^PIjYw)XC-xFk+M<6>MfG;WJr
+zuN}7b;p^`uc0j(73^=XJcw;|D4B(`)Flm|qEbB?>qBBv2V?`mWA?Q3yRdLkK7b}y&
+z+!3!JBI{+&`~;%Pj#n&&y+<;IQzw5SvqlbC<hrT)sBs!K|EW5H^76b8wi?&5jaqoB
+zdZ2NRMM|}GTQWlnULm3*Tw}|kY|0D0spF;??&YCTeOo~Duw_Bz&0>+V=kLZLAHOQb
+zS{{8E&JXy1p|B&$K!T*GKtSV^{|Uk;`oE*F;?@q1dX|>|KWb@|Dy*lbGV0Gx;gpA$
+z*N16`v*gQ?6Skw(f^|SL;;^ox6jf2AQ$Zl?gvEV&H|-ep*hIS@0TmGu1X1ZmEPY&f
+zKCrV{UgRAiNU*=+Uw%gjIQhTAC@67m)6(_D+N>)(^gK74F%M2NUpWpho}aq|Kxh$3
+zz#DWOmQV4L<sDJGB1~xI&#K@a<rftJ&W$tS7|})}p7LCV^RAnbsUrP_V*uhk=;!pl
+zs4zoj`KucSBFKjBcKXW*EHB;&BS$tidMG;U{H8n7wJ)AAvB2L*UBNbpb;dN7LsCrE
+zL;cL{W0B-y=uz}$?A3Z<^oG{u-AX|Svz(WP+@{ryM8&-@TzJ+nBT;gLmX|TuUS7tX
+zbu7uYkz$71L||aR32Yb{k;9>g&}`XTU41Z|P~5;wN2c?2L{a=)Xi~!m#*=22c~&AW
+zgG#yc!_p##fI&E{xQD9l#^x|9`wSyCMxXe<3^kDIkS0N>=oAz7b`@M>aT?e$IGZR;
+zS;I{gnr4cS^u$#>D(sjkh^T6_$s=*o%vNLC5+6J=HA$&0v6(Y1lm|RDn&v|^CTV{=
+zjVrg_S}WZ|k=zzp>DX08AtfT@LhW&}!rv^);ds7|mKc5^zge_Li>FTNFoA8dbk@K$
+zuuzmDQRL1leikp%m}2_`A7*7=1p2!HBlj0KjPC|W<t!gw4p)|NM)%cW9T$k`o|lfo
+zg*aR{7NSC?*?~1-ovU>T?5{_aa%}rQ+9Mqcf<RjoiaEgO6aLbf%7cdA%8(Z(Lepcg
+z;EK+)sbwoSMUuni>XI0NtjvXz1U)|H>0{6^JpHspI4MfXjV%1Tc1O!tdvd{!IpO+@
+z!nh()i-J3`AXow^MP!oVLVhVW&!CDaQxlD9b|Zsc%IzsZ@d~OfMvTFXoEQg9Nj|_L
+zI+^=(GK9!FGck+y8!KF!nzw8ZCX>?kQr=p@7EL_^;2Mlu1e7@ixfZQ#pqp<X+0Re_
+zrJ{H^$-Z@QA7ETVM2%a&#GG%~hgC@{06tyBwQZmlXSm57v9B9QX(aJLI_U;c+x!4Y
+zc@Lpfn;l;r15OkOarCAT2KT0TI&b@nuFwDm5s2$h*ySA~Ad%ZKk`|FTjsVplUIi{5
+zlFa?pIp_hLcE?CXH;$pLba~E##@hT^OvK63FoxCFx@_5ii6TR$R#n$|+i^+&#se{6
+zDr7|zkeVUxEFj8#1(pWjg_@>yCJ```(m;la2NpJNoLQR};i4E;hd+|QBL@GdQy(Cc
+zTSgZ)4O~hXj86x<7&ho5ePzDrVD`XL7{7PjjNM1|6d5>*1hFPY!E(XDMA+AS;_%E~
+z(dOs)vy29&I`5_yEw0x{8Adg%wvmoW&Q;x?5`HJFB@KtmS+o0ZFkE@f)v>YYh-z&m
+z#>ze?@JK4oE7kFRFD%MPC@x$^p{aW}*CH9Y_(oJ~St#(2)4e-b34D>VG6giMGFA83
+zpZTHM2I*c8HE}5G;?Y<M+?LyWn?03qS587BS{lq0V4R8#J8=B>7RXMA2k{Y?RxHb2
+zZFQv?!*Kr_q;jt3`{?B5Wf}_a7`roT&m1BN9{;5Vqo6JPh*gnN(gj}#=A$-F(SRJj
+zUih_ce0f%K19VL<E3HrXlqqoBf~c20@9ozE$2qZsljz1QN-PVpQS1W!)YMjSijFXX
+z{P)`?A`eAJ?oh<!djz+PC3lVbl99-ayrp8oi=_canYFfMH62C}^0hP3`X)L9+i4`Q
+zm?I7fbusV!Jv(kfxmM>Xi5(<VS*XQmy2&`ZRfWgKV9~k|yVKp~M)9<_9P`znoH<lN
+z$~@NdPe<+%!i}Jugmv9Pnb}eLR?O8Po%je^XGWy*@HH7__y8%?t*~t>VBGOFbc(YF
+zLvvOJl+W<}>_6_4O?LhD>MRGlrk;~J{S#Q;Q9F^;Cu@>EgZAH=-5fp02(VND(v#7n
+zK-`CfxEdonk!!65?3Ry(s$=|CvNV}u$5YpUf?9kZl8h@M!AMR7RG<9#=`_@qF@})d
+ztJDH>=F!5I+h!4#^DN6C$pd6^)_;0Bz7|#^edb9_qFg&eI}x{Roovml5^Yf5;=ehZ
+zGqz-x{I`J$ejkmGTFipKrUbv-+1S_Yga=)I2ZsO16_ye@!%&Op^6;#*Bm;=I^#F;?
+z27Sz-pXm4x-ykSW*3`)y4$89wy6dNOP$(@VYuPfb97XPDTY2FE{Z+{6=}LLA23mAc
+zskjZJ05>b)I7^SfVc)LnKW(&*(kP*jBnj>jtph`ZD@&30362cnQpZW8juUWcDnghc
+zy|tN1T6m?R7E8iyrL%)53`ymXX~_;#r${G`4Q(&7=m7b#jN%wdLlS0lb~r9RMdSuU
+zJ{~>>zGA5N`^QmrzaqDJ(=9y*?@HZyE!yLFONJO!8q5Up#2v>fR6CkquE$PEcvw5q
+zC8FZX!15JgSn{Gqft&>A9r0e#be^C<%<F$|nV^6m7s?pfGWrS!*h<5zg%%}lEg1TI
+z|E5UO7&eitGHgtFuU&)>)psE*nyW^e>tsc8s4Q}OIm})rOhuc{3o)g1r>Q^w5mas)
+zDlZQyjQefhl0PmH%cK05*&v{-M1QCiK=rAP%c#pdCq_StgDW}mmw$S&K6ASE=`u4+
+z5wcmtrP27nAlQCc4qazffZoFV7*l2=Va}SVJD6CgRY^=5Ul=VYLGqR7H^LHA;<kSL
+zyrh(Zd)qJDxpzjXJoFc+eRH#(kkiWb-uI_%f85g24L`FdF1fP}Kg{iZ+*Fo8ju*cl
+z3Aw1YGq0cxadL4N9aS#>H^1g}ekn=4K8SPRCT+pel*@jUXnLz+AIePjz@mUsslCN2
+z({jl?BWf&DS+FlE5Xwp%5zXC7{!C=k9oQLP5B;sLQxd`pg+B@qPRqZ6FU(k~QkQu{
+zF~5P=kLhs+D}8qqa|CQo2=cv$wkqAzBRmz_HL9(HRBj&73T@+B{(zZahlkkJ>EQmQ
+zen<iPJWnXR=;Z=9fu?|et|Rb%*gDj8sMD`ZMBMaR)@W4I!@ZJ=6-0EUr*wDEx&_hw
+zhU+|E`Yc!V0@6Vf^U<QOMIE_YSpmh%i+yFO|G~yVs99EScY@d$n{uR4Xtly{afZWj
+zO}~7A(I*J<@B|oPywvLj91a5kZfNN5H=|EF#}if+=~cl#!%<3XeHAhGPkCdLS{G`f
+z#i{^H6>p59dy+L;sSWYde!z_W+I~-+2Xnm;c;wI_wH=RTgxpMlCW@;Us*0}L74J#E
+z8XbDWJGpBscw?W$&ZxZNxUq(*DKDwNzW7_}AIw$HF6Ix|;AJ3t6lN=v(c9=?n9;Y0
+zK9A0uW4Ib9|Mp-itnzS#5in=Ny+XhGO8#(1_H4%Z6yEBciBiHfn*h;^r9gWb^$UB4
+zJtN8^++GfT`1!WfQt#3sXGi-p<~gIVdMM<#ZZ0e_kdPG%Q5s20NNt3Jj^t$(?5cJ$
+zGZ#FT(Lt>-0fP4b5V3az4_byF12k%}Spc$WsRydi&H|9H5u1RbfPC#lq=z#a9W(r1
+z!*}KST!Yhsem0tO#r!z`znSL-=NnP~f(pw-sE+Z$e7i7t9nBP^5ts1~WFmW+j+<@7
+zIh@^zKO{1%Lpx^$w8-S+T_59v;%N;<ZZyRu1Je84c8pEeE|Tu>EZtJzcfN%&@(Ux5
+z@YzX^MwbbXESD*d(&qT7-eOHD6iaH-^N>p2sVd<d@hTC>q&(`C$;?#mgBANIc5$r|
+z^A$r)@c{Z}N%sbf<VV6f)%mV{w>o?T`tTHz9-YpiMW?6>kr&W9t$Cuk{q^g1<$I~L
+zo++o2!!$;|U93cI#p4hyc!_Mv2QKXxv419}Ej#w#%N+YIBDdnn8;35!f2QZkUG?8O
+zpP47Wf9rnoI^^!9!dy~XsZ&!DU4bVTAi3Fc<9$_krGR&3TI=Az9uMgYU5dd~ksx+}
+zP+bs9y+NgEL>c@l>H1R%@>5SWg2k&@QZL(qNUI4XwDl6(=!Q^U%o984{|0e|mR$p+
+z9BcwttR#7?As?@Q{+j?K6H7R71PuiA^Dl$=f47nUKL|koCwutc_P<-m{|Al3C~o7w
+z=4S=}s5LcJFT1zjS)+10X_r$74`K78pz!nGGH%JV%w75!YSIt#hT7}}K>+@{{a+Im
+z5p#6%^X*txY?}|T17xWW*sa^?G2QHt#@tlcw0GIcy;|NR2vaCBDvn=`h)1il7E5Rx
+z%)mA4$`$OZx)NF5vXZnaJ1)*cA6ryx6Ll~t!LzhxvcTedxT;>JS&e=?-&DXUPaQ2~
+zH*69ezE`hgV{K-|0z|m~ld}=X^-Ob={wpex&}*+Rz{gx)G}gn!C_VN{UN=>^EV=Xc
+zr$-HO09cW&p4^M}V3yBjTP_xrVcc8iU_^Y-JD~(bgw*@GXGB1gYKz5DWO+O`>})|N
+zWrC)MR<YoNN@dNjcYj<b;OF){>93yA)3{&27-M)TJB6Ml3~?zZg#mYsF=#OSTaw&K
+z@hBftpt+2l@)YK@|3DvTjl(8wZtpLp<?0%pKTY3}XX{MHIljL%Fw{_Z|9d-yvblgQ
+z{!wyH{yqQi?Iie*$>9Ik!6G$CSL_idZ$Ti?R)4toe8bb)l|)lNb}?K;O2K9vyn1QG
+zd=v#y-Ld49UVkmfRU>Egc+(Y$^-;6vW;3Lcu*6~etz}0|@+b|+!UCal)DEYGLbHWJ
+zll5Wi^<vfZ?T~^`8=zPM$Z@j*S$t!Y<EhDvm+zMzHqRrjoNgJR4PlwtA%~M-7oKg-
+z@*>$Y<6@S%^y%hdjRh6&{!z1Py|lZ|q&Wub3l41uN2zEF8E&5H5?PL*&V}?*a}Lp%
+zCYi{ghjpRNT^^B+_U59No50Ghih5qn(W5`RkrsDWr{~A1dgtv{sRkH4RU2^A{jb&0
+zxVRnrm|u<;$iI;M6A>$POP)TWGU-gSjAERk*EGmVT(aw$!XUS<asJ?{P8@w6qBfov
+zI%`}^njNd1_{}A_uRkev<-TXKuoiFlFOyqT%8rk1`2%BKM5Z+~M&?E}fqqOZAZVB5
+zNS{DO+i9FHCCFSvH|Q|2xQ%x$MZhjBSt(99856FiHO!aT?oD?|(v2KHy<imYT_Zl)
+zzM{QvD-38PfU~%Cj@UhZn!-(N#6a8!Zp46^fmJDt%0~G+`{28Ol&R+}En*ZB(Ap5-
+zS3xTHV!d88{~H$@*|Xf2m9Ev~cClRLKWq-Dy`0?=Ka(0bKO7k6Ia^0ek#FeuLW^Ka
+z+29SP{BV|X`LItvfG~$^QN1DscL6_hZV#x+g@RJSzbH{*7vi&EuO^0lmWyRo%n-;p
+zrQ@enXxznWo93lX0onG|8<ExHhjsVv&yv#5$}JubQ-~k2)eX#tYEp#B=ZL)3W6xvQ
+z^tSx&3RvXN^2EDb;%<?Qv9hrD;ImRS1@Ev)+k3=jO{~2fBe<e5TLY_Vf+5&KlA(i%
+z-tx@Qc4VuOh0tKo5#`$=9<^cjcq8Ip7qpr<1+>e~7Ql-oRA54^4V(JWS6Q1mG?!vZ
+zx+pE!FEtvqr|Xrcb3oR`%LHFLmU_&{<QAAHttd1Er^!DxXsl03mv0y!k#PYpGSMeW
+zem^VXYsEEPcK*)T#s$EH8n9Tms!@q~oOuVmpZ((3>=p%mGy6MRe2Yz_5WJ8p@IgU2
+zdVvvhhQtiQkChK%*&PsiPCBL9oDOoJX8!$S(V>R}+1M}wzK*U*A{KJ`r=lM;mPrKU
+zQDqqN(W*u-5-?$(SIk<6A0E}34y&@-IVC%S!a1F4kz<3bIKjlyD)ooO_7ft<QDC;4
+zO#}hIX3cX+ou-UMWv@FumqiR;#JOI;$Lna5#MA^fv9k{O*GC+<$Nq+kGZ+M%7QHYI
+zk9IArOT7c%DRktDP2?F4i2($6s%HL>l%S_(6w`!vX&1PZ!K`@D@L6JR)6zO@Dl!<l
+z=BdWEtebJj+jz>YF{R<WP!R4PHXBT&cyt|IAe~n=dcnCOe*w5G5oS~}#&qbcuT(6I
+z-K*(&5{r9`!3B<qxqwHIOne-7;C;+8dR9=$r{8B+k8sIfec{W>Y}d3HZ7?Q5E>w=$
+ze)H_)48Ds*Ov4?zoGb2fe3}{!5Ooc|KCIni1o)(Gj+CO?`*7jsV`hIv@8J(22o4Q?
+zu?Bvi)zDG<OK;2aO}BggmGd-%r>(me?7XKeL|iF9ZRgZdT*}Ffsl62Cu;{Gv9j6dO
+zPt*H2GqC)-C`V`ceuu=tM{7!2yTEj=*5+T~5DYiZ)Hy)*PARYI6R2lZXoOj;v8M4W
+z*O-NX(7_~Q&A3>Oaw&1lBH_H%SwmISX-i3)HfHvBOeVwTT{LUM3}ZuZmg<(>)KE;d
+zbs2!0v6>J;1nQ0UJkUxnkE@Ibi~Q}M=-=Rk;hcOnxO$luOKEVxZc|!XECgex(2`}T
+z3Y;Q_6rL)e+SrOZhQj5_e}Lv>w7n*Pep$yWZNQl>ubBgb_NIWWDn3kNpn+MPQXV;8
+zV|_Ba5jsQ(w&Ey^IM|@|y!AqcJ#3m0#Q6_qvgCG~eoF#mnGmbO(;DP+bW%_aOs1R_
+z@9p#7X2UA^--#Nwx_Hvk2l1`eO{P*#j@q2UELtH|Uh6<W{C0d%;SO*X17Hg*_nhVo
+zUj8d@XC~-{FK%b15_u=5Zi$$rw|PRP{3P&%r4IFKW@%M_k3l}b-a!ZM6ZqfV-oe0z
+zHcS2@f;}*ROge~8O|p+DJW!EVo_da^QYfpcqO^~19<4~HG-T$^cIunesE=MWKhim-
+z7Goy+*ll|&6M44>hxR`h_847wIJo0=5CQQ`6it|%a-I$^&a@we1rc&*;QIu5Ck^?)
+zx*5eSd*mG#=6Hi(5!;5uUi&{HfnT1S8X-)?gE5CZ6KWoqM5|CyrULmuFBKOU8SOp*
+z{IB1$OCcq`S-k*xs;4fmhKsIGZ;GYAY*%(@875NxhM<x^qSdQMzkq<XP|<&O=Wdj5
+zG5b8jqr5|XkTRdFnfoy|e#_<2FW~3dCqmjftH}M+1ln*+nwXqXXr0NK&8fHefdP~`
+z<>q|j*m4CNLI(Vho|N|F);!E0cS5y^$H^Izje?z}oTgyr`9x9G&rlJZw&uqIoBMtz
+zzhU0(9;w02?m#0!)cFi*r+8YvooQ;(s2lLVvyLqAE%Xqe!vtWbIs!l1Bpp(FIht-Z
+zPn#CN-2C|J*GhA2fuHqYQ2mJiXlGTzD}mkr2;ia8Wp}h^;OS7+N^M<nb8{1bSa3A+
+zL8!27%|p8>w|en!1${vN6<B1T15(f#0UdAk{Wr$+OIZmA!F!Rj#Z~!T7({o*mB$j>
+z-x{8N*4UekA~`IV2&K-GzhAqau|}d*pEQ$1MH$cFi03OG^1NetZ_jW^STaEzr&Xho
+zB452St%v3ez2#TFm~`gZ<UBEKV7u<uCXTZP`7$*T39B#gt?T&`4)K;E&|ZM6WSMdG
+zebuH**%SihzOx;;CUDFI*)EgzXx=I3<*D-whBHjKN-pq1#;zw`)Wn{zX$8V;zVw$q
+zbhEvq3kJ(?s``MV!AS6_c(5D)L4tK*Aw)gIAhX&Z%n4p62=O5*U-Y5Ba)ZL6Adcrk
+z)x8`?1tz4OdUR+*taVv0tA0F%j2gu>h$vi=in+y2d!z<{OZ~Kty-5bQ;0O<LNwDnI
+zC}8-6mq`yuqDIHx`*=Y3Ma%=;%#E>=k_ESi8Nx9{*T`LJy6jqR>&|+>OZ;+=0hA04
+zE25t^sE9HG)3^<Ym7m{BQ^G!z>KKR_A5WDkqispweP9!I-@dCO&N!JrD@i{WBHnfQ
+z95o8;d$`AFnca3;N-0iX-CmbbAp5yQ!GoH;h7Cn?m{ammZJI8igP{U73lFnl2&gCs
+zqJ4(Vo~^j`{zOA<UI~9WX4R%(>zScL5B_Sm?Mjtek1d(A6X5ObcZi$;aOYy|g$}BY
+z$GEP3#i60Ju_&3SHzryH!gUFwC9-295u??cf+aYRQ1$+!rc#42YNattd6mZEFI@?C
+zqFM>6+zxEunIHDZ>{Z15u##>N(28Dw!>G(k*dB{NHvip@aP}f`@=Q;!o;zRMWo{Cx
+zo?kyzh8n7#f1g0&g>Cd>O-2g?uPwy8sy8hZbHSsXPmU;@l=HL=zm7mN(=@*|D$i+u
+zs~TllkCTvD$f&-#b9B?}#Lg*-ibK13R_a$RyoN3m5`10tdhAq{+VW)K#Bht-ra1*J
+z+n$N%V>u0rVtx`aKJDwXXrxa<i8EX06UO&LLD=n5qGhcYvn1Mgi;G^)TV4yilP*(Y
+zoKH+I4#~X)gA)B$;S;Huvs1a%d&HL})yYqqyVy1<B|Kl_6$aedKOq)GM61zpA^OQY
+zD*lN>D7nS<>$=c82v7<sDF~4nP`e39${9XIsr;e(ythhyAUnjOkWQ<YzhIcj{t&n{
+zx(8T~Ps>@KVx^S@vT;h=SZE37K>iahpx3;VDzEr9GY=2(%uaqM;^76eSP0QLzo4sI
+z>p_Eei*T$K;|qK`sq;?Hesp}(@VvX2Q4sAMYAJ}b&d$htDMC{FG-$o4k9ApECi1$a
+zXdamjiOGKHBh(4M<3(2x6n-CrmZMCknkQxdSS!qlis#I}btfX;J`JU3RlvtLdrymP
+zG0ZzrsGXVFiq+Wk1=BFay&9ZiCE#(`h~CL+c-Hs@iGTU@YxM%vlg;)`Tf~IknA^02
+zXkN#Txo6aR{j$wP5T#|UH#<s*%`(Km<n&(n-VMO61HPpba9D&s-YZ<E)NH59!I|A9
+zqN-T-CD))<D9dzh{pWi6;9v!e;Gu01;Ra@5B;qlH=@ASvlOB+p<XN`E#p(1Aq3B41
+z)+3^0JXTY<%Czvf6l;_I-72Od>5AP2{rSY8p?<egp~%*QDVvn_i1jVI<vF4YO5Wv6
+ztWwz1KFP<1kO#Hjq^e=sWVsSgwV`63V3pc#=)rascLi7{-yp$_z50Wja%IQ)>jKFv
+zG3kn3y`FaV!*Jq%m39_TQEhD>M@l*bhEPGe1{ft3q#K5AknT=F2_=T^l#ou5ln@D#
+z5Tzs(kRG@qNDa~<d^7jn_a!bDdDr)>HLNvfv7Z0g=bSlb?`QAx|Gfoni|iHJ%K0cy
+z;~Nsaa+{8HP_qrb{nj+xzkdYhSI@W4N_1`z(eSGIkbDP)!Ko|M%}Rqp(~KI2hl~eE
+zvJ!j4m6iwMgKy>fkCLC)`M$z9EV}B+sq1}}kVf$(ig0pWTY?rHz1Sm=4srTGNb^JG
+z=2$9wz-C@aZZZ2!HY#HNejqZRmE=pN(D$Kui$NpfhU`!y_s{@MIxiJdHb1|{6xb`>
+zE74_@QtgtG{4=3P1$^vn&m}7Aw8!1DnT$2thO#~44wl(N#ao8S0@t@m+Z!KD2CfK;
+z)n5DAPKV_etmH1aLDK$<bfKTSGeuYq_HlONO3C#M3PFvqt3PoSz0>?`;sL91iVt$D
+z*SG}=-LIAg(*+JON!-5ivqOMQ1S!OQUgHglDsKik&Mwg;vva523`JwQH6SRz9eTY#
+zTIi23145~kc3r1mSWC_RzD%hs$S#!pkI9!BU80jJCJcwo*FZolQG$q`8C1d9pP@ND
+zG^&-ZraIvhg_FDVSfKGwkcI=avIan%2sK4coUs~Nr8jC*&!G0#?}_^s3r-c}-uAqi
+zM-Lw>Y}I``T;IS%Y|qH;s{F*ZefM!4{I5awr!K+T@uPd*Vu*iPWI}>(-D{zxsN>LG
+z=@747a_Rb2<sth+J2Z?T^N6ka2dx@o>>q?y8xYf?dq2HM5tFO8Y5e4N;Y=xy8yAhI
+zsm>oy%R5;7)7T3V_b2%`aH^tNlsQpFxIFW<Pc_7hO>#iV#8?{6{^cGr{A0@1bA)|K
+z>MMTuZD(pd2t|7vmHtywGXb%%=)S<`OG~}U+jm#xd%H8<zV$)T@@IDRa^1+^lW~x>
+z$v8-C%F?ah3$;hn?{G3(LT!SgvCVi$vwsZssAQvUwT`Q%qSw!LSd!(<CTTRep1wpD
+z+1amWP^M+0sC8ZA)6PVj+g*a{JY^{LZp|zaB+|iUBf2HHkx&1DcY_YMj%(o)N(g~8
+zuOD62JY+Vu*^6K_|7K^R++2{-!+XRjo6R-MpFwn>I!64w1=%Sc1Mck)q1@pZ@)=SY
+zoX}d+L3-RA<kqVpViiwE2+1D(*ikr;H!OUuItq{`ksBj7b-a&@`xR$^jH(snEHH~+
+z(=1=%lU_?$?ERV8-3T`#N?ATVklfraz}x&yFwwIzZ7NQQfnqa96c>|c?G3_BQNm&(
+z!i$AZ7cI(z7q|e9VM##6T3Xorj1JG(9os$;(I$y%mBy(#8{|3l4|x*oBAQL^XhZ0g
+zy1FR1teRrpKq{uLAibTLx#n({qwjlkOvR{OdSAeT5ah4-sNN)n4Clg1T9lzF)&yj;
+zyal1%+s4n1IG;^VPWJ;#olpk8Z42Gj-tjFeQ&PlxB)`oCNoUYKj4U$AeG8rYiD{pK
+zndDf&2;2;)D|KvOZP+e7fcPU9k4M2sfhr@vC~Ly0?S-4dz)ZGAYpCsAhChgbxLd4g
+zhTrbIPkO5SEp_kD>Ha0m12h5n3s;mE8kn515&n<G5W?|M#KpzT&e--JK0@kIpJd@a
+zo$oEcM{PP18Ny#xS;1ngiAr#v&bUmbji#^iady0^<*7sdBUjhh1TZPRkf>zSf+^D=
+zyE{JnJ;43l&BH55CL<=W%CF;6iUI)V5C*6!`**KqvzR2=Fj*3Y4`HYwx}TYD445(K
+z-QtXwtL?m*(F=LVH*H4oM>dXHBW=38q_dZ-_Vr&qpEPxd9Fs95P5W~@Z|Rt+WZP6l
+zPSQ}~Dh4V?Pp1g&H<P(ih9)F<lyKeQW3i>k*Px?lm16C@X6M29Vrk%Rw@E||E-v~$
+zb_E~{z<}#8i`Mx9mkqtd#Z1lZ-E_J8I+2oumc#x1)jdvh{W76NKm6x-RYpM~v!P8$
+zw3e|YVf|}Hse9~oC@N7^j}Fi$hNpyaYnu1}bdXsD=^oI*%WKvbme|<Oza_wpW8gk;
+zu2yC)2m?TABYV?-o`?uFUCrz2#D@wpoKDwtWV7N~cyL3h>BI}$G3>smu#6y)ls|j?
+zF7Bhu9Z)j)C;3cZb+I>0stSK^WLOYV^U{pUYkgv>?+Nt^5j*CUB=eGw-CvU&40>y~
+zGoHLXxY^7k5Xgv62{iQy|5jJQuq0|LU`}lE@flQ2Z*Zn*VWcQjm4FTb>LSVox^S4q
+zLn`LfS@mrjKCmg$nb^af?d?0&$aX6#2u(JyzIJvuJ*lwPrh|0~aEnSACCTezSdG%h
+zmSQg`17j@$Iq)r1&?+eR@1nlX<hZA96|9?2Pc{<?%#({H1;$K9kGnzSr(*CLy;MCq
+z%~Qs5<0+7FZWenzFJQAz8d%>|H`<}_!?BQSF&N+QQnvEAqZe+mIFui!0V49R?|9*$
+zv!K1A01{8xq;L()Tv*Qk0-$Oj6+vCT*TUD{HvxO@3JjxBwM!4g3ydy&eaJw4CoQBF
+zJtULJ!YxgNR7_Ls%LmogyI7uIs=!B&?=MYY^yX+v;j@D_xGeZg>eZk0C;4e|HRNSi
+z6KlD9>q=3v-$4Zik&^ZDhNm1X)+7<A8tsuQP$bTVU`(p}?t_F!BJ>LCH1k!s+T3tn
+z<oekdyD0CJe2We4yeX>Un@={1U&NJLq@K?~w|(=Y<4W{ucX}F<B#7eu{_F0(M`~qI
+zEPqMc=S17TFa*Ut$xJ>dRr6pLw(l2$iK)At<eBP=<9%0^t_Ek7)YPj~HbzFdS?&Z-
+zFWq#s<_owUG*W9*3T5d3x?Z=@Xg0_}q&OpWn<UO2%6U`unYl-6@mymg@taxBjyc#}
+zd)7tZ=4f`2N^@IyGR7RJjM#l%PlXpmAf&TWaZ{@~`%NOfGu<_iX{6IZhLU^5%U~Eu
+z>%t3gYBMlJz#(K0Nqm;=K<FO+Hmo`&$bpQVtC{pgje|zpXK%6B)|FgdwTg%Nz2k)`
+z8X|UntK@qHxvr+JIl!et<9kIpEAP}K!ng>AML!&MMSNz=%k=j*zh77r34Rs37iCY`
+z=_kva_41bdrj(b=4Wc5MO0~q^z#pIWJ>)vDSgIQF=3JVJe1iDy%h)8oNy{s_r&;m`
+zL{DYKSB_5xRb9xKNOS{qAY3qv5sSXVrrf%~*q5HO|CQ&lbKMePa$M5D{vlJcoGrCZ
+zD?fKbZN$6rWwz)w7`9h4DAmh1ij2}EO|bO#A9L0_RW6l*$sPP<sv8r8rA9owl!eeR
+z1NTGO4fH_iJ$h#A4{SmcyR>UJrUbhLC75L9%W5iO$Iw5~Yut-qBeu~hF|xD7-eQ%l
+z412vpq_;t%^F*pYDk%Q35c-erK|6Ve=FxQbAv~ikZ4c9$Y4;ee#ciOD9{yRqf55Qk
+zumv}#+JciT|Gj$uFOxBUze)=?l{B}qaC0_7m`t82<$K53!4Xvi9Tr)ADp3Off?O8o
+zVDG0Yx|tfn@r((m?Nxrh(b0DGjg)$;DfO&$6uY;4&<!k&O=hr#o>F!4jnxkhP}Y3x
+zS?WFFt>=HWzqlQhffVfvM$Ta8Sg*r3j!Eo&rUOW7SCL2~lG7<+XZ;+{&8<DyiSykp
+zA7l-}(I|=ms%tNFTYkoIsuLyg?+I~Z*3Q|??RFu4_0^U6Re;X@@34fx?CAjIypLRX
+z$t)jPOy0bd<@4-yMHz0{9Y1LCV%IkRJ|jg%fPCmT)F-!8_Y#Dx3{FysRp`Q!doW+6
+zZ}IrYb2DD<Y8pA*#%c==4-8brg}Y#8wFDK<c2$i#jeUy3OkIIRUG3<@gcwUTYAl?p
+z`@7Fcaz|&cdl(`^C!Qo@F-$oXtl)ANqe_kyV5z5QcLFH5ktesECpz2i%Uy3K;o$nU
+zRHA31(@H1&5F`A#ssy`goLx2j=rBn*CE>h5g8ElI+P>>yR2U%S93NN<c)T<0U~gz;
+z>!Xhm|C682t6ysH-=o1=Bd*N*V<P)26zv@1P>lnG%l+KZFtjG`UkL;%65qn0UYQ`h
+zh0{9jDQx(`aBe7J0Aj3Z)4}`A|4OMM0a;?{j}qkYwi)~O8$9D}ITiMH2buiU>ixYp
+zhL${nwj6X($*OwmpVG`y5b6v45tX*J8?og}Qju6eJ9H}`X87iEd%BUo7<`2q(HJx+
+zMR<Pt%@%D0sbR}bR2vchjFmv@&giX(?>}d-J4oAf{V1W^a2~`M-YAdZ81<O(x-LLB
+ziYJ(IlIy^J+VaY)YgPSiQ0Us4I~n$rwJ4oe0cPBI>dd4o6NPO{cmZaAS@RS4ir#Sr
+zf<VdxlnqAnRM2AE_ghvSVwSte-XRVIyT(D^slNqE-8jf%6<nCMa`zf|$630Q?axs+
+z8-|ze)?RSqAckM?+w@&cuhDl@^|OO`O*pLVJKYxi4OohAU>FZO-VIL|VN<%nEXr2`
+z$0FK2L#8O_f1w~c@G70JrB@N}r(gJ!Vmkk6{r68w!o$qO?HrFcjeU0_3F5;*!E2%(
+zTx<?~WRM!G0a&ySR$<jsjlFDU!_cQ=rm^f3a0m@pR~S~3x#Q!vBQ8QrLR>>4?gP8w
+z1B?3UVZmz^%d_dIps>>0{cB~mp3{9U<B7u|njwlkXBz*b%D0;yhSH%?j@*Qn*llsX
+zO1Db$I4fzAEAs;fb^Hb!dP&&H(*QyAv^S{c)(B}+d64a7WNv#fMaw`2RTzNS*TvY_
+z7H6;X#FS2^bTGaO6(xFKPOPseR+?{`;POC2m5aaA&EKov%Vz!k+>oPR6uQFecVq&}
+zY{ebB?AlPAD_}(ll{fK99;Wh1cgRbnw)maD^F>*J!R}eHM*W0VYN1TADWMy9H=$00
+z5bHY${oDgwX7(W9LZw?}{!8(_{JB~Xkje6{0x4fgC4kUmpfJ+LT1DYD*TWu4#h{Y7
+zFLronmc=hS=W=j1ar3r1JNjQoWo2hMWsqW*e?TF%#&{GpsaLp}iN~$)ar+7Ti}E&X
+z-nq~+Gkp(`qF0F_4A22>VZn-x>I$?PDZSeG8h_ifoWf^DxIb5%T7UytYo3}F|4#RC
+zUHpg$=)qVqD~=m(!~?Xwocux<fMdw81nD!;t@a*4neQ(aVD(J+A2??uX#HB8h{SA^
+zdwHZPt(_kv#Cy%vSUh54y~cPXj=D^*;zTVk5y{_bC5yAz3CQA`(UWK4rS;tBXU@kM
+zdej%biGz)+Zyb}ApQWbz*^ZVHpgtmw$q*Vpwt!Q&h9PG6;&Z4L%=lGi5uP2+Iw}}%
+zRw^VYFqyiS!j*Ylw*m}O)GZr&wh(LNL_SF4+fnf#U_g+~SMcMFhbA4}sBM0v^=YW-
+z&lY;LS6yEUO8A78NCxHMrs`yWt-AgIrz<}>U1u}9qhhM7d^eqmJPi_e-!IO`*{u7A
+zbu*?L$Mbj-X9n3G2>+Kc#l`@d8}Xb9{l*IN{#<s%V4>M*d;s+3Pdr8FO$EBELR=8{
+zd?LJbSv9fI`{OqTH)5{b?WulgMb)psp+W|@cSp=jtl-&5C}9lw@*0H+gEW(}mAWNz
+zf{~U;;<ij^TC}|2a=b@Y*t)@0v1xP(v60Z1AVFC^6OFVSu>N}|wdSaphgqn<w7=w9
+zK8);m^xjJ26KBA^s+X~_;*<r_i1!(b_J^XZTX2ts<uU`4&%E_cmAS3_5^hk59|kgD
+zMLF}`MyE`hy%MFvhK6uW0T0ZwJE%ubf^cybN1t(tFSjlXmU%iNJM_KhC?w8%lwxG%
+z^l3qjQ#&r)nR&TI7eX29AQRbBd!NtWy|6g3o?g!*>H{FWUy!{y3^=AC*c?RJ5Eb<^
+zCgH_v7^axIUVmHSFL^zlj2R$zow$|y#7>%#U7d#Vp_ezcp3lefMyd5ES=q$>4pWyA
+zp_Zso^^NP~lu2=S6nD(3Z5u=Uy&B&F<ZVfpeB?A^;A;yfb|T-IdCr4F&4;vkGQ(ce
+zh3=uO>1i$J*3;3KhEkD_lgscHGR*;T;U!9vgQa(hI}oh9IzEf_PU_8F+i77t-~gDX
+z490Sb<R_L<O5Q@b5$Zq8%`yG)pr{P@%VAd&n*7r>)LyVZmf18N6w{+37$aO<2!Av0
+ztLaPOv^J<2@p{WnMiDudoghX_`luFZt_4eNU}*~cF5i%eEcNLs;D>QVIwr8mH;=dc
+z09`}JV;aaF;13<?rh<ybd3+ERtA!AF+n4vv*yO!S>@&iS(w>Jc=k~|d_1hcpM(l|O
+zu>!@}me%isTT$xT#hNUvh(ATd0wT4fbv=6htc<!_*5tIlcw;jfC)7eiH`TZ#yg33G
+z*K{nA3s&@UJ|kOpm^FmpZH!jpU$uLLL0hBd*qzwn)R|bYU?5GP?km8IK}b(Rmo(9m
+ztmUrC#OLcS1`w=qT%q{r;x6q#X*G<@Q?b$fk$PV_;x3)8-*Cma`(%rzI}~@X_mynt
+z){EdYfW}JcHE72h7O(F)3GWJ5QyDsqkV#hvVxfwA+tCRWd-}F=Z{E9X{i^#g-uA}M
+z8A};Fz|8*u<?gci0HA-zkJWo>HNEZIw9%E6wlYmwfu2{j0kh1y=$;Yf!|NldgB9ul
+zB{dbE&LfRnr8ITm@;-68wo#VV?8lG3ed&9k1}QBS3}WGV9%26?A1rBkkDR9Z3o+g+
+z)eQg8BY3y(Dh5&z?VLLNdDV`C=muUvCPpGg!oYxIgOI3^%4>5d7jTh~ni!Fg2;fhx
+z(*c%H6Je84kmQh;5tC3*l~7khLxK-e|Cz?FLh!yYe7g|*LwqU?2wv^_ZyK<Of{dhu
+zsv0|3@?TRSx1dhZz(pM4pWCNW)x%RcI9qU7{OJ?KVPb2=ae`t5N2|Np!TnR=miT6l
+z=X6%jw%pdV6l@QFlD~p?kP+pL<B%Y@NatKA$=T#KFRv!+!jsp)t11X)#&Hl3U6lMU
+zJRO~gIozN7FCmvReeSbLXwrCX?C>T$fYVkGJo@AK0$+ml?}zJeB~deT2WL1vz}dxB
+z)y??t!}%M@)u$_I<M8Xr7=Atw2=U{1NPY=Pxyvvn&o=WU(EM~W-`~1~CfLfw1<p(O
+z>yW~)6u1SttJ!awd6N5lx|xBrmyrBh>tb&D*=C+Z3nPfq$1%WgY0bY*?PZ#Hk|=xn
+zGM#0*w4CaB^y0G(J4q=;5NeM@m-P}#mv7QZNF)M!dK^w{mk_!n0`+Y3PQutu-%NBt
+zzgPXug?JLEbUL{e_dk;Vd896&yPe(hliVK!lj%5+@BKdcrEZ2Nc_*i@ve*2lB>u~{
+zFozd2FM|_0+nAGR4TLNHanQn_Oeb!Jr<ML^n#x(-lWYbAxZ^lzL{91ce=r_rMNh&3
+z5ZH&~&=xx-`k!k3r63SzRZbe5pFX5uiE~x{Yij<#VF%9Yp7eo6*ry-Is`SOWzco`o
+zD|OPe5MeBR9K!M!O8w?{d(zJiQDi%gL-lj>UcvzJ?7p9TTNB}ocO3j$7ij!li8#k6
+z@2tSd1>K03K9A#_-MIq)S;T#oE^;>U$)&}okIvDf3lm?kI{d80$>~<aBIV=g^}I;q
+zHz)SwoEc)S_BbfR&P{vn%<b8oJvk9{`Zix4ac<U&X5Y>xKUoS!%q1Pi?WpsUUt(tI
+ztjNjY*y&Rm9(S(DC2GuPHBJs@5M{RGm`c1z<6nwyN^)rMo-AS{M2$oM9|y%fM|}G~
+DHx0+F
+
+literal 0
+HcmV?d00001
+
+diff --git a/position-service/gradle/wrapper/gradle-wrapper.properties b/position-service/gradle/wrapper/gradle-wrapper.properties
+new file mode 100644
+index 0000000..a4cf193
+--- /dev/null
++++ b/position-service/gradle/wrapper/gradle-wrapper.properties
+@@ -0,0 +1,8 @@
++distributionBase=GRADLE_USER_HOME
++distributionPath=wrapper/dists
++distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
++distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
++networkTimeout=10000
++validateDistributionUrl=true
++zipStoreBase=GRADLE_USER_HOME
++zipStorePath=wrapper/dists
+diff --git a/position-service/gradlew b/position-service/gradlew
+new file mode 100755
+index 0000000..faf9300
+--- /dev/null
++++ b/position-service/gradlew
+@@ -0,0 +1,251 @@
++#!/bin/sh
++
++#
++# Copyright © 2015-2021 the original authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#      https://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++#
++# SPDX-License-Identifier: Apache-2.0
++#
++
++##############################################################################
++#
++#   Gradle start up script for POSIX generated by Gradle.
++#
++#   Important for running:
++#
++#   (1) You need a POSIX-compliant shell to run this script. If your /bin/sh is
++#       noncompliant, but you have some other compliant shell such as ksh or
++#       bash, then to run this script, type that shell name before the whole
++#       command line, like:
++#
++#           ksh Gradle
++#
++#       Busybox and similar reduced shells will NOT work, because this script
++#       requires all of these POSIX shell features:
++#         * functions;
++#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
++#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
++#         * compound commands having a testable exit status, especially «case»;
++#         * various built-in commands including «command», «set», and «ulimit».
++#
++#   Important for patching:
++#
++#   (2) This script targets any POSIX shell, so it avoids extensions provided
++#       by Bash, Ksh, etc; in particular arrays are avoided.
++#
++#       The "traditional" practice of packing multiple parameters into a
++#       space-separated string is a well documented source of bugs and security
++#       problems, so this is (mostly) avoided, by progressively accumulating
++#       options in "$@", and eventually passing that to Java.
++#
++#       Where the inherited environment variables (DEFAULT_JVM_OPTS, JAVA_OPTS,
++#       and GRADLE_OPTS) rely on word-splitting, this is performed explicitly;
++#       see the in-line comments for details.
++#
++#       There are tweaks for specific operating systems such as AIX, CygWin,
++#       Darwin, MinGW, and NonStop.
++#
++#   (3) This script is generated from the Groovy template
++#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
++#       within the Gradle project.
++#
++#       You can find Gradle at https://github.com/gradle/gradle/.
++#
++##############################################################################
++
++# Attempt to set APP_HOME
++
++# Resolve links: $0 may be a link
++app_path=$0
++
++# Need this for daisy-chained symlinks.
++while
++    APP_HOME=${app_path%"${app_path##*/}"}  # leaves a trailing /; empty if no leading path
++    [ -h "$app_path" ]
++do
++    ls=$( ls -ld "$app_path" )
++    link=${ls#*' -> '}
++    case $link in             #(
++      /*)   app_path=$link ;; #(
++      *)    app_path=$APP_HOME$link ;;
++    esac
++done
++
++# This is normally unused
++# shellcheck disable=SC2034
++APP_BASE_NAME=${0##*/}
++# Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
++APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
++
++# Use the maximum available, or set MAX_FD != -1 to use that value.
++MAX_FD=maximum
++
++warn () {
++    echo "$*"
++} >&2
++
++die () {
++    echo
++    echo "$*"
++    echo
++    exit 1
++} >&2
++
++# OS specific support (must be 'true' or 'false').
++cygwin=false
++msys=false
++darwin=false
++nonstop=false
++case "$( uname )" in                #(
++  CYGWIN* )         cygwin=true  ;; #(
++  Darwin* )         darwin=true  ;; #(
++  MSYS* | MINGW* )  msys=true    ;; #(
++  NONSTOP* )        nonstop=true ;;
++esac
++
++CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
++
++
++# Determine the Java command to use to start the JVM.
++if [ -n "$JAVA_HOME" ] ; then
++    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
++        # IBM's JDK on AIX uses strange locations for the executables
++        JAVACMD=$JAVA_HOME/jre/sh/java
++    else
++        JAVACMD=$JAVA_HOME/bin/java
++    fi
++    if [ ! -x "$JAVACMD" ] ; then
++        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
++
++Please set the JAVA_HOME variable in your environment to match the
++location of your Java installation."
++    fi
++else
++    JAVACMD=java
++    if ! command -v java >/dev/null 2>&1
++    then
++        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
++
++Please set the JAVA_HOME variable in your environment to match the
++location of your Java installation."
++    fi
++fi
++
++# Increase the maximum file descriptors if we can.
++if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
++    case $MAX_FD in #(
++      max*)
++        # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
++        # shellcheck disable=SC2039,SC3045
++        MAX_FD=$( ulimit -H -n ) ||
++            warn "Could not query maximum file descriptor limit"
++    esac
++    case $MAX_FD in  #(
++      '' | soft) :;; #(
++      *)
++        # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
++        # shellcheck disable=SC2039,SC3045
++        ulimit -n "$MAX_FD" ||
++            warn "Could not set maximum file descriptor limit to $MAX_FD"
++    esac
++fi
++
++# Collect all arguments for the java command, stacking in reverse order:
++#   * args from the command line
++#   * the main class name
++#   * -classpath
++#   * -D...appname settings
++#   * --module-path (only if needed)
++#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and GRADLE_OPTS environment variables.
++
++# For Cygwin or MSYS, switch paths to Windows format before running java
++if "$cygwin" || "$msys" ; then
++    APP_HOME=$( cygpath --path --mixed "$APP_HOME" )
++    CLASSPATH=$( cygpath --path --mixed "$CLASSPATH" )
++
++    JAVACMD=$( cygpath --unix "$JAVACMD" )
++
++    # Now convert the arguments - kludge to limit ourselves to /bin/sh
++    for arg do
++        if
++            case $arg in                                #(
++              -*)   false ;;                            # don't mess with options #(
++              /?*)  t=${arg#/} t=/${t%%/*}              # looks like a POSIX filepath
++                    [ -e "$t" ] ;;                      #(
++              *)    false ;;
++            esac
++        then
++            arg=$( cygpath --path --ignore --mixed "$arg" )
++        fi
++        # Roll the args list around exactly as many times as the number of
++        # args, so each arg winds up back in the position where it started, but
++        # possibly modified.
++        #
++        # NB: a `for` loop captures its iteration list before it begins, so
++        # changing the positional parameters here affects neither the number of
++        # iterations, nor the values presented in `arg`.
++        shift                   # remove old arg
++        set -- "$@" "$arg"      # push replacement arg
++    done
++fi
++
++
++# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
++DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
++
++# Collect all arguments for the java command:
++#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
++#     and any embedded shellness will be escaped.
++#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
++#     treated as '${Hostname}' itself on the command line.
++
++set -- \
++        "-Dorg.gradle.appname=$APP_BASE_NAME" \
++        -classpath "$CLASSPATH" \
++        org.gradle.wrapper.GradleWrapperMain \
++        "$@"
++
++# Stop when "xargs" is not available.
++if ! command -v xargs >/dev/null 2>&1
++then
++    die "xargs is not available"
++fi
++
++# Use "xargs" to parse quoted args.
++#
++# With -n1 it outputs one arg per line, with the quotes and backslashes removed.
++#
++# In Bash we could simply go:
++#
++#   readarray ARGS < <( xargs -n1 <<<"$var" ) &&
++#   set -- "${ARGS[@]}" "$@"
++#
++# but POSIX shell has neither arrays nor command substitution, so instead we
++# post-process each arg (as a line of input to sed) to backslash-escape any
++# character that might be a shell metacharacter, then use eval to reverse
++# that process (while maintaining the separation between arguments), and wrap
++# the whole thing up as a single "set" statement.
++#
++# This will of course break if any of these variables contains a newline or
++# an unmatched quote.
++#
++
++eval "set -- $(
++        printf '%s\n' "$DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS" |
++        xargs -n1 |
++        sed ' s~[^-[:alnum:]+,./:=@_]~\\&~g; ' |
++        tr '\n' ' '
++    )" '"$@"'
++
++exec "$JAVACMD" "$@"
+diff --git a/position-service/gradlew.bat b/position-service/gradlew.bat
+new file mode 100644
+index 0000000..9b42019
+--- /dev/null
++++ b/position-service/gradlew.bat
+@@ -0,0 +1,94 @@
++@rem
++@rem Copyright 2015 the original author or authors.
++@rem
++@rem Licensed under the Apache License, Version 2.0 (the "License");
++@rem you may not use this file except in compliance with the License.
++@rem You may obtain a copy of the License at
++@rem
++@rem      https://www.apache.org/licenses/LICENSE-2.0
++@rem
++@rem Unless required by applicable law or agreed to in writing, software
++@rem distributed under the License is distributed on an "AS IS" BASIS,
++@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++@rem See the License for the specific language governing permissions and
++@rem limitations under the License.
++@rem
++@rem SPDX-License-Identifier: Apache-2.0
++@rem
++
++@if "%DEBUG%"=="" @echo off
++@rem ##########################################################################
++@rem
++@rem  Gradle startup script for Windows
++@rem
++@rem ##########################################################################
++
++@rem Set local scope for the variables with windows NT shell
++if "%OS%"=="Windows_NT" setlocal
++
++set DIRNAME=%~dp0
++if "%DIRNAME%"=="" set DIRNAME=.
++@rem This is normally unused
++set APP_BASE_NAME=%~n0
++set APP_HOME=%DIRNAME%
++
++@rem Resolve any "." and ".." in APP_HOME to make it shorter.
++for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
++
++@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
++set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
++
++@rem Find java.exe
++if defined JAVA_HOME goto findJavaFromJavaHome
++
++set JAVA_EXE=java.exe
++%JAVA_EXE% -version >NUL 2>&1
++if %ERRORLEVEL% equ 0 goto execute
++
++echo. 1>&2
++echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
++echo. 1>&2
++echo Please set the JAVA_HOME variable in your environment to match the 1>&2
++echo location of your Java installation. 1>&2
++
++goto fail
++
++:findJavaFromJavaHome
++set JAVA_HOME=%JAVA_HOME:"=%
++set JAVA_EXE=%JAVA_HOME%/bin/java.exe
++
++if exist "%JAVA_EXE%" goto execute
++
++echo. 1>&2
++echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
++echo. 1>&2
++echo Please set the JAVA_HOME variable in your environment to match the 1>&2
++echo location of your Java installation. 1>&2
++
++goto fail
++
++:execute
++@rem Setup the command line
++
++set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
++
++
++@rem Execute Gradle
++"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
++
++:end
++@rem End local scope for the variables with windows NT shell
++if %ERRORLEVEL% equ 0 goto mainEnd
++
++:fail
++rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
++rem the _cmd.exe /c_ return code!
++set EXIT_CODE=%ERRORLEVEL%
++if %EXIT_CODE% equ 0 set EXIT_CODE=1
++if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
++exit /b %EXIT_CODE%
++
++:mainEnd
++if "%OS%"=="Windows_NT" endlocal
++
++:omega
 diff --git a/position-service/openapi.yaml b/position-service/openapi.yaml
 new file mode 100644
 index 0000000..9c78a47
@@ -3847,10 +7686,10 @@ index 0000000..49f24c9
 +}
 diff --git a/position-service/src/main/resources/application.properties b/position-service/src/main/resources/application.properties
 new file mode 100644
-index 0000000..ad0a1b2
+index 0000000..25b603d
 --- /dev/null
 +++ b/position-service/src/main/resources/application.properties
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +server.port=${POSITION_SERVICE_PORT:18090}
 +server.forward-headers-strategy=framework
 +
@@ -3861,7 +7700,6 @@ index 0000000..ad0a1b2
 +spring.threads.virtual.enabled=true
 +
 +server.max-http-request-header-size=1000000
-+springdoc.swagger-ui.disable-swagger-default-url=true
 diff --git a/position-service/src/main/resources/test-application.properties b/position-service/src/main/resources/test-application.properties
 new file mode 100644
 index 0000000..45268a9
@@ -3935,13 +7773,13 @@ index 0000000..1ee7a00
 +- Dataset: `data/s-and-p-500-companies.csv`
 diff --git a/reference-data/SPEC.manifest.json b/reference-data/SPEC.manifest.json
 new file mode 100644
-index 0000000..82db810
+index 0000000..eb93b43
 --- /dev/null
 +++ b/reference-data/SPEC.manifest.json
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,33 @@
 +{
 +  "schemaVersion": "1.0.0",
-+  "generatedAtUtc": "2026-03-31T12:59:32Z",
++  "generatedAtUtc": "2026-07-22T12:27:30Z",
 +  "component": {
 +    "id": "reference-data",
 +    "kind": "service",
@@ -3955,7 +7793,8 @@ index 0000000..82db810
 +  "runtime": {
 +    "defaultPort": 18085,
 +    "dependsOn": ["database"],
-+    "requiredEnv": []
++    "requiredEnv": [],
++    "healthHint": "http://<host>:18085/stocks"
 +  },
 +  "contracts": {
 +    "primary": "specs/001-baseline-uncontainerized-parity/contracts/reference-data/openapi.yaml"
@@ -4570,15 +8409,16 @@ index 0000000..c98ad8b
 +          example: ok
 diff --git a/reference-data/package-lock.json b/reference-data/package-lock.json
 new file mode 100644
-index 0000000..2eab1b0
+index 0000000..dbb66b0
 --- /dev/null
 +++ b/reference-data/package-lock.json
-@@ -0,0 +1,4308 @@
+@@ -0,0 +1,4257 @@
 +{
 +  "name": "@traderspec/reference-data-specfirst",
 +  "version": "0.1.0",
 +  "lockfileVersion": 3,
 +  "requires": true,
++  "traderxPackageJsonSha256": "457620fc1d00d0b5e9ae096635384a5713e42cd13d6799993b8548a90013c5f5",
 +  "packages": {
 +    "": {
 +      "name": "@traderspec/reference-data-specfirst",
@@ -4600,9 +8440,9 @@ index 0000000..2eab1b0
 +      }
 +    },
 +    "node_modules/@angular-devkit/core": {
-+      "version": "19.2.24",
-+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.24.tgz",
-+      "integrity": "sha512-Kd49warf6U/EyWe5BszF/eebN3zQ3bk7tgfEljAw8q/rX95UUtriJubWvp6pgzHfzBA4jwq8f+QiNZB8eBEXPA==",
++      "version": "19.2.27",
++      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.27.tgz",
++      "integrity": "sha512-3amNzoCVSKd7ah6l6lBQL4onwwJvqvam7FMoQBILrxtW5LB5ezh8gMSPuA4zJjKjoRzf9uoWdlzqv/84I52xZA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -4638,13 +8478,13 @@ index 0000000..2eab1b0
 +      }
 +    },
 +    "node_modules/@angular-devkit/schematics": {
-+      "version": "19.2.24",
-+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.24.tgz",
-+      "integrity": "sha512-lnw+ZM1Io+cJAkReC0NPDjqObL8NtKzKIkdgEEKC8CUmkhurYhedbicN8Y8NYHgG1uLd2GozW3+/QqPRZaN+Lw==",
++      "version": "19.2.27",
++      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.27.tgz",
++      "integrity": "sha512-/PZmyAlb2NGWPikRRuiWLdfHQd8Wrx6lX4HqvTcaDhlU43M3T0ud4PH2T3QDp7BzHYY92xtD8iPxX2asg67G1A==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@angular-devkit/core": "19.2.24",
++        "@angular-devkit/core": "19.2.27",
 +        "jsonc-parser": "3.3.1",
 +        "magic-string": "0.30.17",
 +        "ora": "5.4.1",
@@ -4657,14 +8497,14 @@ index 0000000..2eab1b0
 +      }
 +    },
 +    "node_modules/@angular-devkit/schematics-cli": {
-+      "version": "19.2.24",
-+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-19.2.24.tgz",
-+      "integrity": "sha512-bsStZQG67J1HBqTmWxtIcobvgrn32L4UOdL7hGyOru5VxDWPNA8pRnDYavT3hnJeBkJYPoQIw8u7Dm0ecoQprw==",
++      "version": "19.2.27",
++      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-19.2.27.tgz",
++      "integrity": "sha512-wHYH6SVXVykhLzovUHtYor3Nl4SpIiITi7r9DQDaKYUD4hpRBx25W6N9eGuakT9Vd5tV/x6wmvQFWQZQwFB7eA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@angular-devkit/core": "19.2.24",
-+        "@angular-devkit/schematics": "19.2.24",
++        "@angular-devkit/core": "19.2.27",
++        "@angular-devkit/schematics": "19.2.27",
 +        "@inquirer/prompts": "7.3.2",
 +        "ansi-colors": "4.1.3",
 +        "symbol-observable": "4.0.0",
@@ -5210,15 +9050,15 @@ index 0000000..2eab1b0
 +      }
 +    },
 +    "node_modules/@nestjs/cli": {
-+      "version": "11.0.19",
-+      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.19.tgz",
-+      "integrity": "sha512-9htODqTVVNH4lJqyeIotsAgfeaYngDi020cVCd6JhJRKuOT83c/t4JDSky6+xr0lhHyNTNMgZmulxqcMNZFfrw==",
++      "version": "11.0.23",
++      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.23.tgz",
++      "integrity": "sha512-2V0Bf5jz0KXhUZk3eJi9GljIyqH04otwsE/mYLbqJR+X0iiYx+6bkNJ2Qz28uHNFj1cpHgimf9xDzHkqarie0g==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@angular-devkit/core": "19.2.24",
-+        "@angular-devkit/schematics": "19.2.24",
-+        "@angular-devkit/schematics-cli": "19.2.24",
++        "@angular-devkit/core": "19.2.27",
++        "@angular-devkit/schematics": "19.2.27",
++        "@angular-devkit/schematics-cli": "19.2.27",
 +        "@inquirer/prompts": "7.10.1",
 +        "@nestjs/schematics": "^11.0.1",
 +        "ansis": "4.2.0",
@@ -5232,7 +9072,7 @@ index 0000000..2eab1b0
 +        "tsconfig-paths": "4.2.0",
 +        "tsconfig-paths-webpack-plugin": "4.2.0",
 +        "typescript": "5.9.3",
-+        "webpack": "5.106.0",
++        "webpack": "5.106.2",
 +        "webpack-node-externals": "3.0.0"
 +      },
 +      "bin": {
@@ -5255,9 +9095,9 @@ index 0000000..2eab1b0
 +      }
 +    },
 +    "node_modules/@nestjs/common": {
-+      "version": "11.1.18",
-+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.18.tgz",
-+      "integrity": "sha512-0sLq8Z+TIjLnz1Tqp0C/x9BpLbqpt1qEu0VcH4/fkE0y3F5JxhfK1AdKQ/SPbKhKgwqVDoY4gS8GQr2G6ujaWg==",
++      "version": "11.1.27",
++      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.27.tgz",
++      "integrity": "sha512-kEGSzqM2lWr4whh4Ubflw+oPZSEzxvRMu9WL+LveZploJWTjec5bBlCiRVlVzTPg2kIwBiLwWSvCCW7Wnin1gg==",
 +      "license": "MIT",
 +      "dependencies": {
 +        "file-type": "21.3.4",
@@ -5286,13 +9126,11 @@ index 0000000..2eab1b0
 +      }
 +    },
 +    "node_modules/@nestjs/core": {
-+      "version": "11.1.18",
-+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.18.tgz",
-+      "integrity": "sha512-wR3DtGyk/LUAiPtbXDuWJJwVkWElKBY0sqnTzf9d4uM3+X18FRZhK7WFc47czsIGOdWuRsMeLYV+1Z9dO4zDEQ==",
-+      "hasInstallScript": true,
++      "version": "11.1.27",
++      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.27.tgz",
++      "integrity": "sha512-K6DX7hcqmZdeXkv7tsPakKBRCgqL19a4mtbX4FluY0hWtFdtPKp6lbe+lb8gWPfvLdbOWr/CPScn7BSjBX+Ecg==",
 +      "license": "MIT",
 +      "dependencies": {
-+        "@nuxt/opencollective": "0.4.1",
 +        "fast-safe-stringify": "2.1.1",
 +        "iterare": "1.2.1",
 +        "path-to-regexp": "8.4.2",
@@ -5327,9 +9165,9 @@ index 0000000..2eab1b0
 +      }
 +    },
 +    "node_modules/@nestjs/platform-express": {
-+      "version": "11.1.18",
-+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.18.tgz",
-+      "integrity": "sha512-s6GdHMTa3qx0fJewR74Xa30ysPHfBEqxIwZ7BGSTLoAEQ1vTP24urNl+b6+s49NFLEIOyeNho5fN/9/I17QlOw==",
++      "version": "11.1.27",
++      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.27.tgz",
++      "integrity": "sha512-0ZFhz6H6EdGh4xQVbUNwjoAwBuz73P7FvUAl67h9CTdMqQlJDaQYJApBv8pKfVZ1fGjMCbl0m9DcC6pXaZPWSQ==",
 +      "license": "MIT",
 +      "dependencies": {
 +        "cors": "2.8.6",
@@ -5419,22 +9257,6 @@ index 0000000..2eab1b0
 +      "license": "Apache-2.0",
 +      "dependencies": {
 +        "tslib": "^2.1.0"
-+      }
-+    },
-+    "node_modules/@nuxt/opencollective": {
-+      "version": "0.4.1",
-+      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
-+      "integrity": "sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==",
-+      "license": "MIT",
-+      "dependencies": {
-+        "consola": "^3.2.3"
-+      },
-+      "bin": {
-+        "opencollective": "bin/opencollective.js"
-+      },
-+      "engines": {
-+        "node": "^14.18.0 || >=16.10.0",
-+        "npm": ">=5.10.0"
 +      }
 +    },
 +    "node_modules/@tokenizer/inflate": {
@@ -5993,7 +9815,7 @@ index 0000000..2eab1b0
 +      "dependencies": {
 +        "baseline-browser-mapping": "^2.10.12",
 +        "caniuse-lite": "^1.0.30001782",
-+        "electron-to-chromium": "^1.5.348",
++        "electron-to-chromium": "^1.5.328",
 +        "node-releases": "^2.0.36",
 +        "update-browserslist-db": "^1.2.3"
 +      },
@@ -6291,15 +10113,6 @@ index 0000000..2eab1b0
 +        "inherits": "^2.0.3",
 +        "readable-stream": "^3.0.2",
 +        "typedarray": "^0.0.6"
-+      }
-+    },
-+    "node_modules/consola": {
-+      "version": "3.4.2",
-+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-+      "license": "MIT",
-+      "engines": {
-+        "node": "^14.18.0 || >=16.10.0"
 +      }
 +    },
 +    "node_modules/content-disposition": {
@@ -7468,9 +11281,9 @@ index 0000000..2eab1b0
 +      "license": "MIT"
 +    },
 +    "node_modules/multer": {
-+      "version": "2.1.1",
-+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
++      "version": "2.2.0",
++      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
++      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
 +      "license": "MIT",
 +      "dependencies": {
 +        "append-field": "^1.0.0",
@@ -8696,9 +12509,9 @@ index 0000000..2eab1b0
 +      }
 +    },
 +    "node_modules/webpack": {
-+      "version": "5.106.0",
-+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.0.tgz",
-+      "integrity": "sha512-Pkx5joZ9RrdgO5LBkyX1L2ZAJeK/Taz3vqZ9CbcP0wS5LEMx5QkKsEwLl29QJfihZ+DKRBFldzy1O30pJ1MDpA==",
++      "version": "5.106.2",
++      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
++      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -8718,9 +12531,8 @@ index 0000000..2eab1b0
 +        "events": "^3.2.0",
 +        "glob-to-regexp": "^0.4.1",
 +        "graceful-fs": "^4.2.11",
-+        "json-parse-even-better-errors": "^2.3.1",
 +        "loader-runner": "^4.3.1",
-+        "mime-types": "^2.1.27",
++        "mime-db": "^1.54.0",
 +        "neo-async": "^2.6.2",
 +        "schema-utils": "^4.3.3",
 +        "tapable": "^2.3.0",
@@ -8780,29 +12592,6 @@ index 0000000..2eab1b0
 +        "ajv": {
 +          "optional": true
 +        }
-+      }
-+    },
-+    "node_modules/webpack/node_modules/mime-db": {
-+      "version": "1.52.0",
-+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-+      "dev": true,
-+      "license": "MIT",
-+      "engines": {
-+        "node": ">= 0.6"
-+      }
-+    },
-+    "node_modules/webpack/node_modules/mime-types": {
-+      "version": "2.1.35",
-+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-+      "dev": true,
-+      "license": "MIT",
-+      "dependencies": {
-+        "mime-db": "1.52.0"
-+      },
-+      "engines": {
-+        "node": ">= 0.6"
 +      }
 +    },
 +    "node_modules/webpack/node_modules/schema-utils": {
@@ -8879,15 +12668,14 @@ index 0000000..2eab1b0
 +        "url": "https://github.com/sponsors/sindresorhus"
 +      }
 +    }
-+  },
-+  "traderxPackageJsonSha256": "b8c26142661f5d5e0883fe1a5fa92d69c0b13e43c820d65909604eb23115feed"
++  }
 +}
 diff --git a/reference-data/package.json b/reference-data/package.json
 new file mode 100644
-index 0000000..9ca2fbe
+index 0000000..f61e0d6
 --- /dev/null
 +++ b/reference-data/package.json
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,29 @@
 +{
 +  "name": "@traderspec/reference-data-specfirst",
 +  "version": "0.1.0",
@@ -8911,6 +12699,10 @@ index 0000000..9ca2fbe
 +    "@types/node": "^22.13.14",
 +    "ts-node": "^10.9.2",
 +    "typescript": "^5.8.2"
++  },
++  "overrides": {
++    "multer": "2.2.0",
++    "qs": "6.15.2"
 +  }
 +}
 diff --git a/reference-data/src/app.module.ts b/reference-data/src/app.module.ts
@@ -9217,10 +13009,10 @@ index 0000000..0f3f6db
 +}
 diff --git a/runtime/deploy/aws-ec2-compose/README.md b/runtime/deploy/aws-ec2-compose/README.md
 new file mode 100644
-index 0000000..49d4db0
+index 0000000..496c792
 --- /dev/null
 +++ b/runtime/deploy/aws-ec2-compose/README.md
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,73 @@
 +# AWS EC2 Compose Deploy Bundle (004-containerized-compose-runtime)
 +
 +This bundle is generated for state `004-containerized-compose-runtime` and is intended for compose-based demo rollout.
@@ -9242,9 +13034,11 @@ index 0000000..49d4db0
 +- `TRADERX_BRANCH` (default: generated-state branch for this state)
 +- `TRADERX_WORKDIR` (default: `$HOME/traderx`)
 +- `TRADERX_COMPOSE_PATH_REL` (default: `containerized-compose/docker-compose.yml`)
++- `TRADERX_GHCR_COMPOSE_PATH_REL` (default: `runtime/ghcr/004-containerized-compose-runtime/docker-compose.ghcr.yml`)
 +- `TRADERX_COMPOSE_PROJECT_NAME` (default: `traderx-004-containerized-compose-runtime`)
 +- `TRADERX_DEPLOY_ENV` (default: `demo`)
 +- `TRADERX_IMAGE_TAG` (default: `latest`)
++- `TRADERX_CORS_ALLOWED_ORIGINS` (default: `https://$TRADERX_FQDN,http://$TRADERX_FQDN,http://localhost:8080`)
 +- `TRADERX_PRUNE_DOCKER` (`1` enables aggressive prune in `cleanup.sh`)
 +- `TRADERX_RUN_CLEANUP` (`1` runs cleanup before `upgrade.sh`)
 +
@@ -9252,9 +13046,46 @@ index 0000000..49d4db0
 +
 +```bash
 +./runtime/deploy/aws-ec2-compose/deploy.sh --dry-run
++./runtime/deploy/aws-ec2-compose/deploy.sh --use-ghcr --dry-run
 +./runtime/deploy/aws-ec2-compose/upgrade.sh --dry-run
 +./runtime/deploy/aws-ec2-compose/cleanup.sh --dry-run
 +```
++
++## Front Proxy Note
++
++If you run an external NGINX in front of TraderX, include
++`runtime/deploy/aws-ec2-compose/nginx.reverse-proxy.snippet.conf` in that front-proxy
++server block. This generated snippet is state-aware and includes websocket routes
++that match the emitted runtime ingress transport for this state.
++
++## Host Setup
++
++Before running deploy/upgrade, verify host prerequisites:
++
++```bash
++./runtime/deploy/aws-ec2-compose/host-setup-check.sh
++```
++
++Install missing prerequisites (or preview with dry-run):
++
++```bash
++./runtime/deploy/aws-ec2-compose/host-setup-install.sh --dry-run
++./runtime/deploy/aws-ec2-compose/host-setup-install.sh
++```
++
++Canonical host prerequisites guidance:
++
++- https://github.com/finos/traderX/blob/main/docs/spec-kit/aws-ec2-compose-prerequisites.md
++
++## Public Repo Clone Default
++
++Generated-state branches in `finos/traderX` are public. Default deploy flow uses:
++
++```bash
++git clone https://github.com/finos/traderX.git
++```
++
++Use token-authenticated clone URLs only when deploying from private forks/overlays.
 diff --git a/runtime/deploy/aws-ec2-compose/cleanup.sh b/runtime/deploy/aws-ec2-compose/cleanup.sh
 new file mode 100755
 index 0000000..cc06eb7
@@ -9308,10 +13139,10 @@ index 0000000..cc06eb7
 +echo "[done] cleanup completed for state ${STATE_ID}"
 diff --git a/runtime/deploy/aws-ec2-compose/deploy.sh b/runtime/deploy/aws-ec2-compose/deploy.sh
 new file mode 100755
-index 0000000..b5c1bed
+index 0000000..2c5bf30
 --- /dev/null
 +++ b/runtime/deploy/aws-ec2-compose/deploy.sh
-@@ -0,0 +1,71 @@
+@@ -0,0 +1,105 @@
 +#!/usr/bin/env bash
 +set -euo pipefail
 +
@@ -9320,20 +13151,26 @@ index 0000000..b5c1bed
 +TRADERX_BRANCH="${TRADERX_BRANCH:-code/generated-state-004-containerized-compose-runtime}"
 +TRADERX_WORKDIR="${TRADERX_WORKDIR:-${HOME}/traderx}"
 +TRADERX_COMPOSE_PATH_REL="${TRADERX_COMPOSE_PATH_REL:-containerized-compose/docker-compose.yml}"
++TRADERX_GHCR_COMPOSE_PATH_REL="${TRADERX_GHCR_COMPOSE_PATH_REL:-runtime/ghcr/${STATE_ID}/docker-compose.ghcr.yml}"
 +TRADERX_COMPOSE_PROJECT_NAME="${TRADERX_COMPOSE_PROJECT_NAME:-traderx-${STATE_ID}}"
 +TRADERX_DEPLOY_ENV="${TRADERX_DEPLOY_ENV:-demo}"
 +TRADERX_FQDN="${TRADERX_FQDN:-demo.traderx.finos.org}"
 +TRADERX_IMAGE_TAG="${TRADERX_IMAGE_TAG:-latest}"
++TRADERX_CORS_ALLOWED_ORIGINS="${TRADERX_CORS_ALLOWED_ORIGINS:-https://${TRADERX_FQDN},http://${TRADERX_FQDN},http://localhost:8080}"
 +DRY_RUN=0
++USE_GHCR=0
 +
 +while (( "$#" )); do
 +  case "$1" in
 +    --dry-run)
 +      DRY_RUN=1
 +      ;;
++    --use-ghcr)
++      USE_GHCR=1
++      ;;
 +    *)
 +      echo "[fail] unknown argument: $1"
-+      echo "[hint] supported: --dry-run"
++      echo "[hint] supported: --dry-run --use-ghcr"
 +      exit 1
 +      ;;
 +  esac
@@ -9355,12 +13192,23 @@ index 0000000..b5c1bed
 +
 +run_compose_up() {
 +  local compose_file="$1"
-+  echo "[run] TRADERX_FQDN=${TRADERX_FQDN} TRADERX_IMAGE_TAG=${TRADERX_IMAGE_TAG} docker compose -f ${compose_file} --project-name ${TRADERX_COMPOSE_PROJECT_NAME} up -d --build"
++  echo "[run] TRADERX_FQDN=${TRADERX_FQDN} TRADERX_IMAGE_TAG=${TRADERX_IMAGE_TAG} TRADERX_CORS_ALLOWED_ORIGINS=${TRADERX_CORS_ALLOWED_ORIGINS} docker compose -f ${compose_file} --project-name ${TRADERX_COMPOSE_PROJECT_NAME} up -d --build"
 +  if (( DRY_RUN == 1 )); then
 +    return 0
 +  fi
-+  TRADERX_FQDN="${TRADERX_FQDN}" TRADERX_IMAGE_TAG="${TRADERX_IMAGE_TAG}" \
++  TRADERX_FQDN="${TRADERX_FQDN}" TRADERX_IMAGE_TAG="${TRADERX_IMAGE_TAG}" CORS_ALLOWED_ORIGINS="${TRADERX_CORS_ALLOWED_ORIGINS}" \
 +    docker compose -f "${compose_file}" --project-name "${TRADERX_COMPOSE_PROJECT_NAME}" up -d --build
++}
++
++run_compose_ghcr_up() {
++  local ghcr_compose_file="$1"
++  echo "[run] TRADERX_CORS_ALLOWED_ORIGINS=${TRADERX_CORS_ALLOWED_ORIGINS} docker compose -f ${ghcr_compose_file} --project-name ${TRADERX_COMPOSE_PROJECT_NAME} pull"
++  echo "[run] TRADERX_CORS_ALLOWED_ORIGINS=${TRADERX_CORS_ALLOWED_ORIGINS} docker compose -f ${ghcr_compose_file} --project-name ${TRADERX_COMPOSE_PROJECT_NAME} up -d"
++  if (( DRY_RUN == 1 )); then
++    return 0
++  fi
++  CORS_ALLOWED_ORIGINS="${TRADERX_CORS_ALLOWED_ORIGINS}" docker compose -f "${ghcr_compose_file}" --project-name "${TRADERX_COMPOSE_PROJECT_NAME}" pull
++  CORS_ALLOWED_ORIGINS="${TRADERX_CORS_ALLOWED_ORIGINS}" docker compose -f "${ghcr_compose_file}" --project-name "${TRADERX_COMPOSE_PROJECT_NAME}" up -d
 +}
 +
 +if [[ ! -d "${TRADERX_WORKDIR}/.git" ]]; then
@@ -9372,17 +13220,180 @@ index 0000000..b5c1bed
 +run_cmd git -C "${TRADERX_WORKDIR}" reset --hard "origin/${TRADERX_BRANCH}"
 +
 +compose_file="${TRADERX_WORKDIR}/${TRADERX_COMPOSE_PATH_REL}"
-+if [[ ! -f "${compose_file}" ]]; then
-+  if (( DRY_RUN == 1 )); then
-+    echo "[warn] compose file not found in dry-run mode: ${compose_file}"
-+  else
-+    echo "[fail] compose file not found: ${compose_file}"
-+    exit 1
++ghcr_compose_file="${TRADERX_WORKDIR}/${TRADERX_GHCR_COMPOSE_PATH_REL}"
++if (( USE_GHCR == 1 )); then
++  if [[ ! -f "${ghcr_compose_file}" ]]; then
++    if (( DRY_RUN == 1 )); then
++      echo "[warn] GHCR compose file not found in dry-run mode: ${ghcr_compose_file}"
++    else
++      echo "[fail] GHCR compose file not found: ${ghcr_compose_file}"
++      exit 1
++    fi
++  fi
++else
++  if [[ ! -f "${compose_file}" ]]; then
++    if (( DRY_RUN == 1 )); then
++      echo "[warn] compose file not found in dry-run mode: ${compose_file}"
++    else
++      echo "[fail] compose file not found: ${compose_file}"
++      exit 1
++    fi
 +  fi
 +fi
 +
-+run_compose_up "${compose_file}"
-+echo "[done] deploy completed for state ${STATE_ID} (${TRADERX_DEPLOY_ENV})"
++if (( USE_GHCR == 1 )); then
++  run_compose_ghcr_up "${ghcr_compose_file}"
++  echo "[done] deploy completed for state ${STATE_ID} (${TRADERX_DEPLOY_ENV}) using ghcr images"
++else
++  run_compose_up "${compose_file}"
++  echo "[done] deploy completed for state ${STATE_ID} (${TRADERX_DEPLOY_ENV}) using local builds"
++fi
+diff --git a/runtime/deploy/aws-ec2-compose/host-setup-check.sh b/runtime/deploy/aws-ec2-compose/host-setup-check.sh
+new file mode 100755
+index 0000000..c71df24
+--- /dev/null
++++ b/runtime/deploy/aws-ec2-compose/host-setup-check.sh
+@@ -0,0 +1,62 @@
++#!/usr/bin/env bash
++set -euo pipefail
++
++DRY_RUN=0
++while (( "$#" )); do
++  case "$1" in
++    --dry-run)
++      DRY_RUN=1
++      ;;
++    *)
++      echo "[fail] unknown argument: $1"
++      echo "[hint] supported: --dry-run"
++      exit 1
++      ;;
++  esac
++  shift
++done
++
++missing=0
++check_cmd() {
++  local cmd="$1"
++  if command -v "${cmd}" >/dev/null 2>&1; then
++    echo "[ok] ${cmd} is installed"
++  else
++    echo "[missing] ${cmd} is not installed"
++    missing=1
++  fi
++}
++
++echo "[info] validating EC2 host prerequisites for TraderX deploy bundle"
++check_cmd git
++check_cmd curl
++check_cmd jq
++check_cmd docker
++check_cmd nginx
++
++if command -v docker >/dev/null 2>&1; then
++  if docker compose version >/dev/null 2>&1; then
++    echo "[ok] docker compose plugin is available"
++  else
++    echo "[missing] docker compose plugin is not available"
++    missing=1
++  fi
++fi
++
++if command -v certbot >/dev/null 2>&1; then
++  echo "[ok] certbot is installed"
++else
++  echo "[warn] certbot is not installed (required for automated TLS issuance)"
++fi
++
++if (( DRY_RUN == 1 )); then
++  echo "[done] host setup check completed (dry-run mode)"
++  exit 0
++fi
++
++if (( missing == 1 )); then
++  echo "[fail] missing required host prerequisites; run host-setup-install.sh"
++  exit 1
++fi
++
++echo "[done] host setup check passed"
+diff --git a/runtime/deploy/aws-ec2-compose/host-setup-install.sh b/runtime/deploy/aws-ec2-compose/host-setup-install.sh
+new file mode 100755
+index 0000000..fa50ca7
+--- /dev/null
++++ b/runtime/deploy/aws-ec2-compose/host-setup-install.sh
+@@ -0,0 +1,72 @@
++#!/usr/bin/env bash
++set -euo pipefail
++
++DRY_RUN=0
++while (( "$#" )); do
++  case "$1" in
++    --dry-run)
++      DRY_RUN=1
++      ;;
++    *)
++      echo "[fail] unknown argument: $1"
++      echo "[hint] supported: --dry-run"
++      exit 1
++      ;;
++  esac
++  shift
++done
++
++if [[ "${EUID}" -eq 0 ]]; then
++  SUDO=""
++else
++  SUDO="sudo"
++fi
++
++run_cmd() {
++  echo "[run] $*"
++  if (( DRY_RUN == 1 )); then
++    return 0
++  fi
++  "$@"
++}
++
++install_with_apt() {
++  run_cmd ${SUDO} apt-get update
++  run_cmd ${SUDO} apt-get install -y git curl jq nginx docker.io docker-compose-plugin certbot python3-certbot-nginx
++}
++
++install_with_dnf() {
++  run_cmd ${SUDO} dnf install -y git curl jq nginx docker docker-compose-plugin certbot python3-certbot-nginx
++}
++
++install_with_yum() {
++  run_cmd ${SUDO} yum install -y git curl jq nginx docker certbot
++}
++
++echo "[info] installing EC2 host prerequisites for TraderX deploy bundle"
++
++if command -v apt-get >/dev/null 2>&1; then
++  install_with_apt
++elif command -v dnf >/dev/null 2>&1; then
++  install_with_dnf
++elif command -v yum >/dev/null 2>&1; then
++  install_with_yum
++else
++  echo "[fail] unsupported package manager (expected apt-get, dnf, or yum)"
++  exit 1
++fi
++
++if command -v systemctl >/dev/null 2>&1; then
++  run_cmd ${SUDO} systemctl enable docker || true
++  run_cmd ${SUDO} systemctl start docker || true
++  run_cmd ${SUDO} systemctl enable nginx || true
++  run_cmd ${SUDO} systemctl start nginx || true
++fi
++
++if (( DRY_RUN == 1 )); then
++  echo "[done] host setup install dry-run complete"
++  exit 0
++fi
++
++"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/host-setup-check.sh"
++echo "[done] host setup install complete"
 diff --git a/runtime/deploy/aws-ec2-compose/nginx.reverse-proxy.snippet.conf b/runtime/deploy/aws-ec2-compose/nginx.reverse-proxy.snippet.conf
 new file mode 100644
 index 0000000..8d624b8
@@ -9549,1694 +13560,30 @@ index 0000000..1a64d75
 +trade-processor=ghcr.io/finos/traderx-c0/trade-processor:latest
 +trade-service=ghcr.io/finos/traderx-c0/trade-service:latest
 +web-front-end-angular=ghcr.io/finos/traderx-c0/web-front-end-angular:latest
-diff --git a/scripts/README.runtime-harness.md b/scripts/README.runtime-harness.md
-deleted file mode 100644
-index ddced90..0000000
---- a/scripts/README.runtime-harness.md
-+++ /dev/null
-@@ -1,8 +0,0 @@
--# Generated Runtime Harness
--
--This directory is generated for state: 003-agentic-harness-foundation
--
--- Scripts in this folder are local-runtime wrappers for the generated codebase.
--- They are designed to run without invoking root pipeline generation.
--- Root repository scripts may delegate to these local scripts when present.
--- State-specific usage is documented in `../RUN_FROM_GENERATED.md`.
-diff --git a/scripts/lib/generated-state-detection.ps1 b/scripts/lib/generated-state-detection.ps1
-deleted file mode 100644
-index 0ca32de..0000000
---- a/scripts/lib/generated-state-detection.ps1
-+++ /dev/null
-@@ -1,107 +0,0 @@
--Set-StrictMode -Version Latest
--$ErrorActionPreference = 'Stop'
--
--function Get-StateOrderNumber {
--  param([Parameter(Mandatory = $true)][string]$StateId)
--
--  if ($StateId -match '^([0-9]{3})-') {
--    return [int]$Matches[1]
--  }
--
--  return $null
--}
--
--function Read-GeneratedStateId {
--  param([Parameter(Mandatory = $true)][string]$GeneratedRoot)
--
--  $metadataPath = Join-Path $GeneratedRoot 'code/target-generated/ci/state-metadata.json'
--  if (-not (Test-Path -LiteralPath $metadataPath)) {
--    return $null
--  }
--
--  try {
--    $metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json -ErrorAction Stop
--    if ($metadata.stateId) {
--      return [string]$metadata.stateId
--    }
--  }
--  catch {
--    # Fall back to regex extraction for malformed JSON.
--  }
--
--  $raw = Get-Content -LiteralPath $metadataPath -Raw
--  $m = [regex]::Match($raw, '"stateId"\s*:\s*"([^"]+)"')
--  if ($m.Success) {
--    return $m.Groups[1].Value
--  }
--
--  return $null
--}
--
--function Report-GeneratedState {
--  param(
--    [Parameter(Mandatory = $true)][string]$ExpectedState,
--    [Parameter(Mandatory = $true)][string]$GeneratedRoot
--  )
--
--  $metadataPath = Join-Path $GeneratedRoot 'code/target-generated/ci/state-metadata.json'
--  $currentState = Read-GeneratedStateId -GeneratedRoot $GeneratedRoot
--
--  if ([string]::IsNullOrWhiteSpace($currentState)) {
--    Write-Host "[warn] unable to detect current generated state (missing/invalid: $metadataPath)"
--    Write-Host "[hint] run: bash pipeline/generate-state.sh $ExpectedState"
--    return 2
--  }
--
--  Write-Host "[info] generated output state: $currentState"
--
--  if ($currentState -eq $ExpectedState) {
--    Write-Host "[info] generated output matches expected state: $ExpectedState"
--    return 0
--  }
--
--  Write-Host "[warn] expected generated state $ExpectedState, found $currentState"
--
--  $expectedNum = Get-StateOrderNumber -StateId $ExpectedState
--  $currentNum = Get-StateOrderNumber -StateId $currentState
--
--  if ($null -ne $expectedNum -and $null -ne $currentNum) {
--    if ($currentNum -lt $expectedNum) {
--      Write-Host '[hint] this is a forward transition (older -> newer). Regeneration is usually safe.'
--    }
--    elseif ($currentNum -gt $expectedNum) {
--      Write-Host '[hint] this is a backward transition (newer -> older). Clean rebuild/regeneration is recommended.'
--    }
--  }
--
--  Write-Host "[hint] regenerate now: bash pipeline/generate-state.sh $ExpectedState"
--  Write-Host '[hint] set TRADERX_REGENERATE_ON_STATE_MISMATCH=1 to auto-regenerate before startup'
--  return 3
--}
--
--function Ensure-GeneratedState {
--  param(
--    [Parameter(Mandatory = $true)][string]$ExpectedState,
--    [Parameter(Mandatory = $true)][string]$RepoRoot,
--    [Parameter(Mandatory = $true)][string]$GeneratedRoot
--  )
--
--  $status = Report-GeneratedState -ExpectedState $ExpectedState -GeneratedRoot $GeneratedRoot
--
--  if ($status -ne 0 -and [Environment]::GetEnvironmentVariable('TRADERX_REGENERATE_ON_STATE_MISMATCH') -eq '1' -and [Environment]::GetEnvironmentVariable('TRADERX_LOCAL_RUNTIME_SCRIPT') -ne '1') {
--    Write-Host "[action] regenerating expected state $ExpectedState"
--    $bashCommand = Get-Command bash -ErrorAction SilentlyContinue
--    if (-not $bashCommand) {
--      throw '[error] auto-regeneration requires bash on PATH; install bash or unset TRADERX_REGENERATE_ON_STATE_MISMATCH'
--    }
--    & $bashCommand.Source (Join-Path $RepoRoot 'pipeline/generate-state.sh') $ExpectedState
--    if ($LASTEXITCODE -ne 0) {
--      throw '[error] generation failed'
--    }
--    $status = Report-GeneratedState -ExpectedState $ExpectedState -GeneratedRoot $GeneratedRoot
--  }
--
--  if ($status -ne 0 -and [Environment]::GetEnvironmentVariable('TRADERX_STATE_MISMATCH_STRICT') -eq '1') {
--    throw '[error] generated state mismatch remains (TRADERX_STATE_MISMATCH_STRICT=1)'
--  }
--}
-diff --git a/scripts/lib/generated-state-detection.sh b/scripts/lib/generated-state-detection.sh
-deleted file mode 100755
-index 2ecba9e..0000000
---- a/scripts/lib/generated-state-detection.sh
-+++ /dev/null
-@@ -1,95 +0,0 @@
--#!/usr/bin/env bash
--
--traderx_state_order_number() {
--  local state_id="$1"
--  if [[ "${state_id}" =~ ^([0-9]{3})- ]]; then
--    printf '%d' "${BASH_REMATCH[1]}"
--    return 0
--  fi
--  return 1
--}
--
--traderx_read_generated_state_id() {
--  local generated_root="$1"
--  local metadata_path="${generated_root}/code/target-generated/ci/state-metadata.json"
--  local state_id=""
--
--  if [[ ! -f "${metadata_path}" ]]; then
--    return 1
--  fi
--
--  if command -v jq >/dev/null 2>&1; then
--    state_id="$(jq -r '.stateId // empty' "${metadata_path}" 2>/dev/null || true)"
--  fi
--
--  if [[ -z "${state_id}" ]]; then
--    state_id="$(grep -Eo '"stateId"[[:space:]]*:[[:space:]]*"[^"]+"' "${metadata_path}" | head -n 1 | sed -E 's/.*"([^"]+)".*/\1/' || true)"
--  fi
--
--  [[ -n "${state_id}" ]] || return 1
--  printf '%s' "${state_id}"
--}
--
--traderx_report_generated_state() {
--  local expected_state="$1"
--  local generated_root="$2"
--  local metadata_path="${generated_root}/code/target-generated/ci/state-metadata.json"
--  local current_state=""
--
--  current_state="$(traderx_read_generated_state_id "${generated_root}" || true)"
--
--  if [[ -z "${current_state}" ]]; then
--    echo "[warn] unable to detect current generated state (missing/invalid: ${metadata_path})"
--    echo "[hint] run: bash pipeline/generate-state.sh ${expected_state}"
--    return 2
--  fi
--
--  echo "[info] generated output state: ${current_state}"
--
--  if [[ "${current_state}" == "${expected_state}" ]]; then
--    echo "[info] generated output matches expected state: ${expected_state}"
--    return 0
--  fi
--
--  echo "[warn] expected generated state ${expected_state}, found ${current_state}"
--
--  local expected_num=""
--  local current_num=""
--  expected_num="$(traderx_state_order_number "${expected_state}" || true)"
--  current_num="$(traderx_state_order_number "${current_state}" || true)"
--
--  if [[ -n "${expected_num}" && -n "${current_num}" ]]; then
--    if (( current_num < expected_num )); then
--      echo "[hint] this is a forward transition (older -> newer). Regeneration is usually safe."
--    elif (( current_num > expected_num )); then
--      echo "[hint] this is a backward transition (newer -> older). Clean rebuild/regeneration is recommended."
--    fi
--  fi
--
--  echo "[hint] regenerate now: bash pipeline/generate-state.sh ${expected_state}"
--  echo "[hint] set TRADERX_REGENERATE_ON_STATE_MISMATCH=1 to auto-regenerate before startup"
--  return 3
--}
--
--traderx_ensure_generated_state() {
--  local expected_state="$1"
--  local repo_root="$2"
--  local generated_root="$3"
--  local status=0
--
--  traderx_report_generated_state "${expected_state}" "${generated_root}" || status=$?
--
--  if (( status != 0 )) && [[ "${TRADERX_REGENERATE_ON_STATE_MISMATCH:-0}" == "1" ]] && [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--    echo "[action] regenerating expected state ${expected_state}"
--    bash "${repo_root}/pipeline/generate-state.sh" "${expected_state}"
--    status=0
--    traderx_report_generated_state "${expected_state}" "${generated_root}" || status=$?
--  fi
--
--  if (( status != 0 )) && [[ "${TRADERX_STATE_MISMATCH_STRICT:-0}" == "1" ]]; then
--    echo "[error] generated state mismatch remains (TRADERX_STATE_MISMATCH_STRICT=1)"
--    return 1
--  fi
--
--  return 0
--}
-diff --git a/scripts/lib/resolve-socketio-client-path.sh b/scripts/lib/resolve-socketio-client-path.sh
-deleted file mode 100755
-index 229990a..0000000
---- a/scripts/lib/resolve-socketio-client-path.sh
-+++ /dev/null
-@@ -1,45 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--candidate_paths=(
--  "${GENERATED_ROOT}/code/target-generated/trade-feed/node_modules/socket.io-client"
--  "${GENERATED_ROOT}/code/components/trade-feed-specfirst/node_modules/socket.io-client"
--  "${REPO_ROOT}/node_modules/socket.io-client"
--)
--
--for candidate in "${candidate_paths[@]}"; do
--  if [[ -d "${candidate}" ]]; then
--    echo "${candidate}"
--    exit 0
--  fi
--done
--
--if ! command -v npm >/dev/null 2>&1; then
--  echo "[error] npm command not found and no socket.io-client module is available" >&2
--  exit 1
--fi
--
--cache_dir="${GENERATED_ROOT}/tool-cache/socketio-client"
--module_dir="${cache_dir}/node_modules/socket.io-client"
--
--if [[ ! -d "${module_dir}" ]]; then
--  mkdir -p "${cache_dir}"
--  if [[ ! -f "${cache_dir}/package.json" ]]; then
--    cat > "${cache_dir}/package.json" <<'EOF'
--{
--  "name": "traderx-smoke-tooling",
--  "private": true,
--  "dependencies": {
--    "socket.io-client": "^4.8.1"
--  }
--}
--EOF
--  fi
--  echo "[setup] installing socket.io-client smoke-test dependency in ${cache_dir}" >&2
--  npm --prefix "${cache_dir}" install --no-audit --prefer-offline >/dev/null
--fi
--
--echo "${module_dir}"
-diff --git a/scripts/lib/runtime-common.ps1 b/scripts/lib/runtime-common.ps1
-deleted file mode 100644
-index c8e6449..0000000
---- a/scripts/lib/runtime-common.ps1
-+++ /dev/null
-@@ -1,223 +0,0 @@
--Set-StrictMode -Version Latest
--$ErrorActionPreference = 'Stop'
--
--function Set-DefaultEnv {
--  param(
--    [Parameter(Mandatory = $true)][string]$Name,
--    [Parameter(Mandatory = $true)][string]$Value
--  )
--
--  if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($Name))) {
--    [Environment]::SetEnvironmentVariable($Name, $Value)
--  }
--}
--
--function Get-TraderxRepoRoot {
--  param([Parameter(Mandatory = $true)][string]$ScriptPath)
--  return (Resolve-Path (Join-Path (Split-Path -Parent $ScriptPath) '..')).Path
--}
--
--function Get-TraderxGeneratedRoot {
--  param([Parameter(Mandatory = $true)][string]$RepoRoot)
--  $generatedRoot = [Environment]::GetEnvironmentVariable('TRADERX_GENERATED_ROOT')
--  if ([string]::IsNullOrWhiteSpace($generatedRoot)) {
--    return (Join-Path $RepoRoot 'generated')
--  }
--  return $generatedRoot
--}
--
--function Use-GeneratedRuntimeScript {
--  param(
--    [Parameter(Mandatory = $true)][string]$ScriptPath,
--    [Parameter(Mandatory = $true)][string]$GeneratedRoot,
--    [Parameter(Mandatory = $true)][string]$RepoRoot,
--    [Parameter(Mandatory = $true)][string[]]$ScriptArgs,
--    [hashtable]$AdditionalEnv = @{}
--  )
--
--  if ([Environment]::GetEnvironmentVariable('TRADERX_LOCAL_RUNTIME_SCRIPT') -eq '1') {
--    return
--  }
--
--  $scriptName = Split-Path -Leaf $ScriptPath
--  $localScript = Join-Path $GeneratedRoot (Join-Path 'code/target-generated/scripts' $scriptName)
--  if (-not (Test-Path -LiteralPath $localScript)) {
--    return
--  }
--
--  $prior = @{}
--  $envVars = @{ 
--    TRADERX_LOCAL_RUNTIME_SCRIPT = '1'
--    TRADERX_GENERATED_ROOT = $GeneratedRoot
--    TRADERX_SOURCE_REPO_ROOT = $RepoRoot
--  }
--
--  foreach ($k in $AdditionalEnv.Keys) {
--    $envVars[$k] = [string]$AdditionalEnv[$k]
--  }
--
--  foreach ($k in $envVars.Keys) {
--    $prior[$k] = [Environment]::GetEnvironmentVariable($k)
--    [Environment]::SetEnvironmentVariable($k, $envVars[$k])
--  }
--
--  try {
--    & $localScript @ScriptArgs
--    exit $LASTEXITCODE
--  }
--  finally {
--    foreach ($k in $envVars.Keys) {
--      [Environment]::SetEnvironmentVariable($k, $prior[$k])
--    }
--  }
--}
--
--function Write-Utf8NoBomFile {
--  param(
--    [Parameter(Mandatory = $true)][string]$Path,
--    [Parameter(Mandatory = $true)][string]$Content
--  )
--
--  $dir = Split-Path -Parent $Path
--  if (-not [string]::IsNullOrWhiteSpace($dir)) {
--    New-Item -ItemType Directory -Path $dir -Force | Out-Null
--  }
--
--  $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
--  [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
--}
--
--function Test-PortOpen {
--  param([Parameter(Mandatory = $true)][int]$Port)
--
--  $tcp = [System.Net.Sockets.TcpClient]::new()
--  try {
--    $asyncResult = $tcp.BeginConnect('127.0.0.1', $Port, $null, $null)
--    if (-not $asyncResult.AsyncWaitHandle.WaitOne(200)) {
--      return $false
--    }
--    $tcp.EndConnect($asyncResult)
--    return $true
--  }
--  catch {
--    return $false
--  }
--  finally {
--    $tcp.Dispose()
--  }
--}
--
--function Wait-Port {
--  param(
--    [Parameter(Mandatory = $true)][string]$ProcessName,
--    [Parameter(Mandatory = $true)][int]$Port,
--    [int]$Attempts = 120,
--    [int]$SleepSeconds = 1
--  )
--
--  for ($i = 1; $i -le $Attempts; $i++) {
--    if (Test-PortOpen -Port $Port) {
--      Write-Host "[ready] $ProcessName on :$Port"
--      return $true
--    }
--    Start-Sleep -Seconds $SleepSeconds
--  }
--
--  Write-Host "[error] timeout waiting for $ProcessName on :$Port"
--  return $false
--}
--
--function Test-ProcessAlive {
--  param([Parameter(Mandatory = $true)][int]$Pid)
--
--  try {
--    $null = Get-Process -Id $Pid -ErrorAction Stop
--    return $true
--  }
--  catch {
--    return $false
--  }
--}
--
--function Get-PortListenerPids {
--  param([Parameter(Mandatory = $true)][int]$Port)
--
--  if ($IsWindows) {
--    try {
--      return @(Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction Stop | Select-Object -ExpandProperty OwningProcess -Unique)
--    }
--    catch {
--      return @()
--    }
--  }
--
--  if (Get-Command lsof -ErrorAction SilentlyContinue) {
--    $raw = & lsof -nP -tiTCP:$Port -sTCP:LISTEN 2>$null
--    if ($LASTEXITCODE -eq 0 -or -not [string]::IsNullOrWhiteSpace(($raw -join ''))) {
--      return @($raw | ForEach-Object { $_.ToString().Trim() } | Where-Object { $_ -match '^\d+$' } | ForEach-Object { [int]$_ } | Select-Object -Unique)
--    }
--  }
--
--  return @()
--}
--
--function Invoke-LoggedCommand {
--  param(
--    [Parameter(Mandatory = $true)][string]$WorkDir,
--    [Parameter(Mandatory = $true)][string]$Command,
--    [Parameter(Mandatory = $true)][string]$Label,
--    [switch]$DryRun
--  )
--
--  if ($DryRun) {
--    Write-Host "[dry-run] ${Label}: cd $WorkDir && $Command"
--    return
--  }
--
--  Push-Location $WorkDir
--  try {
--    & pwsh -NoProfile -Command $Command
--    if ($LASTEXITCODE -ne 0) {
--      throw "command failed ($LASTEXITCODE)"
--    }
--  }
--  finally {
--    Pop-Location
--  }
--}
--
--function Start-LoggedBackgroundCommand {
--  param(
--    [Parameter(Mandatory = $true)][string]$WorkDir,
--    [Parameter(Mandatory = $true)][string]$Command,
--    [Parameter(Mandatory = $true)][string]$LogFile,
--    [Parameter(Mandatory = $true)][string]$PidFile
--  )
--
--  $escapedWorkDir = $WorkDir.Replace("'", "''")
--  $launcher = "`$ErrorActionPreference='Stop'; Set-StrictMode -Version Latest; Set-Location -LiteralPath '$escapedWorkDir'; $Command"
--  $proc = Start-Process -FilePath (Get-Command pwsh).Source -ArgumentList @('-NoProfile', '-Command', $launcher) -RedirectStandardOutput $LogFile -RedirectStandardError $LogFile -PassThru
--  Write-Utf8NoBomFile -Path $PidFile -Content ("{0}`n" -f $proc.Id)
--}
--
--function Read-PidFile {
--  param([Parameter(Mandatory = $true)][string]$PidFile)
--
--  if (-not (Test-Path -LiteralPath $PidFile)) {
--    return $null
--  }
--
--  $raw = (Get-Content -LiteralPath $PidFile -Raw).Trim()
--  if ($raw -match '^\d+$') {
--    return [int]$raw
--  }
--  return $null
--}
--
--function Ensure-Command {
--  param([Parameter(Mandatory = $true)][string]$Command)
--
--  if (-not (Get-Command $Command -ErrorAction SilentlyContinue)) {
--    throw "[error] missing required command: $Command"
--  }
--}
-diff --git a/scripts/start-base-uncontainerized-generated.ps1 b/scripts/start-base-uncontainerized-generated.ps1
-deleted file mode 100644
-index 6470aa9..0000000
---- a/scripts/start-base-uncontainerized-generated.ps1
-+++ /dev/null
-@@ -1,435 +0,0 @@
--#!/usr/bin/env pwsh
--Set-StrictMode -Version Latest
--$ErrorActionPreference = 'Stop'
--
--$env:TRADERX_LOCAL_RUNTIME_SCRIPT = '1'
--$env:TRADERX_SKIP_GENERATE = '1'
--if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('TRADERX_GENERATED_ROOT'))) {
--  $env:TRADERX_GENERATED_ROOT = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
--}
--
--param(
--  [switch]$DryRun,
--  [switch]$BuildOnly
--)
--
--. "$PSScriptRoot/lib/runtime-common.ps1"
--. "$PSScriptRoot/lib/generated-state-detection.ps1"
--
--$repoRoot = Get-TraderxRepoRoot -ScriptPath $PSCommandPath
--$generatedRoot = Get-TraderxGeneratedRoot -RepoRoot $repoRoot
--Use-GeneratedRuntimeScript -ScriptPath $PSCommandPath -GeneratedRoot $generatedRoot -RepoRoot $repoRoot -ScriptArgs $args
--
--$target = Join-Path $generatedRoot 'code/target-generated'
--$expectedState = if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('TRADERX_EXPECTED_STATE_ID'))) { '001-baseline-uncontainerized-parity' } else { [Environment]::GetEnvironmentVariable('TRADERX_EXPECTED_STATE_ID') }
--$sourceRepoRoot = if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('TRADERX_SOURCE_REPO_ROOT'))) { $repoRoot } else { [Environment]::GetEnvironmentVariable('TRADERX_SOURCE_REPO_ROOT') }
--$specSource = Join-Path $sourceRepoRoot 'catalog/base-uncontainerized-processes.csv'
--$spec = Join-Path $target 'catalog/base-uncontainerized-processes.csv'
--
--$runRoot = [Environment]::GetEnvironmentVariable('TRADERX_RUN_DIR')
--if ([string]::IsNullOrWhiteSpace($runRoot)) {
--  if ($IsWindows) {
--    $username = if ([string]::IsNullOrWhiteSpace($env:USERNAME)) { 'unknown-user' } else { $env:USERNAME }
--    $runRoot = Join-Path $env:TEMP "$username/traderx"
--  }
--  else {
--    $userName = if ([string]::IsNullOrWhiteSpace($env:USER)) { 'unknown-user' } else { $env:USER }
--    $runRoot = "/var/tmp/$userName/traderx"
--  }
--}
--$runDir = Join-Path $runRoot 'base-uncontainerized'
--$toolCacheDir = Join-Path $runDir 'tool-cache'
--
--$referenceDataSpecfirst = Join-Path $generatedRoot 'code/components/reference-data-specfirst'
--$databaseSpecfirst = Join-Path $generatedRoot 'code/components/database-specfirst'
--$peopleServiceSpecfirst = Join-Path $generatedRoot 'code/components/people-service-specfirst'
--$accountServiceSpecfirst = Join-Path $generatedRoot 'code/components/account-service-specfirst'
--$positionServiceSpecfirst = Join-Path $generatedRoot 'code/components/position-service-specfirst'
--$tradeFeedSpecfirst = Join-Path $generatedRoot 'code/components/trade-feed-specfirst'
--$tradeProcessorSpecfirst = Join-Path $generatedRoot 'code/components/trade-processor-specfirst'
--$tradeServiceSpecfirst = Join-Path $generatedRoot 'code/components/trade-service-specfirst'
--$webFrontEndAngularSpecfirst = Join-Path $generatedRoot 'code/components/web-front-end-angular-specfirst'
--
--Ensure-GeneratedState -ExpectedState $expectedState -RepoRoot $repoRoot -GeneratedRoot $generatedRoot
--
--function Ensure-ComponentLayout {
--  param(
--    [Parameter(Mandatory = $true)][string]$SourceDir,
--    [Parameter(Mandatory = $true)][string]$TargetDir
--  )
--
--  if (Test-Path -LiteralPath $TargetDir) {
--    return
--  }
--
--  Copy-Item -LiteralPath $SourceDir -Destination $TargetDir -Recurse -Force
--}
--
--function Prepare-GeneratedBaseLayout {
--  $generatedPaths = @(
--    $referenceDataSpecfirst,
--    $databaseSpecfirst,
--    $peopleServiceSpecfirst,
--    $accountServiceSpecfirst,
--    $positionServiceSpecfirst,
--    $tradeFeedSpecfirst,
--    $tradeProcessorSpecfirst,
--    $tradeServiceSpecfirst,
--    $webFrontEndAngularSpecfirst
--  )
--
--  foreach ($p in $generatedPaths) {
--    if (-not (Test-Path -LiteralPath $p -PathType Container)) {
--      throw "[error] required generated component not found: $p`n[hint] run the root pipeline generation scripts first."
--    }
--  }
--
--  New-Item -ItemType Directory -Path $target -Force | Out-Null
--  New-Item -ItemType Directory -Path (Join-Path $target 'web-front-end') -Force | Out-Null
--  New-Item -ItemType Directory -Path (Join-Path $target 'catalog') -Force | Out-Null
--
--  if (-not (Test-Path -LiteralPath $specSource -PathType Leaf)) {
--    throw "[error] missing startup spec source: $specSource"
--  }
--  Copy-Item -LiteralPath $specSource -Destination $spec -Force
--
--  Ensure-ComponentLayout -SourceDir $referenceDataSpecfirst -TargetDir (Join-Path $target 'reference-data')
--  Ensure-ComponentLayout -SourceDir $databaseSpecfirst -TargetDir (Join-Path $target 'database')
--  Ensure-ComponentLayout -SourceDir $peopleServiceSpecfirst -TargetDir (Join-Path $target 'people-service')
--  Ensure-ComponentLayout -SourceDir $accountServiceSpecfirst -TargetDir (Join-Path $target 'account-service')
--  Ensure-ComponentLayout -SourceDir $positionServiceSpecfirst -TargetDir (Join-Path $target 'position-service')
--  Ensure-ComponentLayout -SourceDir $tradeFeedSpecfirst -TargetDir (Join-Path $target 'trade-feed')
--  Ensure-ComponentLayout -SourceDir $tradeProcessorSpecfirst -TargetDir (Join-Path $target 'trade-processor')
--  Ensure-ComponentLayout -SourceDir $tradeServiceSpecfirst -TargetDir (Join-Path $target 'trade-service')
--  Ensure-ComponentLayout -SourceDir $webFrontEndAngularSpecfirst -TargetDir (Join-Path $target 'web-front-end/angular')
--
--  Write-Host "[ok] generated base layout prepared in $target"
--}
--
--function Resolve-GradleWrapperCommand {
--  param([Parameter(Mandatory = $true)][string]$WorkDir)
--
--  if ($IsWindows) {
--    if (-not (Test-Path -LiteralPath (Join-Path $WorkDir 'gradlew.bat'))) {
--      throw "[error] missing Gradle wrapper batch script in $WorkDir"
--    }
--    return '.\\gradlew.bat'
--  }
--
--  if (-not (Test-Path -LiteralPath (Join-Path $WorkDir 'gradlew'))) {
--    throw "[error] missing Gradle wrapper script in $WorkDir"
--  }
--  return './gradlew'
--}
--
--function Get-JavaServiceJar {
--  param([Parameter(Mandatory = $true)][string]$WorkDir)
--
--  $jars = Get-ChildItem -LiteralPath (Join-Path $WorkDir 'build/libs') -Filter '*.jar' -File -ErrorAction SilentlyContinue |
--    Where-Object { $_.Name -notmatch 'plain' } |
--    Sort-Object Name
--
--  if (-not $jars -or $jars.Count -eq 0) {
--    return $null
--  }
--
--  return $jars[0].FullName
--}
--
--function Build-ArtifactExists {
--  param(
--    [Parameter(Mandatory = $true)][string]$ProcessName,
--    [Parameter(Mandatory = $true)][string]$WorkDir
--  )
--
--  switch ($ProcessName) {
--    'web-front-end-angular' {
--      return (Test-Path -LiteralPath (Join-Path $WorkDir 'node_modules') -PathType Container) -and
--        (Test-Path -LiteralPath (Join-Path $WorkDir 'dist') -PathType Container)
--    }
--    'reference-data' { return (Test-Path -LiteralPath (Join-Path $WorkDir 'node_modules') -PathType Container) }
--    'trade-feed' { return (Test-Path -LiteralPath (Join-Path $WorkDir 'node_modules') -PathType Container) }
--    'people-service' {
--      $candidate = Get-ChildItem -LiteralPath (Join-Path $WorkDir 'bin/Debug') -Filter 'PeopleService.WebApi.dll' -File -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
--      return $null -ne $candidate
--    }
--    'database' {
--      return Test-Path -LiteralPath (Join-Path $WorkDir 'build/libs/database-specfirst.jar') -PathType Leaf
--    }
--    'account-service' { return $null -ne (Get-JavaServiceJar -WorkDir $WorkDir) }
--    'position-service' { return $null -ne (Get-JavaServiceJar -WorkDir $WorkDir) }
--    'trade-processor' { return $null -ne (Get-JavaServiceJar -WorkDir $WorkDir) }
--    'trade-service' { return $null -ne (Get-JavaServiceJar -WorkDir $WorkDir) }
--    default { return $false }
--  }
--}
--
--function Invoke-Build {
--  param(
--    [Parameter(Mandatory = $true)][string]$ProcessName,
--    [Parameter(Mandatory = $true)][string]$WorkDir,
--    [switch]$DryRunMode
--  )
--
--  if (Build-ArtifactExists -ProcessName $ProcessName -WorkDir $WorkDir) {
--    Write-Host "[build-skip] $ProcessName`: already built"
--    return
--  }
--
--  switch ($ProcessName) {
--    'reference-data' {
--      Invoke-LoggedCommand -WorkDir $WorkDir -Command 'npm install' -Label "[build] $ProcessName" -DryRun:$DryRunMode
--      return
--    }
--    'trade-feed' {
--      Invoke-LoggedCommand -WorkDir $WorkDir -Command 'npm install' -Label "[build] $ProcessName" -DryRun:$DryRunMode
--      return
--    }
--    'web-front-end-angular' {
--      Invoke-LoggedCommand -WorkDir $WorkDir -Command 'npm install' -Label "[build] $ProcessName" -DryRun:$DryRunMode
--      Invoke-LoggedCommand -WorkDir $WorkDir -Command 'npm run build' -Label "[build] $ProcessName" -DryRun:$DryRunMode
--      return
--    }
--    'people-service' {
--      Invoke-LoggedCommand -WorkDir $WorkDir -Command 'dotnet build' -Label "[build] $ProcessName" -DryRun:$DryRunMode
--      return
--    }
--    'database' {
--      $gradleCmd = Resolve-GradleWrapperCommand -WorkDir $WorkDir
--      Invoke-LoggedCommand -WorkDir $WorkDir -Command "$gradleCmd build -x test" -Label "[build] $ProcessName" -DryRun:$DryRunMode
--      return
--    }
--    'account-service' {
--      $gradleCmd = Resolve-GradleWrapperCommand -WorkDir $WorkDir
--      Invoke-LoggedCommand -WorkDir $WorkDir -Command "$gradleCmd build -x test" -Label "[build] $ProcessName" -DryRun:$DryRunMode
--      return
--    }
--    'position-service' {
--      $gradleCmd = Resolve-GradleWrapperCommand -WorkDir $WorkDir
--      Invoke-LoggedCommand -WorkDir $WorkDir -Command "$gradleCmd build -x test" -Label "[build] $ProcessName" -DryRun:$DryRunMode
--      return
--    }
--    'trade-processor' {
--      $gradleCmd = Resolve-GradleWrapperCommand -WorkDir $WorkDir
--      Invoke-LoggedCommand -WorkDir $WorkDir -Command "$gradleCmd build -x test" -Label "[build] $ProcessName" -DryRun:$DryRunMode
--      return
--    }
--    'trade-service' {
--      $gradleCmd = Resolve-GradleWrapperCommand -WorkDir $WorkDir
--      Invoke-LoggedCommand -WorkDir $WorkDir -Command "$gradleCmd build -x test" -Label "[build] $ProcessName" -DryRun:$DryRunMode
--      return
--    }
--    default {
--      throw "[error] no build handler for process: $ProcessName"
--    }
--  }
--}
--
--function Resolve-StartCommand {
--  param(
--    [Parameter(Mandatory = $true)][string]$ProcessName,
--    [Parameter(Mandatory = $true)][string]$WorkDir
--  )
--
--  switch ($ProcessName) {
--    'database' {
--      if ($IsWindows) {
--        if (-not (Test-Path -LiteralPath (Join-Path $WorkDir 'run.ps1'))) {
--          throw "[error] missing database runner: $WorkDir/run.ps1"
--        }
--        return '& ./run.ps1'
--      }
--      return './run.sh'
--    }
--    'reference-data' { return 'npm run start' }
--    'trade-feed' { return 'npm run start' }
--    'people-service' { return '$env:ASPNETCORE_ENVIRONMENT=''Development''; dotnet ./bin/Debug/net9.0/PeopleService.WebApi.dll' }
--    'account-service' {
--      $jar = Get-JavaServiceJar -WorkDir $WorkDir
--      if (-not $jar) {
--        throw "[error] unable to resolve jar for $ProcessName"
--      }
--      return "java -jar '$jar'"
--    }
--    'position-service' {
--      $jar = Get-JavaServiceJar -WorkDir $WorkDir
--      if (-not $jar) {
--        throw "[error] unable to resolve jar for $ProcessName"
--      }
--      return "java -jar '$jar'"
--    }
--    'trade-processor' {
--      $jar = Get-JavaServiceJar -WorkDir $WorkDir
--      if (-not $jar) {
--        throw "[error] unable to resolve jar for $ProcessName"
--      }
--      return "java -jar '$jar'"
--    }
--    'trade-service' {
--      $jar = Get-JavaServiceJar -WorkDir $WorkDir
--      if (-not $jar) {
--        throw "[error] unable to resolve jar for $ProcessName"
--      }
--      return "java -jar '$jar'"
--    }
--    'web-front-end-angular' { return 'node serve-angular-dist.js' }
--    default { throw "[error] no start handler for process: $ProcessName" }
--  }
--}
--
--function Preflight-Checks {
--  Ensure-Command -Command dotnet
--
--  & dotnet --version *> $null
--  if ($LASTEXITCODE -ne 0) {
--    throw '[error] dotnet runtime is installed but not runnable on this machine.'
--  }
--
--  $dotnetRuntimes = (& dotnet --list-runtimes 2>$null) -join "`n"
--  if ($dotnetRuntimes -notmatch '^Microsoft\.NETCore\.App 9\.' -and $dotnetRuntimes -notmatch "`nMicrosoft\.NETCore\.App 9\.") {
--    throw '[error] missing required runtime: Microsoft.NETCore.App 9.x (arm64) for people-service (net9.0).'
--  }
--  if ($dotnetRuntimes -notmatch '^Microsoft\.AspNetCore\.App 9\.' -and $dotnetRuntimes -notmatch "`nMicrosoft\.AspNetCore\.App 9\.") {
--    throw '[error] missing required runtime: Microsoft.AspNetCore.App 9.x (arm64) for people-service (net9.0).'
--  }
--
--  if ([Environment]::GetEnvironmentVariable('TRADERSPEC_SKIP_NETWORK_CHECK') -eq '1') {
--    return
--  }
--
--  $gradleDistUrl = if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('GRADLE_WRAPPER_CHECK_URL'))) { 'https://services.gradle.org/distributions/' } else { [Environment]::GetEnvironmentVariable('GRADLE_WRAPPER_CHECK_URL') }
--  $mavenRepoUrl = if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('MAVEN_CENTRAL_CHECK_URL'))) { 'https://repo.maven.apache.org/maven2/' } else { [Environment]::GetEnvironmentVariable('MAVEN_CENTRAL_CHECK_URL') }
--
--  foreach ($url in @($gradleDistUrl, $mavenRepoUrl)) {
--    try {
--      Invoke-WebRequest -Uri $url -Method Head -TimeoutSec 10 | Out-Null
--    }
--    catch {
--      throw "[error] gradle network preflight failed for $url"
--    }
--  }
--}
--
--Prepare-GeneratedBaseLayout
--
--New-Item -ItemType Directory -Path (Join-Path $runDir 'logs') -Force | Out-Null
--New-Item -ItemType Directory -Path (Join-Path $runDir 'pids') -Force | Out-Null
--New-Item -ItemType Directory -Path (Join-Path $toolCacheDir 'gradle') -Force | Out-Null
--New-Item -ItemType Directory -Path (Join-Path $toolCacheDir 'npm') -Force | Out-Null
--New-Item -ItemType Directory -Path (Join-Path $toolCacheDir 'dotnet-home') -Force | Out-Null
--New-Item -ItemType Directory -Path (Join-Path $toolCacheDir 'nuget') -Force | Out-Null
--
--Set-DefaultEnv -Name 'GRADLE_USER_HOME' -Value (Join-Path $toolCacheDir 'gradle')
--Set-DefaultEnv -Name 'npm_config_cache' -Value (Join-Path $toolCacheDir 'npm')
--Set-DefaultEnv -Name 'DOTNET_CLI_HOME' -Value (Join-Path $toolCacheDir 'dotnet-home')
--Set-DefaultEnv -Name 'NUGET_PACKAGES' -Value (Join-Path $toolCacheDir 'nuget')
--
--Set-DefaultEnv -Name 'DATABASE_TCP_PORT' -Value '18082'
--Set-DefaultEnv -Name 'DATABASE_PG_PORT' -Value '18083'
--Set-DefaultEnv -Name 'DATABASE_WEB_PORT' -Value '18084'
--Set-DefaultEnv -Name 'REFERENCE_DATA_SERVICE_PORT' -Value '18085'
--Set-DefaultEnv -Name 'TRADE_FEED_PORT' -Value '18086'
--Set-DefaultEnv -Name 'ACCOUNT_SERVICE_PORT' -Value '18088'
--Set-DefaultEnv -Name 'PEOPLE_SERVICE_PORT' -Value '18089'
--Set-DefaultEnv -Name 'POSITION_SERVICE_PORT' -Value '18090'
--Set-DefaultEnv -Name 'TRADE_PROCESSOR_SERVICE_PORT' -Value '18091'
--Set-DefaultEnv -Name 'TRADING_SERVICE_PORT' -Value '18092'
--Set-DefaultEnv -Name 'WEB_SERVICE_ANGULAR_PORT' -Value '18093'
--
--Set-DefaultEnv -Name 'DATABASE_TCP_HOST' -Value 'localhost'
--Set-DefaultEnv -Name 'PEOPLE_SERVICE_HOST' -Value 'localhost'
--Set-DefaultEnv -Name 'ACCOUNT_SERVICE_HOST' -Value 'localhost'
--Set-DefaultEnv -Name 'REFERENCE_DATA_HOST' -Value 'localhost'
--Set-DefaultEnv -Name 'TRADE_FEED_HOST' -Value 'localhost'
--
--$processes = @(
--  @{ Order = 1; Name = 'database'; Workdir = 'database'; Port = 18082 },
--  @{ Order = 2; Name = 'reference-data'; Workdir = 'reference-data'; Port = 18085 },
--  @{ Order = 3; Name = 'trade-feed'; Workdir = 'trade-feed'; Port = 18086 },
--  @{ Order = 4; Name = 'people-service'; Workdir = 'people-service/PeopleService.WebApi'; Port = 18089 },
--  @{ Order = 5; Name = 'account-service'; Workdir = 'account-service'; Port = 18088 },
--  @{ Order = 6; Name = 'position-service'; Workdir = 'position-service'; Port = 18090 },
--  @{ Order = 7; Name = 'trade-processor'; Workdir = 'trade-processor'; Port = 18091 },
--  @{ Order = 8; Name = 'trade-service'; Workdir = 'trade-service'; Port = 18092 },
--  @{ Order = 9; Name = 'web-front-end-angular'; Workdir = 'web-front-end/angular'; Port = 18093 }
--)
--
--if (-not (Test-Path -LiteralPath $spec -PathType Leaf)) {
--  throw "[error] missing startup spec: $spec"
--}
--
--if (-not $DryRun) {
--  Preflight-Checks
--}
--
--if ($BuildOnly) {
--  Write-Host '[build] building base uncontainerized services (--build-only)'
--  foreach ($proc in $processes | Sort-Object Order) {
--    $workdir = Join-Path $target $proc.Workdir
--    if (-not (Test-Path -LiteralPath $workdir -PathType Container)) {
--      throw "[error] missing workdir for $($proc.Name): $workdir"
--    }
--    Invoke-Build -ProcessName $proc.Name -WorkDir $workdir -DryRunMode:$DryRun
--  }
--
--  if ($DryRun) {
--    Write-Host '[done] dry run complete'
--  }
--  else {
--    Write-Host '[done] build phase complete'
--    Write-Host '[hint] run the same script without -BuildOnly to start services'
--  }
--  exit 0
--}
--
--foreach ($proc in $processes | Sort-Object Order) {
--  $workdir = Join-Path $target $proc.Workdir
--  if (-not (Build-ArtifactExists -ProcessName $proc.Name -WorkDir $workdir)) {
--    Write-Host "[error] $($proc.Name): missing build artifacts required by start command."
--    Write-Host '[hint] run ./scripts/start-base-uncontainerized-generated.ps1 -BuildOnly'
--    exit 1
--  }
--
--  $pidFile = Join-Path (Join-Path $runDir 'pids') "$($proc.Name).pid"
--  $logFile = Join-Path (Join-Path $runDir 'logs') "$($proc.Name).log"
--
--  $oldPid = Read-PidFile -PidFile $pidFile
--  if ($null -ne $oldPid -and (Test-ProcessAlive -Pid $oldPid)) {
--    Write-Host "[skip] $($proc.Name) already running (pid $oldPid)"
--    continue
--  }
--
--  if (Test-PortOpen -Port $proc.Port) {
--    Write-Host "[error] port :$($proc.Port) already in use before starting $($proc.Name)"
--    $pids = @(Get-PortListenerPids -Port $proc.Port)
--    if ($pids.Count -gt 0) {
--      Write-Host "[hint] listener pid(s): $($pids -join ', ')"
--    }
--    Write-Host '[hint] run stop script, then retry:'
--    Write-Host '       ./scripts/stop-base-uncontainerized-generated.ps1'
--    exit 1
--  }
--
--  $startCommand = Resolve-StartCommand -ProcessName $proc.Name -WorkDir $workdir
--
--  if ($DryRun) {
--    Write-Host "[dry-run] $($proc.Name): cd $workdir && $startCommand"
--    continue
--  }
--
--  Write-Host "[start] $($proc.Name)"
--  Start-LoggedBackgroundCommand -WorkDir $workdir -Command $startCommand -LogFile $logFile -PidFile $pidFile
--
--  if (-not (Wait-Port -ProcessName $proc.Name -Port $proc.Port)) {
--    Write-Host "[hint] check logs: $logFile"
--    exit 1
--  }
--}
--
--if ($DryRun) {
--  Write-Host '[done] dry run complete'
--}
--else {
--  Write-Host '[done] base uncontainerized generated stack started'
--  Write-Host "[ui] http://localhost:$($env:WEB_SERVICE_ANGULAR_PORT)"
--}
-diff --git a/scripts/start-base-uncontainerized-generated.sh b/scripts/start-base-uncontainerized-generated.sh
-deleted file mode 100755
-index 6f33e1b..0000000
---- a/scripts/start-base-uncontainerized-generated.sh
-+++ /dev/null
-@@ -1,425 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    TRADERX_LOCAL_RUNTIME_SCRIPT=1 \
--    TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
--    TRADERX_SOURCE_REPO_ROOT="${REPO_ROOT}" \
--      exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--TARGET="${GENERATED_ROOT}/code/target-generated"
--EXPECTED_STATE="${TRADERX_EXPECTED_STATE_ID:-001-baseline-uncontainerized-parity}"
--SOURCE_REPO_ROOT="${TRADERX_SOURCE_REPO_ROOT:-${REPO_ROOT}}"
--SPEC_SOURCE="${SOURCE_REPO_ROOT}/catalog/base-uncontainerized-processes.csv"
--SPEC="${TARGET}/catalog/base-uncontainerized-processes.csv"
--RUN_ROOT="${TRADERX_RUN_DIR:-/var/tmp/${USER:-unknown-user}/traderx}"
--RUN_DIR="${RUN_ROOT}/base-uncontainerized"
--TOOL_CACHE_DIR="${RUN_DIR}/tool-cache"
--REFERENCE_DATA_SPECFIRST="${GENERATED_ROOT}/code/components/reference-data-specfirst"
--DATABASE_SPECFIRST="${GENERATED_ROOT}/code/components/database-specfirst"
--PEOPLE_SERVICE_SPECFIRST="${GENERATED_ROOT}/code/components/people-service-specfirst"
--ACCOUNT_SERVICE_SPECFIRST="${GENERATED_ROOT}/code/components/account-service-specfirst"
--POSITION_SERVICE_SPECFIRST="${GENERATED_ROOT}/code/components/position-service-specfirst"
--TRADE_FEED_SPECFIRST="${GENERATED_ROOT}/code/components/trade-feed-specfirst"
--TRADE_PROCESSOR_SPECFIRST="${GENERATED_ROOT}/code/components/trade-processor-specfirst"
--TRADE_SERVICE_SPECFIRST="${GENERATED_ROOT}/code/components/trade-service-specfirst"
--WEB_FRONT_END_ANGULAR_SPECFIRST="${GENERATED_ROOT}/code/components/web-front-end-angular-specfirst"
--
--DRY_RUN=0
--BUILD_ONLY=0
--while (( "$#" )); do
--  case "$1" in
--    --dry-run)
--      DRY_RUN=1
--      ;;
--    --build-only)
--      BUILD_ONLY=1
--      ;;
--    *)
--      echo "[error] unknown argument: $1"
--      echo "[hint] supported: --dry-run --build-only"
--      exit 1
--      ;;
--  esac
--  shift
--done
--
--source "${REPO_ROOT}/scripts/lib/generated-state-detection.sh"
--traderx_ensure_generated_state "${EXPECTED_STATE}" "${REPO_ROOT}" "${GENERATED_ROOT}"
--
--ensure_component_layout() {
--  local source_dir="$1"
--  local target_dir="$2"
--
--  if [[ -d "${target_dir}" ]]; then
--    return 0
--  fi
--
--  cp -R "${source_dir}" "${target_dir}"
--}
--
--prepare_generated_base_layout() {
--  local generated_paths=(
--    "${REFERENCE_DATA_SPECFIRST}"
--    "${DATABASE_SPECFIRST}"
--    "${PEOPLE_SERVICE_SPECFIRST}"
--    "${ACCOUNT_SERVICE_SPECFIRST}"
--    "${POSITION_SERVICE_SPECFIRST}"
--    "${TRADE_FEED_SPECFIRST}"
--    "${TRADE_PROCESSOR_SPECFIRST}"
--    "${TRADE_SERVICE_SPECFIRST}"
--    "${WEB_FRONT_END_ANGULAR_SPECFIRST}"
--  )
--
--  local p
--  for p in "${generated_paths[@]}"; do
--    if [[ ! -d "${p}" ]]; then
--      echo "[error] required generated component not found: ${p}"
--      echo "[hint] run the root pipeline generation scripts first."
--      exit 1
--    fi
--  done
--
--  mkdir -p "${TARGET}" "${TARGET}/web-front-end" "${TARGET}/catalog"
--
--  if [[ ! -f "${SPEC_SOURCE}" ]]; then
--    echo "[error] missing startup spec source: ${SPEC_SOURCE}"
--    exit 1
--  fi
--  cp "${SPEC_SOURCE}" "${SPEC}"
--
--  ensure_component_layout "${REFERENCE_DATA_SPECFIRST}" "${TARGET}/reference-data"
--  ensure_component_layout "${DATABASE_SPECFIRST}" "${TARGET}/database"
--  ensure_component_layout "${PEOPLE_SERVICE_SPECFIRST}" "${TARGET}/people-service"
--  ensure_component_layout "${ACCOUNT_SERVICE_SPECFIRST}" "${TARGET}/account-service"
--  ensure_component_layout "${POSITION_SERVICE_SPECFIRST}" "${TARGET}/position-service"
--  ensure_component_layout "${TRADE_FEED_SPECFIRST}" "${TARGET}/trade-feed"
--  ensure_component_layout "${TRADE_PROCESSOR_SPECFIRST}" "${TARGET}/trade-processor"
--  ensure_component_layout "${TRADE_SERVICE_SPECFIRST}" "${TARGET}/trade-service"
--  ensure_component_layout "${WEB_FRONT_END_ANGULAR_SPECFIRST}" "${TARGET}/web-front-end/angular"
--
--  echo "[ok] generated base layout prepared in ${TARGET}"
--}
--
--prepare_generated_base_layout
--
--mkdir -p \
--  "${RUN_DIR}/logs" \
--  "${RUN_DIR}/pids" \
--  "${TOOL_CACHE_DIR}/gradle" \
--  "${TOOL_CACHE_DIR}/npm" \
--  "${TOOL_CACHE_DIR}/dotnet-home" \
--  "${TOOL_CACHE_DIR}/nuget"
--
--# Keep tool caches inside generated runtime state so startup works in restricted environments.
--export GRADLE_USER_HOME="${GRADLE_USER_HOME:-${TOOL_CACHE_DIR}/gradle}"
--export npm_config_cache="${npm_config_cache:-${TOOL_CACHE_DIR}/npm}"
--export DOTNET_CLI_HOME="${DOTNET_CLI_HOME:-${TOOL_CACHE_DIR}/dotnet-home}"
--export NUGET_PACKAGES="${NUGET_PACKAGES:-${TOOL_CACHE_DIR}/nuget}"
--
--export DATABASE_TCP_PORT="${DATABASE_TCP_PORT:-18082}"
--export DATABASE_PG_PORT="${DATABASE_PG_PORT:-18083}"
--export DATABASE_WEB_PORT="${DATABASE_WEB_PORT:-18084}"
--export REFERENCE_DATA_SERVICE_PORT="${REFERENCE_DATA_SERVICE_PORT:-18085}"
--export TRADE_FEED_PORT="${TRADE_FEED_PORT:-18086}"
--export ACCOUNT_SERVICE_PORT="${ACCOUNT_SERVICE_PORT:-18088}"
--export PEOPLE_SERVICE_PORT="${PEOPLE_SERVICE_PORT:-18089}"
--export POSITION_SERVICE_PORT="${POSITION_SERVICE_PORT:-18090}"
--export TRADE_PROCESSOR_SERVICE_PORT="${TRADE_PROCESSOR_SERVICE_PORT:-18091}"
--export TRADING_SERVICE_PORT="${TRADING_SERVICE_PORT:-18092}"
--export WEB_SERVICE_ANGULAR_PORT="${WEB_SERVICE_ANGULAR_PORT:-18093}"
--
--export DATABASE_TCP_HOST=localhost
--export PEOPLE_SERVICE_HOST=localhost
--export ACCOUNT_SERVICE_HOST=localhost
--export REFERENCE_DATA_HOST=localhost
--export TRADE_FEED_HOST=localhost
--
--preflight_checks() {
--  if ! command -v nc >/dev/null 2>&1; then
--    echo "[error] missing required command: nc"
--    exit 1
--  fi
--
--  if ! command -v dotnet >/dev/null 2>&1; then
--    echo "[error] missing required runtime: dotnet (needed for people-service)"
--    exit 1
--  fi
--
--  if ! dotnet --version >/dev/null 2>&1; then
--    echo "[error] dotnet runtime is installed but not runnable on this machine."
--    echo "[hint] install a native arm64 dotnet runtime or enable Rosetta/x64 compatibility."
--    exit 1
--  fi
--
--  local dotnet_runtimes
--  dotnet_runtimes="$(dotnet --list-runtimes 2>/dev/null || true)"
--
--  if ! printf '%s\n' "${dotnet_runtimes}" | grep -Eq '^Microsoft\.NETCore\.App 9\.'; then
--    echo "[error] missing required runtime: Microsoft.NETCore.App 9.x (arm64) for people-service (net9.0)."
--    exit 1
--  fi
--
--  if ! printf '%s\n' "${dotnet_runtimes}" | grep -Eq '^Microsoft\.AspNetCore\.App 9\.'; then
--    echo "[error] missing required runtime: Microsoft.AspNetCore.App 9.x (arm64) for people-service (net9.0)."
--    echo "[hint] install ASP.NET Core Runtime 9 for arm64 and retry."
--    exit 1
--  fi
--
--  if [[ "${TRADERSPEC_SKIP_NETWORK_CHECK:-0}" != "1" ]]; then
--    if ! command -v curl >/dev/null 2>&1; then
--      echo "[error] missing required command: curl (needed for gradle network preflight)"
--      exit 1
--    fi
--
--    local gradle_dist_url="${GRADLE_WRAPPER_CHECK_URL:-https://services.gradle.org/distributions/}"
--    local maven_repo_url="${MAVEN_CENTRAL_CHECK_URL:-https://repo.maven.apache.org/maven2/}"
--
--    if ! curl -fsSLI --max-time 10 "${gradle_dist_url}" >/dev/null 2>&1; then
--      echo "[error] gradle network preflight failed for ${gradle_dist_url}"
--      echo "[hint] verify outbound HTTPS access (or proxy) for Gradle distribution downloads."
--      echo "[hint] set TRADERSPEC_SKIP_NETWORK_CHECK=1 only if dependencies are already cached."
--      exit 1
--    fi
--
--    if ! curl -fsSLI --max-time 10 "${maven_repo_url}" >/dev/null 2>&1; then
--      echo "[error] gradle network preflight failed for ${maven_repo_url}"
--      echo "[hint] verify outbound HTTPS access (or proxy) for Maven Central dependency resolution."
--      echo "[hint] set TRADERSPEC_SKIP_NETWORK_CHECK=1 only if dependencies are already cached."
--      exit 1
--    fi
--  fi
--}
--
--wait_for_port() {
--  local process="$1"
--  local port="$2"
--  local attempts=120
--  local sleep_seconds=1
--  local i
--
--  for ((i=1; i<=attempts; i++)); do
--    if nc -z localhost "${port}" >/dev/null 2>&1; then
--      echo "[ready] ${process} on :${port}"
--      return 0
--    fi
--    sleep "${sleep_seconds}"
--  done
--
--  echo "[error] timeout waiting for ${process} on :${port}"
--  return 1
--}
--
--port_listener_pids() {
--  local port="$1"
--  if ! command -v lsof >/dev/null 2>&1; then
--    return 0
--  fi
--  lsof -nP -tiTCP:"${port}" -sTCP:LISTEN 2>/dev/null || true
--}
--
--build_artifact_exists() {
--  local process="$1"
--  local workdir_rel="$2"
--  local build_cmd="$3"
--  local workdir="${TARGET}/${workdir_rel}"
--
--  if [[ -z "${build_cmd}" ]]; then
--    return 0
--  fi
--
--  if [[ "${process}" == "web-front-end-angular" ]]; then
--    [[ -d "${workdir}/node_modules" && -d "${workdir}/dist" ]]
--    return $?
--  fi
--
--  if echo "${build_cmd}" | grep -q 'ng build'; then
--    [[ -d "${workdir}/dist" ]]
--    return $?
--  fi
--
--  if echo "${build_cmd}" | grep -q '\[ -d dist \]'; then
--    [[ -d "${workdir}/dist" ]]
--    return $?
--  fi
--
--  if echo "${build_cmd}" | grep -q 'node_modules'; then
--    [[ -d "${workdir}/node_modules" ]]
--    return $?
--  fi
--
--  if echo "${build_cmd}" | grep -q 'dotnet build'; then
--    compgen -G "${workdir}/bin/Debug/net*/PeopleService.WebApi.dll" >/dev/null
--    return $?
--  fi
--
--  if echo "${build_cmd}" | grep -q 'gradlew'; then
--    if [[ "${process}" == "database" ]]; then
--      [[ -f "${workdir}/build/libs/database-specfirst.jar" ]]
--      return $?
--    fi
--
--    local jar
--    jar="$(ls "${workdir}"/build/libs/*.jar 2>/dev/null | grep -v plain | head -1 || true)"
--    [[ -n "${jar}" ]]
--    return $?
--  fi
--
--  return 1
--}
--
--run_build_process() {
--  local process="$1"
--  local workdir_rel="$2"
--  local build_cmd="$3"
--  local workdir="${TARGET}/${workdir_rel}"
--
--  if [[ -z "${build_cmd}" ]]; then
--    return 0
--  fi
--
--  if [[ ! -d "${workdir}" ]]; then
--    echo "[error] missing workdir for ${process}: ${workdir}"
--    exit 1
--  fi
--
--  if build_artifact_exists "${process}" "${workdir_rel}" "${build_cmd}"; then
--    echo "[build-skip] ${process}: already built"
--    return 0
--  fi
--
--  if ((DRY_RUN == 1)); then
--    echo "[dry-run] [build] ${process}: cd ${workdir} && ${build_cmd}"
--    return 0
--  fi
--
--  echo "[build] ${process}: ${build_cmd}"
--  (cd "${workdir}" && eval "${build_cmd}") || {
--    echo "[error] build failed for ${process}"
--    exit 1
--  }
--}
--
--build_check_or_exit() {
--  local process="$1"
--  local workdir_rel="$2"
--  local build_cmd="$3"
--
--  if [[ -z "${build_cmd}" ]]; then
--    return 0
--  fi
--
--  if build_artifact_exists "${process}" "${workdir_rel}" "${build_cmd}"; then
--    return 0
--  fi
--
--  echo "[error] ${process}: missing build artifacts required by start command."
--  echo "[hint] run ./scripts/start-base-uncontainerized-generated.sh --build-only"
--  exit 1
--}
--
--start_process() {
--  local process="$1"
--  local workdir_rel="$2"
--  local cmd="$3"
--  local port="$4"
--
--  local workdir="${TARGET}/${workdir_rel}"
--  local pidfile="${RUN_DIR}/pids/${process}.pid"
--  local logfile="${RUN_DIR}/logs/${process}.log"
--
--  if [[ ! -d "${workdir}" ]]; then
--    echo "[error] missing workdir for ${process}: ${workdir}"
--    exit 1
--  fi
--
--  if [[ -f "${pidfile}" ]]; then
--    local oldpid
--    oldpid="$(cat "${pidfile}")"
--    if kill -0 "${oldpid}" >/dev/null 2>&1; then
--      echo "[skip] ${process} already running (pid ${oldpid})"
--      return 0
--    fi
--  fi
--
--  if ((DRY_RUN == 1)); then
--    echo "[dry-run] ${process}: cd ${workdir} && ${cmd}"
--    return 0
--  fi
--
--  if nc -z localhost "${port}" >/dev/null 2>&1; then
--    echo "[error] port :${port} already in use before starting ${process}"
--    local pids
--    pids="$(port_listener_pids "${port}")"
--    if [[ -n "${pids}" ]]; then
--      echo "[hint] listener pid(s): ${pids}"
--    fi
--    echo "[hint] run stop script, then retry:"
--    echo "       ./scripts/stop-base-uncontainerized-generated.sh"
--    exit 1
--  fi
--
--  echo "[start] ${process}"
--  nohup /bin/zsh -lc "cd '${workdir}' && ${cmd}" >"${logfile}" 2>&1 &
--  echo "$!" > "${pidfile}"
--
--  wait_for_port "${process}" "${port}" || {
--    echo "[hint] check logs: ${logfile}"
--    exit 1
--  }
--}
--
--if [[ ! -f "${SPEC}" ]]; then
--  echo "[error] missing startup spec: ${SPEC}"
--  exit 1
--fi
--
--if ((DRY_RUN == 0)); then
--  preflight_checks
--fi
--
--if ((BUILD_ONLY == 1)); then
--  echo "[build] building base uncontainerized services (--build-only)"
--  while IFS=, read -r order process workdir start_cmd port health_hint build_cmd; do
--    if [[ "${order}" == "order" ]]; then
--      continue
--    fi
--    run_build_process "${process}" "${workdir}" "${build_cmd}"
--  done < <(tail -n +2 "${SPEC}" | sort -t, -k1,1n)
--
--  if ((DRY_RUN == 1)); then
--    echo "[done] dry run complete"
--  else
--    echo "[done] build phase complete"
--    echo "[hint] run the same script without --build-only to start services"
--  fi
--  exit 0
--fi
--
--while IFS=, read -r order process workdir start_cmd port health_hint build_cmd; do
--  if [[ "${order}" == "order" ]]; then
--    continue
--  fi
--  build_check_or_exit "${process}" "${workdir}" "${build_cmd}"
--  start_process "${process}" "${workdir}" "${start_cmd}" "${port}"
--done < <(tail -n +2 "${SPEC}" | sort -t, -k1,1n)
--
--if ((DRY_RUN == 1)); then
--  echo "[done] dry run complete"
--else
--  echo "[done] base uncontainerized generated stack started"
--  echo "[ui] http://localhost:${WEB_SERVICE_ANGULAR_PORT}"
--fi
-diff --git a/scripts/start-state-003-agentic-harness-foundation-generated.ps1 b/scripts/start-state-003-agentic-harness-foundation-generated.ps1
-deleted file mode 100644
-index a012fe4..0000000
---- a/scripts/start-state-003-agentic-harness-foundation-generated.ps1
-+++ /dev/null
-@@ -1,135 +0,0 @@
--#!/usr/bin/env pwsh
--Set-StrictMode -Version Latest
--$ErrorActionPreference = 'Stop'
--
--$env:TRADERX_LOCAL_RUNTIME_SCRIPT = '1'
--$env:TRADERX_SKIP_GENERATE = '1'
--if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('TRADERX_GENERATED_ROOT'))) {
--  $env:TRADERX_GENERATED_ROOT = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
--}
--
--param(
--  [switch]$DryRun,
--  [switch]$BuildOnly
--)
--
--. "$PSScriptRoot/lib/runtime-common.ps1"
--
--$repoRoot = Get-TraderxRepoRoot -ScriptPath $PSCommandPath
--$generatedRoot = Get-TraderxGeneratedRoot -RepoRoot $repoRoot
--$sourceRepoRoot = if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('TRADERX_SOURCE_REPO_ROOT'))) { $repoRoot } else { [Environment]::GetEnvironmentVariable('TRADERX_SOURCE_REPO_ROOT') }
--Use-GeneratedRuntimeScript -ScriptPath $PSCommandPath -GeneratedRoot $generatedRoot -RepoRoot $repoRoot -ScriptArgs $args -AdditionalEnv @{ TRADERX_SOURCE_REPO_ROOT = $sourceRepoRoot }
--
--$target = Join-Path $generatedRoot 'code/target-generated'
--$expectedState = '003-agentic-harness-foundation'
--$edgeComponentDir = Join-Path $generatedRoot 'code/components/edge-proxy-specfirst'
--$edgeTargetDir = Join-Path $target 'edge-proxy'
--$edgeProxyPort = if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('EDGE_PROXY_PORT'))) { 18080 } else { [int][Environment]::GetEnvironmentVariable('EDGE_PROXY_PORT') }
--
--if (-not (Test-Path -LiteralPath $edgeComponentDir -PathType Container)) {
--  throw "[error] missing generated edge-proxy component: $edgeComponentDir`n[hint] run: bash pipeline/generate-state.sh 003-agentic-harness-foundation"
--}
--
--$baseStartScript = Join-Path $repoRoot 'scripts/start-base-uncontainerized-generated.ps1'
--$priorExpected = [Environment]::GetEnvironmentVariable('TRADERX_EXPECTED_STATE_ID')
--$priorGenerated = [Environment]::GetEnvironmentVariable('TRADERX_GENERATED_ROOT')
--$priorSource = [Environment]::GetEnvironmentVariable('TRADERX_SOURCE_REPO_ROOT')
--
--[Environment]::SetEnvironmentVariable('TRADERX_EXPECTED_STATE_ID', $expectedState)
--[Environment]::SetEnvironmentVariable('TRADERX_GENERATED_ROOT', $generatedRoot)
--[Environment]::SetEnvironmentVariable('TRADERX_SOURCE_REPO_ROOT', $sourceRepoRoot)
--
--try {
--  $baseArgs = @()
--  if ($DryRun) { $baseArgs += '-DryRun' }
--  if ($BuildOnly) { $baseArgs += '-BuildOnly' }
--  & $baseStartScript @baseArgs
--  if ($LASTEXITCODE -ne 0) {
--    exit $LASTEXITCODE
--  }
--}
--finally {
--  [Environment]::SetEnvironmentVariable('TRADERX_EXPECTED_STATE_ID', $priorExpected)
--  [Environment]::SetEnvironmentVariable('TRADERX_GENERATED_ROOT', $priorGenerated)
--  [Environment]::SetEnvironmentVariable('TRADERX_SOURCE_REPO_ROOT', $priorSource)
--}
--
--$runRoot = [Environment]::GetEnvironmentVariable('TRADERX_RUN_DIR')
--if ([string]::IsNullOrWhiteSpace($runRoot)) {
--  if ($IsWindows) {
--    $username = if ([string]::IsNullOrWhiteSpace($env:USERNAME)) { 'unknown-user' } else { $env:USERNAME }
--    $runRoot = Join-Path $env:TEMP "$username/traderx"
--  }
--  else {
--    $userName = if ([string]::IsNullOrWhiteSpace($env:USER)) { 'unknown-user' } else { $env:USER }
--    $runRoot = "/var/tmp/$userName/traderx"
--  }
--}
--$runDir = Join-Path $runRoot 'state-003-agentic-harness-foundation'
--
--New-Item -ItemType Directory -Path (Join-Path $runDir 'logs') -Force | Out-Null
--New-Item -ItemType Directory -Path (Join-Path $runDir 'pids') -Force | Out-Null
--if (-not (Test-Path -LiteralPath $edgeTargetDir)) {
--  Copy-Item -LiteralPath $edgeComponentDir -Destination $edgeTargetDir -Recurse -Force
--}
--
--if ($BuildOnly) {
--  if (Test-Path -LiteralPath (Join-Path $edgeTargetDir 'node_modules') -PathType Container) {
--    Write-Host '[build-skip] edge-proxy: already built'
--  }
--  elseif ($DryRun) {
--    Write-Host "[dry-run] [build] edge-proxy: cd $edgeTargetDir && npm install"
--  }
--  else {
--    Write-Host '[build] edge-proxy: npm install'
--    Invoke-LoggedCommand -WorkDir $edgeTargetDir -Command 'npm install' -Label '[build] edge-proxy'
--  }
--
--  if ($DryRun) {
--    Write-Host '[done] dry run complete for state 003'
--  }
--  else {
--    Write-Host '[done] build phase complete for state 003'
--    Write-Host '[hint] run without -BuildOnly to start services'
--  }
--  exit 0
--}
--
--if (-not (Test-Path -LiteralPath (Join-Path $edgeTargetDir 'node_modules') -PathType Container)) {
--  Write-Host '[error] edge-proxy build artifacts missing (node_modules).'
--  Write-Host '[hint] run ./scripts/start-state-003-agentic-harness-foundation-generated.ps1 -BuildOnly'
--  exit 1
--}
--
--$pidFile = Join-Path (Join-Path $runDir 'pids') 'edge-proxy.pid'
--$logFile = Join-Path (Join-Path $runDir 'logs') 'edge-proxy.log'
--$oldPid = Read-PidFile -PidFile $pidFile
--if ($null -ne $oldPid -and (Test-ProcessAlive -Pid $oldPid)) {
--  Write-Host "[skip] edge-proxy already running (pid $oldPid)"
--  exit 0
--}
--
--if (Test-PortOpen -Port $edgeProxyPort) {
--  Write-Host "[error] port :$edgeProxyPort already in use before starting edge-proxy"
--  Write-Host '[hint] run ./scripts/stop-state-003-agentic-harness-foundation-generated.ps1 and retry.'
--  exit 1
--}
--
--if ($DryRun) {
--  Write-Host "[dry-run] edge-proxy: cd $edgeTargetDir && npm run start"
--  Write-Host '[done] dry run complete for state 003'
--  exit 0
--}
--
--Write-Host '[start] edge-proxy'
--Start-LoggedBackgroundCommand -WorkDir $edgeTargetDir -Command 'npm run start' -LogFile $logFile -PidFile $pidFile
--
--if (Wait-Port -ProcessName 'edge-proxy' -Port $edgeProxyPort -Attempts 60) {
--  Write-Host "[ui] http://localhost:$edgeProxyPort"
--  Write-Host "[api-explorer] http://localhost:$edgeProxyPort/api/docs"
--  exit 0
--}
--
--Write-Host "[error] timeout waiting for edge-proxy on :$edgeProxyPort"
--Write-Host "[hint] check logs: $logFile"
--exit 1
-diff --git a/scripts/start-state-003-agentic-harness-foundation-generated.sh b/scripts/start-state-003-agentic-harness-foundation-generated.sh
-deleted file mode 100755
-index 9711b0a..0000000
---- a/scripts/start-state-003-agentic-harness-foundation-generated.sh
-+++ /dev/null
-@@ -1,149 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--SOURCE_REPO_ROOT="${TRADERX_SOURCE_REPO_ROOT:-${REPO_ROOT}}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    TRADERX_LOCAL_RUNTIME_SCRIPT=1 \
--    TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
--    TRADERX_SOURCE_REPO_ROOT="${SOURCE_REPO_ROOT}" \
--      exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--TARGET="${GENERATED_ROOT}/code/target-generated"
--EXPECTED_STATE="003-agentic-harness-foundation"
--RUN_ROOT="${TRADERX_RUN_DIR:-/var/tmp/${USER:-unknown-user}/traderx}"
--RUN_DIR="${RUN_ROOT}/state-003-agentic-harness-foundation"
--EDGE_COMPONENT_DIR="${GENERATED_ROOT}/code/components/edge-proxy-specfirst"
--EDGE_TARGET_DIR="${TARGET}/edge-proxy"
--EDGE_PROXY_PORT="${EDGE_PROXY_PORT:-18080}"
--DRY_RUN=0
--BUILD_ONLY=0
--
--while (( "$#" )); do
--  case "$1" in
--    --dry-run)
--      DRY_RUN=1
--      ;;
--    --build-only)
--      BUILD_ONLY=1
--      ;;
--    *)
--      echo "[error] unknown argument: $1"
--      echo "[hint] supported: --dry-run --build-only"
--      exit 1
--      ;;
--  esac
--  shift
--done
--
--[[ -d "${EDGE_COMPONENT_DIR}" ]] || {
--  echo "[error] missing generated edge-proxy component: ${EDGE_COMPONENT_DIR}"
--  echo "[hint] run: bash pipeline/generate-state.sh 003-agentic-harness-foundation"
--  exit 1
--}
--
--if (( DRY_RUN == 1 )) && (( BUILD_ONLY == 1 )); then
--  TRADERX_EXPECTED_STATE_ID="${EXPECTED_STATE}" \
--  TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
--  TRADERX_SOURCE_REPO_ROOT="${SOURCE_REPO_ROOT}" \
--    "${REPO_ROOT}/scripts/start-base-uncontainerized-generated.sh" --dry-run --build-only
--elif (( DRY_RUN == 1 )); then
--  TRADERX_EXPECTED_STATE_ID="${EXPECTED_STATE}" \
--  TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
--  TRADERX_SOURCE_REPO_ROOT="${SOURCE_REPO_ROOT}" \
--    "${REPO_ROOT}/scripts/start-base-uncontainerized-generated.sh" --dry-run
--elif (( BUILD_ONLY == 1 )); then
--  TRADERX_EXPECTED_STATE_ID="${EXPECTED_STATE}" \
--  TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
--  TRADERX_SOURCE_REPO_ROOT="${SOURCE_REPO_ROOT}" \
--    "${REPO_ROOT}/scripts/start-base-uncontainerized-generated.sh" --build-only
--else
--  TRADERX_EXPECTED_STATE_ID="${EXPECTED_STATE}" \
--  TRADERX_GENERATED_ROOT="${GENERATED_ROOT}" \
--  TRADERX_SOURCE_REPO_ROOT="${SOURCE_REPO_ROOT}" \
--    "${REPO_ROOT}/scripts/start-base-uncontainerized-generated.sh"
--fi
--
--mkdir -p "${RUN_DIR}/logs" "${RUN_DIR}/pids"
--if [[ ! -d "${EDGE_TARGET_DIR}" ]]; then
--  cp -R "${EDGE_COMPONENT_DIR}" "${EDGE_TARGET_DIR}"
--fi
--
--if (( BUILD_ONLY == 1 )); then
--  if [[ -d "${EDGE_TARGET_DIR}/node_modules" ]]; then
--    echo "[build-skip] edge-proxy: already built"
--  elif (( DRY_RUN == 1 )); then
--    echo "[dry-run] [build] edge-proxy: cd ${EDGE_TARGET_DIR} && npm install"
--  else
--    echo "[build] edge-proxy: npm install"
--    (cd "${EDGE_TARGET_DIR}" && npm install)
--  fi
--
--  if (( DRY_RUN == 1 )); then
--    echo "[done] dry run complete for state 003"
--  else
--    echo "[done] build phase complete for state 003"
--    echo "[hint] run without --build-only to start services"
--  fi
--  exit 0
--fi
--
--if [[ ! -d "${EDGE_TARGET_DIR}/node_modules" ]]; then
--  echo "[error] edge-proxy build artifacts missing (node_modules)."
--  echo "[hint] run ./scripts/start-state-003-agentic-harness-foundation-generated.sh --build-only"
--  exit 1
--fi
--
--pidfile="${RUN_DIR}/pids/edge-proxy.pid"
--logfile="${RUN_DIR}/logs/edge-proxy.log"
--
--if [[ -f "${pidfile}" ]]; then
--  oldpid="$(cat "${pidfile}")"
--  if kill -0 "${oldpid}" >/dev/null 2>&1; then
--    echo "[skip] edge-proxy already running (pid ${oldpid})"
--    exit 0
--  fi
--fi
--
--if nc -z localhost "${EDGE_PROXY_PORT}" >/dev/null 2>&1; then
--  echo "[error] port :${EDGE_PROXY_PORT} already in use before starting edge-proxy"
--  echo "[hint] run ./scripts/stop-state-003-agentic-harness-foundation-generated.sh and retry."
--  exit 1
--fi
--
--if (( DRY_RUN == 1 )); then
--  echo "[dry-run] edge-proxy: cd ${EDGE_TARGET_DIR} && npm run start"
--  echo "[done] dry run complete for state 003"
--  exit 0
--fi
--
--echo "[start] edge-proxy"
--nohup /bin/zsh -lc "cd '${EDGE_TARGET_DIR}' && npm run start" >"${logfile}" 2>&1 &
--echo "$!" > "${pidfile}"
--
--attempts=60
--for ((i=1; i<=attempts; i++)); do
--  if nc -z localhost "${EDGE_PROXY_PORT}" >/dev/null 2>&1; then
--    echo "[ready] edge-proxy on :${EDGE_PROXY_PORT}"
--    echo "[ui] http://localhost:${EDGE_PROXY_PORT}"
--    echo "[api-explorer] http://localhost:${EDGE_PROXY_PORT}/api/docs"
--    exit 0
--  fi
--  sleep 1
--done
--
--echo "[error] timeout waiting for edge-proxy on :${EDGE_PROXY_PORT}"
--echo "[hint] check logs: ${logfile}"
--exit 1
 diff --git a/scripts/start-state-004-containerized-generated.sh b/scripts/start-state-004-containerized-generated.sh
 new file mode 100755
-index 0000000..f891b91
+index 0000000..e95180e
 --- /dev/null
 +++ b/scripts/start-state-004-containerized-generated.sh
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,142 @@
 +#!/usr/bin/env bash
 +set -euo pipefail
 +
-+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
++REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
++GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
++
++if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
++  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
++  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
++    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
++  fi
++fi
++STATE_ID="004-containerized-compose-runtime"
 +COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-004}"
-+COMPOSE_FILE="${ROOT}/containerized-compose/docker-compose.yml"
++COMPOSE_DIR="${GENERATED_ROOT}/code/target-generated/containerized-compose"
++COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
++WEB_COMPONENT_DIR="${GENERATED_ROOT}/code/components/web-front-end-angular-specfirst"
++WEB_TARGET_DIR="${GENERATED_ROOT}/code/target-generated/web-front-end/angular"
 +DRY_RUN=0
 +SKIP_BUILD=0
 +
@@ -11257,6 +13604,8 @@ index 0000000..f891b91
 +  shift
 +done
 +
++source "${REPO_ROOT}/scripts/lib/generated-state-detection.sh"
++
 +if ! command -v docker >/dev/null 2>&1; then
 +  echo "[error] docker command not found"
 +  exit 1
@@ -11267,10 +13616,54 @@ index 0000000..f891b91
 +  exit 1
 +fi
 +
-+if [[ ! -f "${COMPOSE_FILE}" ]]; then
++if [[ -z "${DOCKER_BUILDKIT:-}" ]]; then
++  export DOCKER_BUILDKIT=1
++  echo "[info] DOCKER_BUILDKIT not set; defaulting to 1 for Docker cache mounts"
++fi
++
++if [[ "${TRADERX_SKIP_GENERATE:-0}" != "1" ]]; then
++  traderx_report_generated_state "${STATE_ID}" "${GENERATED_ROOT}" || true
++  bash "${REPO_ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
++else
++  echo "[info] skipping state generation for ${STATE_ID} (TRADERX_SKIP_GENERATE=1)"
++  traderx_ensure_generated_state "${STATE_ID}" "${REPO_ROOT}" "${GENERATED_ROOT}"
++fi
++
++sync_state_aware_web_ui() {
++  if [[ ! -d "${WEB_COMPONENT_DIR}" || ! -d "${WEB_TARGET_DIR}" ]]; then
++    return 0
++  fi
++
++  local rel
++  for rel in \
++    "main/app/about" \
++    "main/app/status" \
++    "main/app/model/state-ui-metadata.model.ts" \
++    "main/app/service/state-metadata.service.ts" \
++    "main/app/header/header.component.ts" \
++    "main/app/header/header.component.html" \
++    "main/app/header/header.component.scss" \
++    "main/app/routing.ts" \
++    "main/assets/state-ui.json"; do
++    if [[ -d "${WEB_COMPONENT_DIR}/${rel}" ]]; then
++      rm -rf "${WEB_TARGET_DIR:?}/${rel}"
++      mkdir -p "${WEB_TARGET_DIR}/${rel}"
++      cp -R "${WEB_COMPONENT_DIR}/${rel}/." "${WEB_TARGET_DIR}/${rel}/"
++    elif [[ -f "${WEB_COMPONENT_DIR}/${rel}" ]]; then
++      mkdir -p "$(dirname "${WEB_TARGET_DIR}/${rel}")"
++      cp "${WEB_COMPONENT_DIR}/${rel}" "${WEB_TARGET_DIR}/${rel}"
++    fi
++  done
++
++  echo "[info] synced state-aware About/Status UI sources into containerized web target"
++}
++
++sync_state_aware_web_ui
++
++[[ -f "${COMPOSE_FILE}" ]] || {
 +  echo "[error] compose file not found: ${COMPOSE_FILE}"
 +  exit 1
-+fi
++}
 +
 +if (( DRY_RUN == 1 )); then
 +  if (( SKIP_BUILD == 1 )); then
@@ -11287,2954 +13680,139 @@ index 0000000..f891b91
 +else
 +  docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" up -d --build
 +fi
++
++wait_for_http() {
++  local name="$1"
++  local url="$2"
++  local attempts=90
++  local i
++  for ((i=1; i<=attempts; i++)); do
++    if curl -fsS "${url}" >/dev/null 2>&1; then
++      echo "[ready] ${name} ${url}"
++      return 0
++    fi
++    sleep 2
++  done
++  echo "[error] timeout waiting for ${name} at ${url}"
++  return 1
++}
++
++wait_for_http "database-web" "http://localhost:18084" || exit 1
++wait_for_http "reference-data" "http://localhost:18085/stocks" || exit 1
++wait_for_http "account-service" "http://localhost:18088/account/22214" || exit 1
++wait_for_http "position-service" "http://localhost:18090/positions/22214" || exit 1
++wait_for_http "trade-service" "http://localhost:18092/v3/api-docs" || exit 1
++wait_for_http "ingress" "http://localhost:8080/health" || exit 1
++wait_for_http "ingress-ui" "http://localhost:8080" || exit 1
++
 +echo "[done] state 004 containerized compose runtime started"
 +echo "[ui] http://localhost:8080"
 +echo "[api-explorer] http://localhost:8080/api/docs"
-diff --git a/scripts/status-base-uncontainerized-generated.ps1 b/scripts/status-base-uncontainerized-generated.ps1
-deleted file mode 100644
-index 64f37eb..0000000
---- a/scripts/status-base-uncontainerized-generated.ps1
-+++ /dev/null
-@@ -1,73 +0,0 @@
--#!/usr/bin/env pwsh
--Set-StrictMode -Version Latest
--$ErrorActionPreference = 'Stop'
--
--$env:TRADERX_LOCAL_RUNTIME_SCRIPT = '1'
--$env:TRADERX_SKIP_GENERATE = '1'
--if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('TRADERX_GENERATED_ROOT'))) {
--  $env:TRADERX_GENERATED_ROOT = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
--}
--
--. "$PSScriptRoot/lib/runtime-common.ps1"
--. "$PSScriptRoot/lib/generated-state-detection.ps1"
--
--$repoRoot = Get-TraderxRepoRoot -ScriptPath $PSCommandPath
--$generatedRoot = Get-TraderxGeneratedRoot -RepoRoot $repoRoot
--Use-GeneratedRuntimeScript -ScriptPath $PSCommandPath -GeneratedRoot $generatedRoot -RepoRoot $repoRoot -ScriptArgs $args
--
--$currentGeneratedState = Read-GeneratedStateId -GeneratedRoot $generatedRoot
--if ([string]::IsNullOrWhiteSpace($currentGeneratedState)) {
--  Write-Host '[warn] generated output state is unknown (missing ci/state-metadata.json)'
--}
--else {
--  Write-Host "[info] generated output state: $currentGeneratedState"
--}
--
--$runRoot = [Environment]::GetEnvironmentVariable('TRADERX_RUN_DIR')
--if ([string]::IsNullOrWhiteSpace($runRoot)) {
--  if ($IsWindows) {
--    $username = if ([string]::IsNullOrWhiteSpace($env:USERNAME)) { 'unknown-user' } else { $env:USERNAME }
--    $runRoot = Join-Path $env:TEMP "$username/traderx"
--  }
--  else {
--    $userName = if ([string]::IsNullOrWhiteSpace($env:USER)) { 'unknown-user' } else { $env:USER }
--    $runRoot = "/var/tmp/$userName/traderx"
--  }
--}
--$runDir = Join-Path $runRoot 'base-uncontainerized'
--
--$processes = @(
--  @{ Name = 'database'; Port = 18082 },
--  @{ Name = 'reference-data'; Port = 18085 },
--  @{ Name = 'trade-feed'; Port = 18086 },
--  @{ Name = 'people-service'; Port = 18089 },
--  @{ Name = 'account-service'; Port = 18088 },
--  @{ Name = 'position-service'; Port = 18090 },
--  @{ Name = 'trade-processor'; Port = 18091 },
--  @{ Name = 'trade-service'; Port = 18092 },
--  @{ Name = 'web-front-end-angular'; Port = 18093 }
--)
--
--"{0,-24} {1,-10} {2,-8} {3,-12}" -f 'process', 'pid', 'running', 'port-open'
--"{0,-24} {1,-10} {2,-8} {3,-12}" -f '------------------------', '----------', '--------', '------------'
--
--foreach ($proc in $processes) {
--  $pidFile = Join-Path (Join-Path $runDir 'pids') "$($proc.Name).pid"
--  $pid = '-'
--  $running = 'no'
--  $portOpen = 'no'
--
--  $savedPid = Read-PidFile -PidFile $pidFile
--  if ($null -ne $savedPid) {
--    $pid = [string]$savedPid
--    if (Test-ProcessAlive -Pid $savedPid) {
--      $running = 'yes'
--    }
--  }
--
--  if (Test-PortOpen -Port $proc.Port) {
--    $portOpen = 'yes'
--  }
--
--  "{0,-24} {1,-10} {2,-8} {3,-12}" -f $proc.Name, $pid, $running, $portOpen
--}
-diff --git a/scripts/status-base-uncontainerized-generated.sh b/scripts/status-base-uncontainerized-generated.sh
-deleted file mode 100755
-index 88714e4..0000000
---- a/scripts/status-base-uncontainerized-generated.sh
-+++ /dev/null
-@@ -1,57 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--TARGET="${GENERATED_ROOT}/code/target-generated"
--RUN_ROOT="${TRADERX_RUN_DIR:-/var/tmp/${USER:-unknown-user}/traderx}"
--RUN_DIR="${RUN_ROOT}/base-uncontainerized"
--SPEC="${REPO_ROOT}/catalog/base-uncontainerized-processes.csv"
--source "${REPO_ROOT}/scripts/lib/generated-state-detection.sh"
--
--current_generated_state="$(traderx_read_generated_state_id "${GENERATED_ROOT}" || true)"
--if [[ -n "${current_generated_state}" ]]; then
--  echo "[info] generated output state: ${current_generated_state}"
--else
--  echo "[warn] generated output state is unknown (missing ci/state-metadata.json)"
--fi
--
--printf "%-24s %-10s %-8s %-12s\n" "process" "pid" "running" "port-open"
--printf "%-24s %-10s %-8s %-12s\n" "------------------------" "----------" "--------" "------------"
--
--while IFS=, read -r order process workdir start_cmd port health_hint build_cmd; do
--  if [[ "${order}" == "order" ]]; then
--    continue
--  fi
--  pidfile="${RUN_DIR}/pids/${process}.pid"
--  pid="-"
--  running="no"
--  port_open="no"
--
--  if [[ -f "${pidfile}" ]]; then
--    pid="$(cat "${pidfile}")"
--    if kill -0 "${pid}" >/dev/null 2>&1; then
--      running="yes"
--    fi
--  fi
--
--  if nc -z localhost "${port}" >/dev/null 2>&1; then
--    port_open="yes"
--  fi
--
--  printf "%-24s %-10s %-8s %-12s\n" "${process}" "${pid}" "${running}" "${port_open}"
--done < "${SPEC}"
-diff --git a/scripts/status-state-003-agentic-harness-foundation-generated.ps1 b/scripts/status-state-003-agentic-harness-foundation-generated.ps1
-deleted file mode 100644
-index 45f5ba4..0000000
---- a/scripts/status-state-003-agentic-harness-foundation-generated.ps1
-+++ /dev/null
-@@ -1,53 +0,0 @@
--#!/usr/bin/env pwsh
--Set-StrictMode -Version Latest
--$ErrorActionPreference = 'Stop'
--
--$env:TRADERX_LOCAL_RUNTIME_SCRIPT = '1'
--$env:TRADERX_SKIP_GENERATE = '1'
--if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('TRADERX_GENERATED_ROOT'))) {
--  $env:TRADERX_GENERATED_ROOT = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
--}
--
--. "$PSScriptRoot/lib/runtime-common.ps1"
--
--$repoRoot = Get-TraderxRepoRoot -ScriptPath $PSCommandPath
--$generatedRoot = Get-TraderxGeneratedRoot -RepoRoot $repoRoot
--Use-GeneratedRuntimeScript -ScriptPath $PSCommandPath -GeneratedRoot $generatedRoot -RepoRoot $repoRoot -ScriptArgs $args
--
--$edgeProxyPort = if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('EDGE_PROXY_PORT'))) { 18080 } else { [int][Environment]::GetEnvironmentVariable('EDGE_PROXY_PORT') }
--$runRoot = [Environment]::GetEnvironmentVariable('TRADERX_RUN_DIR')
--if ([string]::IsNullOrWhiteSpace($runRoot)) {
--  if ($IsWindows) {
--    $username = if ([string]::IsNullOrWhiteSpace($env:USERNAME)) { 'unknown-user' } else { $env:USERNAME }
--    $runRoot = Join-Path $env:TEMP "$username/traderx"
--  }
--  else {
--    $userName = if ([string]::IsNullOrWhiteSpace($env:USER)) { 'unknown-user' } else { $env:USER }
--    $runRoot = "/var/tmp/$userName/traderx"
--  }
--}
--$runDir = Join-Path $runRoot 'state-003-agentic-harness-foundation'
--
--& (Join-Path $repoRoot 'scripts/status-base-uncontainerized-generated.ps1')
--if ($LASTEXITCODE -ne 0) {
--  exit $LASTEXITCODE
--}
--
--$pidFile = Join-Path (Join-Path $runDir 'pids') 'edge-proxy.pid'
--$pid = '-'
--$running = 'no'
--$portOpen = 'no'
--
--$savedPid = Read-PidFile -PidFile $pidFile
--if ($null -ne $savedPid) {
--  $pid = [string]$savedPid
--  if (Test-ProcessAlive -Pid $savedPid) {
--    $running = 'yes'
--  }
--}
--
--if (Test-PortOpen -Port $edgeProxyPort) {
--  $portOpen = 'yes'
--}
--
--"{0,-24} {1,-10} {2,-8} {3,-12}" -f 'edge-proxy', $pid, $running, $portOpen
-diff --git a/scripts/status-state-003-agentic-harness-foundation-generated.sh b/scripts/status-state-003-agentic-harness-foundation-generated.sh
-deleted file mode 100755
-index ee210ec..0000000
---- a/scripts/status-state-003-agentic-harness-foundation-generated.sh
-+++ /dev/null
-@@ -1,43 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--TARGET="${GENERATED_ROOT}/code/target-generated"
--RUN_ROOT="${TRADERX_RUN_DIR:-/var/tmp/${USER:-unknown-user}/traderx}"
--RUN_DIR="${RUN_ROOT}/state-003-agentic-harness-foundation"
--EDGE_PROXY_PORT="${EDGE_PROXY_PORT:-18080}"
--
--"${REPO_ROOT}/scripts/status-base-uncontainerized-generated.sh"
--
--pidfile="${RUN_DIR}/pids/edge-proxy.pid"
--pid="-"
--running="no"
--port_open="no"
--
--if [[ -f "${pidfile}" ]]; then
--  pid="$(cat "${pidfile}")"
--  if kill -0 "${pid}" >/dev/null 2>&1; then
--    running="yes"
--  fi
--fi
--
--if nc -z localhost "${EDGE_PROXY_PORT}" >/dev/null 2>&1; then
--  port_open="yes"
--fi
--
--printf "%-24s %-10s %-8s %-12s\n" "edge-proxy" "${pid}" "${running}" "${port_open}"
 diff --git a/scripts/status-state-004-containerized-generated.sh b/scripts/status-state-004-containerized-generated.sh
 new file mode 100755
-index 0000000..74c22d2
+index 0000000..b6e3260
 --- /dev/null
 +++ b/scripts/status-state-004-containerized-generated.sh
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,58 @@
 +#!/usr/bin/env bash
 +set -euo pipefail
 +
-+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-+  COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-004}"
-+COMPOSE_FILE="${ROOT}/containerized-compose/docker-compose.yml"
++REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
++GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
 +
-+if [[ ! -f "${COMPOSE_FILE}" ]]; then
-+  echo "[error] compose file not found: ${COMPOSE_FILE}"
++if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
++  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
++  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
++    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
++  fi
++fi
++COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-004}"
++COMPOSE_FILE="${GENERATED_ROOT}/code/target-generated/containerized-compose/docker-compose.yml"
++source "${REPO_ROOT}/scripts/lib/generated-state-detection.sh"
++
++current_generated_state="$(traderx_read_generated_state_id "${GENERATED_ROOT}" || true)"
++if [[ -n "${current_generated_state}" ]]; then
++  echo "[info] generated output state: ${current_generated_state}"
++else
++  echo "[warn] generated output state is unknown (missing ci/state-metadata.json)"
++fi
++
++if ! command -v docker >/dev/null 2>&1; then
++  echo "[error] docker command not found"
 +  exit 1
 +fi
 +
++if [[ ! -f "${COMPOSE_FILE}" ]]; then
++  echo "[info] compose file not found: ${COMPOSE_FILE}"
++  echo "[hint] run: bash pipeline/generate-state.sh 004-containerized-compose-runtime"
++  exit 0
++fi
++
++echo "[info] compose project: ${COMPOSE_PROJECT_NAME}"
 +docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps
-diff --git a/scripts/stop-base-uncontainerized-generated.ps1 b/scripts/stop-base-uncontainerized-generated.ps1
-deleted file mode 100644
-index 392473f..0000000
---- a/scripts/stop-base-uncontainerized-generated.ps1
-+++ /dev/null
-@@ -1,71 +0,0 @@
--#!/usr/bin/env pwsh
--Set-StrictMode -Version Latest
--$ErrorActionPreference = 'Stop'
--
--$env:TRADERX_LOCAL_RUNTIME_SCRIPT = '1'
--$env:TRADERX_SKIP_GENERATE = '1'
--if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('TRADERX_GENERATED_ROOT'))) {
--  $env:TRADERX_GENERATED_ROOT = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
--}
--
--. "$PSScriptRoot/lib/runtime-common.ps1"
--
--$repoRoot = Get-TraderxRepoRoot -ScriptPath $PSCommandPath
--$generatedRoot = Get-TraderxGeneratedRoot -RepoRoot $repoRoot
--Use-GeneratedRuntimeScript -ScriptPath $PSCommandPath -GeneratedRoot $generatedRoot -RepoRoot $repoRoot -ScriptArgs $args
--
--$runRoot = [Environment]::GetEnvironmentVariable('TRADERX_RUN_DIR')
--if ([string]::IsNullOrWhiteSpace($runRoot)) {
--  if ($IsWindows) {
--    $username = if ([string]::IsNullOrWhiteSpace($env:USERNAME)) { 'unknown-user' } else { $env:USERNAME }
--    $runRoot = Join-Path $env:TEMP "$username/traderx"
--  }
--  else {
--    $userName = if ([string]::IsNullOrWhiteSpace($env:USER)) { 'unknown-user' } else { $env:USER }
--    $runRoot = "/var/tmp/$userName/traderx"
--  }
--}
--$runDir = Join-Path $runRoot 'base-uncontainerized'
--
--$processes = @(
--  @{ Order = 9; Name = 'web-front-end-angular'; Port = 18093 },
--  @{ Order = 8; Name = 'trade-service'; Port = 18092 },
--  @{ Order = 7; Name = 'trade-processor'; Port = 18091 },
--  @{ Order = 6; Name = 'position-service'; Port = 18090 },
--  @{ Order = 5; Name = 'account-service'; Port = 18088 },
--  @{ Order = 4; Name = 'people-service'; Port = 18089 },
--  @{ Order = 3; Name = 'trade-feed'; Port = 18086 },
--  @{ Order = 2; Name = 'reference-data'; Port = 18085 },
--  @{ Order = 1; Name = 'database'; Port = 18082 }
--)
--
--$pidsDir = Join-Path $runDir 'pids'
--if (-not (Test-Path -LiteralPath $pidsDir)) {
--  Write-Host "[info] no pid directory at $pidsDir"
--  New-Item -ItemType Directory -Path $pidsDir -Force | Out-Null
--}
--
--foreach ($proc in $processes | Sort-Object Order -Descending) {
--  $pidFile = Join-Path $pidsDir "$($proc.Name).pid"
--  $pid = Read-PidFile -PidFile $pidFile
--  if ($null -ne $pid) {
--    if (Test-ProcessAlive -Pid $pid) {
--      Write-Host "[stop] $($proc.Name) (pid $pid)"
--      Stop-Process -Id $pid -ErrorAction SilentlyContinue
--    }
--    else {
--      Write-Host "[stale] $($proc.Name) pid file exists but process not running"
--    }
--    Remove-Item -LiteralPath $pidFile -ErrorAction SilentlyContinue
--  }
--
--  $listenerPids = @(Get-PortListenerPids -Port $proc.Port)
--  foreach ($listenerPid in $listenerPids) {
--    if (Test-ProcessAlive -Pid $listenerPid) {
--      Write-Host "[stop-port] $($proc.Name) listener on :$($proc.Port) (pid $listenerPid)"
--      Stop-Process -Id $listenerPid -ErrorAction SilentlyContinue
--    }
--  }
--}
--
--Write-Host '[done] stop sequence complete'
-diff --git a/scripts/stop-base-uncontainerized-generated.sh b/scripts/stop-base-uncontainerized-generated.sh
-deleted file mode 100755
-index 7402b74..0000000
---- a/scripts/stop-base-uncontainerized-generated.sh
-+++ /dev/null
-@@ -1,70 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--TARGET="${GENERATED_ROOT}/code/target-generated"
--RUN_ROOT="${TRADERX_RUN_DIR:-/var/tmp/${USER:-unknown-user}/traderx}"
--RUN_DIR="${RUN_ROOT}/base-uncontainerized"
--SPEC="${REPO_ROOT}/catalog/base-uncontainerized-processes.csv"
--
--if [[ ! -d "${RUN_DIR}/pids" ]]; then
--  echo "[info] no pid directory at ${RUN_DIR}/pids"
--  mkdir -p "${RUN_DIR}/pids"
--fi
--
--kill_listener_on_port() {
--  local process="$1"
--  local port="$2"
--  local pids
--
--  if ! command -v lsof >/dev/null 2>&1; then
--    return 0
--  fi
--
--  pids="$(lsof -nP -tiTCP:"${port}" -sTCP:LISTEN 2>/dev/null || true)"
--  if [[ -z "${pids}" ]]; then
--    return 0
--  fi
--
--  for pid in ${pids}; do
--    if kill -0 "${pid}" >/dev/null 2>&1; then
--      echo "[stop-port] ${process} listener on :${port} (pid ${pid})"
--      kill "${pid}" >/dev/null 2>&1 || true
--    fi
--  done
--}
--
--while IFS=, read -r order process workdir start_cmd port health_hint build_cmd; do
--  if [[ "${order}" == "order" ]]; then
--    continue
--  fi
--  pidfile="${RUN_DIR}/pids/${process}.pid"
--  if [[ -f "${pidfile}" ]]; then
--    pid="$(cat "${pidfile}")"
--    if kill -0 "${pid}" >/dev/null 2>&1; then
--      echo "[stop] ${process} (pid ${pid})"
--      kill "${pid}" >/dev/null 2>&1 || true
--    else
--      echo "[stale] ${process} pid file exists but process not running"
--    fi
--    rm -f "${pidfile}"
--  fi
--  kill_listener_on_port "${process}" "${port}"
--done < <(tail -n +2 "${SPEC}" | sort -t, -k1,1nr)
--
--echo "[done] stop sequence complete"
-diff --git a/scripts/stop-state-003-agentic-harness-foundation-generated.ps1 b/scripts/stop-state-003-agentic-harness-foundation-generated.ps1
-deleted file mode 100644
-index a935c78..0000000
---- a/scripts/stop-state-003-agentic-harness-foundation-generated.ps1
-+++ /dev/null
-@@ -1,49 +0,0 @@
--#!/usr/bin/env pwsh
--Set-StrictMode -Version Latest
--$ErrorActionPreference = 'Stop'
--
--$env:TRADERX_LOCAL_RUNTIME_SCRIPT = '1'
--$env:TRADERX_SKIP_GENERATE = '1'
--if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('TRADERX_GENERATED_ROOT'))) {
--  $env:TRADERX_GENERATED_ROOT = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
--}
--
--. "$PSScriptRoot/lib/runtime-common.ps1"
--
--$repoRoot = Get-TraderxRepoRoot -ScriptPath $PSCommandPath
--$generatedRoot = Get-TraderxGeneratedRoot -RepoRoot $repoRoot
--Use-GeneratedRuntimeScript -ScriptPath $PSCommandPath -GeneratedRoot $generatedRoot -RepoRoot $repoRoot -ScriptArgs $args
--
--$edgeProxyPort = if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('EDGE_PROXY_PORT'))) { 18080 } else { [int][Environment]::GetEnvironmentVariable('EDGE_PROXY_PORT') }
--$runRoot = [Environment]::GetEnvironmentVariable('TRADERX_RUN_DIR')
--if ([string]::IsNullOrWhiteSpace($runRoot)) {
--  if ($IsWindows) {
--    $username = if ([string]::IsNullOrWhiteSpace($env:USERNAME)) { 'unknown-user' } else { $env:USERNAME }
--    $runRoot = Join-Path $env:TEMP "$username/traderx"
--  }
--  else {
--    $userName = if ([string]::IsNullOrWhiteSpace($env:USER)) { 'unknown-user' } else { $env:USER }
--    $runRoot = "/var/tmp/$userName/traderx"
--  }
--}
--$runDir = Join-Path $runRoot 'state-003-agentic-harness-foundation'
--
--$pidFile = Join-Path (Join-Path $runDir 'pids') 'edge-proxy.pid'
--$pid = Read-PidFile -PidFile $pidFile
--if ($null -ne $pid) {
--  if (Test-ProcessAlive -Pid $pid) {
--    Write-Host "[stop] edge-proxy (pid $pid)"
--    Stop-Process -Id $pid -ErrorAction SilentlyContinue
--  }
--  Remove-Item -LiteralPath $pidFile -ErrorAction SilentlyContinue
--}
--
--foreach ($listenerPid in @(Get-PortListenerPids -Port $edgeProxyPort)) {
--  if (Test-ProcessAlive -Pid $listenerPid) {
--    Write-Host "[stop-port] edge-proxy listener on :$edgeProxyPort (pid $listenerPid)"
--    Stop-Process -Id $listenerPid -ErrorAction SilentlyContinue
--  }
--}
--
--& (Join-Path $repoRoot 'scripts/stop-base-uncontainerized-generated.ps1')
--exit $LASTEXITCODE
-diff --git a/scripts/stop-state-003-agentic-harness-foundation-generated.sh b/scripts/stop-state-003-agentic-harness-foundation-generated.sh
-deleted file mode 100755
-index 273f151..0000000
---- a/scripts/stop-state-003-agentic-harness-foundation-generated.sh
-+++ /dev/null
-@@ -1,45 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--TARGET="${GENERATED_ROOT}/code/target-generated"
--RUN_ROOT="${TRADERX_RUN_DIR:-/var/tmp/${USER:-unknown-user}/traderx}"
--RUN_DIR="${RUN_ROOT}/state-003-agentic-harness-foundation"
--EDGE_PROXY_PORT="${EDGE_PROXY_PORT:-18080}"
--
--pidfile="${RUN_DIR}/pids/edge-proxy.pid"
--if [[ -f "${pidfile}" ]]; then
--  pid="$(cat "${pidfile}")"
--  if kill -0 "${pid}" >/dev/null 2>&1; then
--    echo "[stop] edge-proxy (pid ${pid})"
--    kill "${pid}" >/dev/null 2>&1 || true
--  fi
--  rm -f "${pidfile}"
--fi
--
--if command -v lsof >/dev/null 2>&1; then
--  pids="$(lsof -nP -tiTCP:"${EDGE_PROXY_PORT}" -sTCP:LISTEN 2>/dev/null || true)"
--  for pid in ${pids}; do
--    if kill -0 "${pid}" >/dev/null 2>&1; then
--      echo "[stop-port] edge-proxy listener on :${EDGE_PROXY_PORT} (pid ${pid})"
--      kill "${pid}" >/dev/null 2>&1 || true
--    fi
--  done
--fi
--
--"${REPO_ROOT}/scripts/stop-base-uncontainerized-generated.sh"
++
++http_code_for() {
++  local url="$1"
++  curl -sS -o /dev/null -w "%{http_code}" "${url}" 2>/dev/null || true
++}
++
++printf "\n%-24s %-8s %s\n" "endpoint" "http" "url"
++printf "%-24s %-8s %s\n" "------------------------" "--------" "---"
++
++for target in \
++  "ingress-health|http://localhost:8080/health" \
++  "ingress-ui|http://localhost:8080/" \
++  "angular-ui|http://localhost:18093/" \
++  "reference-data|http://localhost:18085/stocks" \
++  "account-service|http://localhost:18088/account/22214" \
++  "position-service|http://localhost:18090/health/alive" \
++  "trade-service|http://localhost:18092/v3/api-docs"; do
++  name="${target%%|*}"
++  url="${target#*|}"
++  code="$(http_code_for "${url}")"
++  printf "%-24s %-8s %s\n" "${name}" "${code:-000}" "${url}"
++done
 diff --git a/scripts/stop-state-004-containerized-generated.sh b/scripts/stop-state-004-containerized-generated.sh
 new file mode 100755
-index 0000000..f9efb24
+index 0000000..e58d5b3
 --- /dev/null
 +++ b/scripts/stop-state-004-containerized-generated.sh
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,27 @@
 +#!/usr/bin/env bash
 +set -euo pipefail
 +
-+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-+  COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-004}"
-+COMPOSE_FILE="${ROOT}/containerized-compose/docker-compose.yml"
++REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
++GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
++
++if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
++  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
++  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
++    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
++  fi
++fi
++COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-004}"
++COMPOSE_FILE="${GENERATED_ROOT}/code/target-generated/containerized-compose/docker-compose.yml"
++
++if ! command -v docker >/dev/null 2>&1; then
++  echo "[error] docker command not found"
++  exit 1
++fi
 +
 +if [[ ! -f "${COMPOSE_FILE}" ]]; then
-+  echo "[error] compose file not found: ${COMPOSE_FILE}"
-+  exit 1
++  echo "[info] compose file not found; nothing to stop: ${COMPOSE_FILE}"
++  exit 0
 +fi
 +
 +docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" down --remove-orphans
 +echo "[done] state 004 containerized compose runtime stopped"
-diff --git a/scripts/test-account-service-overlay.sh b/scripts/test-account-service-overlay.sh
-deleted file mode 100755
-index ecd25c0..0000000
---- a/scripts/test-account-service-overlay.sh
-+++ /dev/null
-@@ -1,73 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--ORIGIN="${1:-http://localhost:18093}"
--BASE_URL="${2:-http://localhost:18088}"
--REQUEST_ORIGIN="$(echo "${BASE_URL}" | sed -E 's#^(https?://[^/]+).*$#\1#')"
--NORMALIZED_ORIGIN="${ORIGIN%/}"
--NORMALIZED_REQUEST_ORIGIN="${REQUEST_ORIGIN%/}"
--
--echo "[check] CORS header from ${BASE_URL}/account/22214 for origin ${ORIGIN}"
--headers="$(curl -sS -i -H "Origin: ${ORIGIN}" "${BASE_URL}/account/22214" | sed -n '1,30p')"
--echo "${headers}"
--
--cors_header="$(printf '%s\n' "${headers}" | awk -F': ' 'tolower($1)=="access-control-allow-origin" {print $2}' | tr -d '\r' || true)"
--if [[ -z "${cors_header}" ]]; then
--  if [[ "${NORMALIZED_ORIGIN}" == "${NORMALIZED_REQUEST_ORIGIN}" ]]; then
--    echo "[info] Access-Control-Allow-Origin header omitted for same-origin request (${NORMALIZED_ORIGIN}); continuing"
--  else
--    echo "[error] missing Access-Control-Allow-Origin header"
--    exit 1
--  fi
--fi
--
--if [[ -n "${cors_header}" && "${cors_header}" != "*" && "${cors_header}" != "${ORIGIN}" ]]; then
--  echo "[error] unexpected Access-Control-Allow-Origin value: ${cors_header}"
--  exit 1
--fi
--
--echo "[check] known account lookup"
--account_json="$(curl -sS "${BASE_URL}/account/22214")"
--echo "${account_json}" | jq
--account_id="$(echo "${account_json}" | jq -r '.id')"
--if [[ "${account_id}" != "22214" ]]; then
--  echo "[error] expected account id 22214, got ${account_id}"
--  exit 1
--fi
--
--echo "[check] account list"
--account_count="$(curl -sS "${BASE_URL}/account/" | jq 'length')"
--echo "[info] account count=${account_count}"
--if [[ "${account_count}" -lt 1 ]]; then
--  echo "[error] expected at least one account"
--  exit 1
--fi
--
--echo "[check] account-user list"
--account_user_count="$(curl -sS "${BASE_URL}/accountuser/" | jq 'length')"
--echo "[info] account-user count=${account_user_count}"
--if [[ "${account_user_count}" -lt 1 ]]; then
--  echo "[error] expected at least one account-user mapping"
--  exit 1
--fi
--
--echo "[check] unknown username rejected by people-service validation"
--unknown_http_code="$(
--  curl -sS -o /tmp/account-service-unknown-user.out -w "%{http_code}" \
--    -X POST "${BASE_URL}/accountuser/" \
--    -H "Content-Type: application/json" \
--    -d '{"accountId":22214,"username":"DOES_NOT_EXIST"}'
--)"
--if [[ "${unknown_http_code}" != "404" ]]; then
--  echo "[error] expected 404 for unknown person on accountuser create, got ${unknown_http_code}"
--  exit 1
--fi
--
--echo "[done] account-service overlay smoke tests passed"
-diff --git a/scripts/test-api-explorer-pubsub-inspector.sh b/scripts/test-api-explorer-pubsub-inspector.sh
-deleted file mode 100755
-index a1b4320..0000000
---- a/scripts/test-api-explorer-pubsub-inspector.sh
-+++ /dev/null
-@@ -1,196 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--INGRESS_URL="${1:-http://localhost:8080}"
--SUBJECT_MAP_FILE="${2:-specs/008-pricing-awareness-market-data/system/messaging-subject-map.md}"
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--WORKSPACE_ROOT="$(git -C "${REPO_ROOT}" rev-parse --show-toplevel 2>/dev/null || printf '%s' "${REPO_ROOT}")"
--
--resolve_subject_map_path() {
--  local candidate="$1"
--  if [[ -f "${candidate}" ]]; then
--    echo "${candidate}"
--    return
--  fi
--  if [[ -f "${REPO_ROOT}/${candidate}" ]]; then
--    echo "${REPO_ROOT}/${candidate}"
--    return
--  fi
--  if [[ -f "${WORKSPACE_ROOT}/${candidate}" ]]; then
--    echo "${WORKSPACE_ROOT}/${candidate}"
--    return
--  fi
--  echo "${WORKSPACE_ROOT}/${candidate}"
--}
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${REPO_ROOT}/generated/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "${INGRESS_URL}" "${SUBJECT_MAP_FILE}"
--  fi
--fi
--
--assert_content_type() {
--  local url="$1"
--  local expected_substring="$2"
--  local headers content_type
--  headers="$(curl -fsSI "${url}")" || {
--    echo "[error] request failed for ${url}"
--    exit 1
--  }
--  content_type="$(
--    printf '%s\n' "${headers}" \
--      | awk -F': *' 'tolower($1)=="content-type"{print tolower($2); exit}' \
--      | tr -d '\r'
--  )"
--  if [[ -z "${content_type}" ]]; then
--    echo "[error] missing Content-Type header for ${url}"
--    exit 1
--  fi
--  if [[ "${content_type}" != *"${expected_substring}"* ]]; then
--    echo "[error] unexpected Content-Type for ${url}: ${content_type} (expected substring: ${expected_substring})"
--    exit 1
--  fi
--}
--
--echo "[check] api explorer index route"
--index_html="$(curl -fsS "${INGRESS_URL}/api/docs/")"
--printf '%s' "${index_html}" | rg -q 'pubsub-inspector\.html' || {
--  echo "[error] expected pubsub inspector link in /api/docs/ index"
--  exit 1
--}
--printf '%s' "${index_html}" | rg -q 'window\.location\.href\.replace\(/\\/\[\^/\]\*\$/' || {
--  echo "[error] expected computed relative inspector URL logic in /api/docs/ index"
--  exit 1
--}
--printf '%s' "${index_html}" | rg -q 'href="/"' || {
--  echo "[error] expected back-to-app link to / in /api/docs/ index"
--  exit 1
--}
--assert_content_type "${INGRESS_URL}/api/docs/" "text/html"
--
--echo "[check] pubsub inspector canonical route"
--inspector_html="$(curl -fsS "${INGRESS_URL}/api/docs/pubsub-inspector.html")"
--printf '%s' "${inspector_html}" | rg -q 'MAX_BUFFER = 2000' || {
--  echo "[error] expected 2000 message buffer cap in pubsub inspector"
--  exit 1
--}
--printf '%s' "${inspector_html}" | rg -q 'id="filter-input"' || {
--  echo "[error] expected filter input in pubsub inspector"
--  exit 1
--}
--printf '%s' "${inspector_html}" | rg -q 'id="pause-btn"' || {
--  echo "[error] expected pause control in pubsub inspector"
--  exit 1
--}
--printf '%s' "${inspector_html}" | rg -q 'id="clear-btn"' || {
--  echo "[error] expected clear control in pubsub inspector"
--  exit 1
--}
--printf '%s' "${inspector_html}" | rg -q './vendor/nats\.ws/nats\.js' || {
--  echo "[error] expected local vendored nats.ws asset in pubsub inspector"
--  exit 1
--}
--printf '%s' "${inspector_html}" | rg -q 'href="/"' || {
--  echo "[error] expected back-to-app link to / in pubsub inspector"
--  exit 1
--}
--if printf '%s' "${inspector_html}" | rg -qi 'unpkg|jsdelivr|skypack|cdn'; then
--  echo "[error] pubsub inspector must not depend on CDN assets"
--  exit 1
--fi
--assert_content_type "${INGRESS_URL}/api/docs/pubsub-inspector.html" "text/html"
--
--echo "[check] pubsub inspector legacy no-extension compatibility route"
--curl -fsS "${INGRESS_URL}/api/docs/pubsub-inspector" >/dev/null || {
--  echo "[error] expected /api/docs/pubsub-inspector compatibility route"
--  exit 1
--}
--
--echo "[check] api explorer catalog messaging subjects"
--catalog_file="$(mktemp)"
--trap 'rm -f "${catalog_file}"' EXIT
--curl -fsS "${INGRESS_URL}/api/docs/catalog.json" > "${catalog_file}"
--assert_content_type "${INGRESS_URL}/api/docs/catalog.json" "application/json"
--
--jq -e '.messagingSubjects | type == "array"' "${catalog_file}" >/dev/null || {
--  echo "[error] expected catalog.json to include messagingSubjects array"
--  exit 1
--}
--
--SUBJECT_MAP_PATH="$(resolve_subject_map_path "${SUBJECT_MAP_FILE}")"
--if [[ ! -f "${SUBJECT_MAP_PATH}" ]]; then
--  echo "[warn] subject map file not found for strict inspector topic validation: ${SUBJECT_MAP_PATH}"
--  exit 0
--fi
--
--CATALOG_FILE="${catalog_file}" SUBJECT_MAP_FILE="${SUBJECT_MAP_PATH}" node <<'NODE'
--const fs = require('node:fs');
--
--const catalogFile = process.env.CATALOG_FILE;
--const mapFile = process.env.SUBJECT_MAP_FILE;
--
--const parseSubjects = (markdown) => {
--  const lines = String(markdown || '').split(/\r?\n/);
--  const subjects = [];
--  let current = null;
--  for (const line of lines) {
--    const familyMatch = line.match(/^\s*-\s+`([^`]+)`\s*$/);
--    if (familyMatch) {
--      current = {
--        subject: familyMatch[1].trim(),
--        pattern: familyMatch[1].trim(),
--        wildcard: false,
--      };
--      subjects.push(current);
--      continue;
--    }
--    if (!current) {
--      continue;
--    }
--    const wildcardMatch = line.match(/^\s*-\s+wildcard:\s+`?yes`?(?:\s+\(`([^`]+)`\))?/i);
--    if (wildcardMatch) {
--      current.wildcard = true;
--      if (wildcardMatch[1]) {
--        current.pattern = wildcardMatch[1].trim();
--      }
--    }
--  }
--  return subjects;
--};
--
--const catalog = JSON.parse(fs.readFileSync(catalogFile, 'utf8'));
--const map = fs.readFileSync(mapFile, 'utf8');
--const expected = parseSubjects(map);
--const actual = Array.isArray(catalog.messagingSubjects) ? catalog.messagingSubjects : [];
--
--const actualByPattern = new Map(actual.map((entry) => [String(entry.pattern || ''), entry]));
--const missing = [];
--for (const subject of expected) {
--  const actualEntry = actualByPattern.get(subject.pattern);
--  if (!actualEntry) {
--    missing.push(subject.pattern);
--    continue;
--  }
--  if (subject.wildcard && !actualEntry.wildcard) {
--    console.error(`[error] expected wildcard=true for pattern ${subject.pattern}`);
--    process.exit(1);
--  }
--}
--
--if (missing.length > 0) {
--  console.error(`[error] missing messagingSubjects patterns in catalog: ${missing.join(', ')}`);
--  process.exit(1);
--}
--
--console.log(`[info] inspector messagingSubjects validated (${expected.length} subjects)`);
--NODE
--
--echo "[done] api explorer pubsub inspector contract checks passed"
-diff --git a/scripts/test-database-overlay.sh b/scripts/test-database-overlay.sh
-deleted file mode 100755
-index 773231a..0000000
---- a/scripts/test-database-overlay.sh
-+++ /dev/null
-@@ -1,28 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--DB_TCP_PORT="${1:-18082}"
--DB_PG_PORT="${2:-18083}"
--DB_WEB_URL="${3:-http://localhost:18084/}"
--ACCOUNT_URL="${4:-http://localhost:18088/account/22214}"
--
--echo "[check] database tcp port ${DB_TCP_PORT}"
--nc -z localhost "${DB_TCP_PORT}"
--
--echo "[check] database pg port ${DB_PG_PORT}"
--nc -z localhost "${DB_PG_PORT}"
--
--echo "[check] database web console"
--curl -sS -i "${DB_WEB_URL}" | sed -n '1,10p'
--
--echo "[check] account-service can query baseline account data"
--curl -sS -i "${ACCOUNT_URL}" | sed -n '1,20p'
--
--echo "[done] database overlay smoke tests passed"
-diff --git a/scripts/test-generated-ci-assets.sh b/scripts/test-generated-ci-assets.sh
-deleted file mode 100755
-index 17cb312..0000000
---- a/scripts/test-generated-ci-assets.sh
-+++ /dev/null
-@@ -1,209 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--TMP_DIR="$(mktemp -d /tmp/traderx-ci-assets.XXXXXX)"
--trap 'rm -rf "${TMP_DIR}"' EXIT
--
--TARGET_ROOT="${TMP_DIR}/generated/code/target-generated"
--mkdir -p "${TARGET_ROOT}"
--
--echo "[check] state 002 installs security/license workflows and suppression files"
--mkdir -p \
--  "${TARGET_ROOT}/reference-data" \
--  "${TARGET_ROOT}/web-front-end/angular" \
--  "${TARGET_ROOT}/account-service" \
--  "${TARGET_ROOT}/people-service" \
--  "${TARGET_ROOT}/ingress"
--touch \
--  "${TARGET_ROOT}/reference-data/package.json" \
--  "${TARGET_ROOT}/web-front-end/angular/package.json" \
--  "${TARGET_ROOT}/account-service/build.gradle" \
--  "${TARGET_ROOT}/people-service/people-service.csproj" \
--  "${TARGET_ROOT}/ingress/Dockerfile.compose"
--
--bash "${ROOT}/pipeline/install-generated-ci-assets.sh" 002-edge-proxy-uncontainerized "${TARGET_ROOT}"
--
--for required in \
--  "${TARGET_ROOT}/.github/workflows/security.yml" \
--  "${TARGET_ROOT}/.github/workflows/license-scanning-node.yml" \
--  "${TARGET_ROOT}/.github/gradle-cve-ignore-list.xml" \
--  "${TARGET_ROOT}/.github/node-cve-ignore-list.xml" \
--  "${TARGET_ROOT}/.github/dotnet-cve-ignore-list.xml" \
--  "${TARGET_ROOT}/ci/state-metadata.json"; do
--  [[ -f "${required}" ]] || {
--    echo "[fail] missing generated CI artifact: ${required}"
--    exit 1
--  }
--done
--
--grep -q "name: Prepare artifact name" "${TARGET_ROOT}/.github/workflows/security.yml" || {
--  echo "[fail] security workflow should include artifact-name preparation step"
--  exit 1
--}
--
--grep -q "security-node-\${{ env.UPNAME }}" "${TARGET_ROOT}/.github/workflows/security.yml" || {
--  echo "[fail] security workflow should use sanitized node artifact names"
--  exit 1
--}
--
--grep -q "security-dotnet-\${{ env.UPNAME }}" "${TARGET_ROOT}/.github/workflows/security.yml" || {
--  echo "[fail] security workflow should use sanitized dotnet artifact names"
--  exit 1
--}
--
--grep -q "security-gradle-\${{ env.UPNAME }}" "${TARGET_ROOT}/.github/workflows/security.yml" || {
--  echo "[fail] security workflow should use sanitized gradle artifact names"
--  exit 1
--}
--
--grep -q "JAVA_HOME: /opt/jdk" "${TARGET_ROOT}/.github/workflows/security.yml" || {
--  echo "[fail] security workflow should set JAVA_HOME=/opt/jdk for dependency-check"
--  exit 1
--}
--
--[[ ! -f "${TARGET_ROOT}/.github/workflows/build-and-publish.yml" ]] || {
--  echo "[fail] state 002 should not generate convergence build-and-publish workflow"
--  exit 1
--}
--[[ ! -d "${TARGET_ROOT}/runtime/deploy" ]] || {
--  echo "[fail] state 002 should not generate deployment bundles"
--  exit 1
--}
--
--echo "[check] state 009 generates convergence workflows + GHCR run bundle"
--rm -rf "${TARGET_ROOT}"
--mkdir -p \
--  "${TARGET_ROOT}/api-explorer" \
--  "${TARGET_ROOT}/reference-data" \
--  "${TARGET_ROOT}/web-front-end/angular" \
--  "${TARGET_ROOT}/order-matcher" \
--  "${TARGET_ROOT}/ingress" \
--  "${TARGET_ROOT}/order-management-matcher"
--touch \
--  "${TARGET_ROOT}/api-explorer/Dockerfile" \
--  "${TARGET_ROOT}/reference-data/package.json" \
--  "${TARGET_ROOT}/web-front-end/angular/package.json" \
--  "${TARGET_ROOT}/order-matcher/Dockerfile.compose" \
--  "${TARGET_ROOT}/ingress/Dockerfile.compose"
--cat > "${TARGET_ROOT}/order-management-matcher/docker-compose.yml" <<'EOF'
--name: traderx-state-009
--services:
--  reference-data:
--    build:
--      context: ../reference-data
--      dockerfile: Dockerfile.compose
--  web-front-end-angular:
--    build:
--      context: ../web-front-end/angular
--      dockerfile: Dockerfile.compose
--  ingress:
--    build:
--      context: ../ingress
--      dockerfile: Dockerfile.compose
--  database:
--    image: postgres:16-alpine
--volumes:
--  postgres_state_009_data: {}
--EOF
--
--bash "${ROOT}/pipeline/install-generated-ci-assets.sh" 009-order-management-matcher "${TARGET_ROOT}"
--
--for required in \
--  "${TARGET_ROOT}/.github/workflows/security.yml" \
--  "${TARGET_ROOT}/.github/workflows/license-scanning-node.yml" \
--  "${TARGET_ROOT}/.github/workflows/build-and-publish.yml" \
--  "${TARGET_ROOT}/runtime/ghcr/009-order-management-matcher/README.md" \
--  "${TARGET_ROOT}/runtime/ghcr/009-order-management-matcher/images.lock" \
--  "${TARGET_ROOT}/runtime/ghcr/009-order-management-matcher/docker-compose.ghcr.yml" \
--  "${TARGET_ROOT}/runtime/deploy/aws-ec2-compose/README.md" \
--  "${TARGET_ROOT}/runtime/deploy/aws-ec2-compose/deploy.sh" \
--  "${TARGET_ROOT}/runtime/deploy/aws-ec2-compose/upgrade.sh" \
--  "${TARGET_ROOT}/runtime/deploy/aws-ec2-compose/cleanup.sh" \
--  "${TARGET_ROOT}/runtime/deploy/aws-ec2-compose/nginx.reverse-proxy.snippet.conf"; do
--  [[ -f "${required}" ]] || {
--    echo "[fail] missing convergence CI artifact: ${required}"
--    exit 1
--  }
--done
--
--grep -q 'IMAGE_NAMESPACE: traderx-c2' "${TARGET_ROOT}/.github/workflows/build-and-publish.yml" || {
--  echo "[fail] convergence namespace traderx-c2 not found in build-and-publish workflow"
--  exit 1
--}
--
--grep -q 'GHCR_PUSH_TOKEN' "${TARGET_ROOT}/.github/workflows/build-and-publish.yml" || {
--  echo "[fail] build-and-publish workflow should support GHCR_PUSH_TOKEN fallback auth"
--  exit 1
--}
--
--if grep -q 'directory: api-explorer' "${TARGET_ROOT}/.github/workflows/build-and-publish.yml"; then
--  echo "[fail] api-explorer should not be included in generated container CI matrix"
--  exit 1
--fi
--
--grep -q 'ghcr.io/finos/traderx-c2' "${TARGET_ROOT}/runtime/ghcr/009-order-management-matcher/images.lock" || {
--  echo "[fail] ghcr namespace mapping missing from images.lock"
--  exit 1
--}
--
--grep -q -- '--dry-run' "${TARGET_ROOT}/runtime/deploy/aws-ec2-compose/deploy.sh" || {
--  echo "[fail] deploy bundle should support --dry-run"
--  exit 1
--}
--
--grep -q -- '--use-ghcr' "${TARGET_ROOT}/runtime/deploy/aws-ec2-compose/deploy.sh" || {
--  echo "[fail] deploy bundle should support --use-ghcr"
--  exit 1
--}
--
--grep -q 'TRADERX_GHCR_COMPOSE_PATH_REL' "${TARGET_ROOT}/runtime/deploy/aws-ec2-compose/deploy.sh" || {
--  echo "[fail] deploy bundle should support GHCR compose path override"
--  exit 1
--}
--
--if rg -qi 'token|password' "${TARGET_ROOT}/runtime/deploy/aws-ec2-compose/deploy.sh"; then
--  echo "[fail] deploy bundle should not embed credentials/tokens"
--  exit 1
--fi
--
--echo "[check] generated-state contract validation guards order-matcher schema"
--mkdir -p "${TARGET_ROOT}/order-matcher" "${TARGET_ROOT}/database" "${TARGET_ROOT}/ci"
--cat > "${TARGET_ROOT}/ci/state-metadata.json" <<'EOF'
--{
--  "stateId": "009-order-management-matcher"
--}
--EOF
--cat > "${TARGET_ROOT}/database/initialSchema.sql" <<'EOF'
--CREATE TABLE Accounts (ID INTEGER PRIMARY KEY);
--EOF
--if bash "${ROOT}/pipeline/validate-generated-state-contracts.sh" "${TARGET_ROOT}" >/dev/null 2>&1; then
--  echo "[fail] contract validator should fail when OrderBook table is missing"
--  exit 1
--fi
--cat > "${TARGET_ROOT}/database/initialSchema.sql" <<'EOF'
--CREATE TABLE Accounts (ID INTEGER PRIMARY KEY);
--CREATE TABLE OrderBook (
--  OrderId VARCHAR(32) PRIMARY KEY,
--  Status VARCHAR(24)
--);
--EOF
--bash "${ROOT}/pipeline/validate-generated-state-contracts.sh" "${TARGET_ROOT}" >/dev/null
--
--echo "[check] template Node.js packages declare Apache-2.0"
--while IFS= read -r pkg; do
--  license="$(jq -r '.license // empty' "${pkg}")"
--  if [[ "${license}" != "Apache-2.0" ]]; then
--    echo "[fail] Node template package license must be Apache-2.0: ${pkg} (found: ${license:-<missing>})"
--    exit 1
--  fi
--done < <(find "${ROOT}/templates" -type d -name node_modules -prune -o -name package.json -print | sort)
--
--echo "[done] generated CI assets checks passed"
-diff --git a/scripts/test-generated-runtime-harness.sh b/scripts/test-generated-runtime-harness.sh
-deleted file mode 100755
-index 2209407..0000000
---- a/scripts/test-generated-runtime-harness.sh
-+++ /dev/null
-@@ -1,75 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--TMP_DIR="$(mktemp -d /tmp/traderx-runtime-harness.XXXXXX)"
--trap 'rm -rf "${TMP_DIR}"' EXIT
--
--TARGET_ROOT="${TMP_DIR}/generated/code/target-generated"
--mkdir -p "${TARGET_ROOT}/containerized-compose" "${TARGET_ROOT}/web-front-end/angular"
--touch "${TARGET_ROOT}/containerized-compose/docker-compose.yml"
--
--echo "[check] install harness into synthetic target-generated root"
--bash "${ROOT}/pipeline/install-generated-runtime-harness.sh" 004-containerized-compose-runtime "${TARGET_ROOT}"
--
--for required in \
--  "${TARGET_ROOT}/scripts/start-state-004-containerized-generated.sh" \
--  "${TARGET_ROOT}/scripts/stop-state-004-containerized-generated.sh" \
--  "${TARGET_ROOT}/scripts/status-state-004-containerized-generated.sh" \
--  "${TARGET_ROOT}/scripts/lib/generated-state-detection.sh" \
--  "${TARGET_ROOT}/scripts/README.runtime-harness.md" \
--  "${TARGET_ROOT}/RUN_FROM_GENERATED.md"; do
--  [[ -f "${required}" ]] || {
--    echo "[fail] missing generated harness artifact: ${required}"
--    exit 1
--  }
--done
--
--echo "[check] local harness scripts are marked local + skip-generate"
--grep -q '^export TRADERX_LOCAL_RUNTIME_SCRIPT=1$' "${TARGET_ROOT}/scripts/start-state-004-containerized-generated.sh"
--grep -q '^export TRADERX_SKIP_GENERATE=1$' "${TARGET_ROOT}/scripts/start-state-004-containerized-generated.sh"
--grep -q 'TRADERX_GENERATED_ROOT="\$(cd "\$(dirname "\${BASH_SOURCE\[0\]}")/../../.." && pwd)"' "${TARGET_ROOT}/scripts/start-state-004-containerized-generated.sh"
--grep -q './scripts/start-state-004-containerized-generated.sh' "${TARGET_ROOT}/RUN_FROM_GENERATED.md"
--
--echo "[check] root wrapper forwards execution to local harness when present"
--cat > "${TARGET_ROOT}/scripts/status-base-uncontainerized-generated.sh" <<'EOF'
--#!/usr/bin/env bash
--set -euo pipefail
--echo "[ok] forwarded-to-local-runtime-harness"
--EOF
--chmod +x "${TARGET_ROOT}/scripts/status-base-uncontainerized-generated.sh"
--
--forward_output="$(
--  TRADERX_GENERATED_ROOT="${TMP_DIR}/generated" \
--    bash "${ROOT}/scripts/status-base-uncontainerized-generated.sh"
--)"
--
--printf '%s\n' "${forward_output}" | grep -q "forwarded-to-local-runtime-harness" || {
--  echo "[fail] root script did not forward to local runtime harness"
--  exit 1
--}
--
--echo "[check] state 003 harness emits generated metadata docs"
--bash "${ROOT}/pipeline/install-generated-runtime-harness.sh" 003-agentic-harness-foundation "${TARGET_ROOT}"
--
--for required in \
--  "${TARGET_ROOT}/AGENTS.md" \
--  "${TARGET_ROOT}/ARCHITECTURE.md" \
--  "${TARGET_ROOT}/CONTRIBUTING.md"; do
--  [[ -f "${required}" ]] || {
--    echo "[fail] missing generated metadata artifact: ${required}"
--    exit 1
--  }
--done
--
--grep -q 'specs/' "${TARGET_ROOT}/CONTRIBUTING.md"
--grep -qi 'generated snapshots are outputs' "${TARGET_ROOT}/CONTRIBUTING.md"
--
--echo "[done] generated runtime harness checks passed"
-diff --git a/scripts/test-messaging-008-pricing-awareness-market-data.sh b/scripts/test-messaging-008-pricing-awareness-market-data.sh
-deleted file mode 100755
-index 25c6e00..0000000
---- a/scripts/test-messaging-008-pricing-awareness-market-data.sh
-+++ /dev/null
-@@ -1,269 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--INGRESS_URL="${1:-http://localhost:8080}"
--TRADE_SERVICE_URL="${2:-http://localhost:18092}"
--ACCOUNT_ID="${3:-22214}"
--SUBJECT_MAP_FILE="${4:-specs/008-pricing-awareness-market-data/system/messaging-subject-map.md}"
--TIMEOUT_MS="${TIMEOUT_MS:-20000}"
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--WORKSPACE_ROOT="$(git -C "${REPO_ROOT}" rev-parse --show-toplevel 2>/dev/null || printf '%s' "${REPO_ROOT}")"
--
--resolve_subject_map_path() {
--  local candidate="$1"
--  if [[ -f "${candidate}" ]]; then
--    echo "${candidate}"
--    return
--  fi
--  if [[ -f "${REPO_ROOT}/${candidate}" ]]; then
--    echo "${REPO_ROOT}/${candidate}"
--    return
--  fi
--  if [[ -f "${WORKSPACE_ROOT}/${candidate}" ]]; then
--    echo "${WORKSPACE_ROOT}/${candidate}"
--    return
--  fi
--  echo "${WORKSPACE_ROOT}/${candidate}"
--}
--
--warn_uncovered_subjects() {
--  local map_file="$1"
--  shift
--  local covered=("$@")
--  local uncovered=0
--
--  if [[ ! -f "${map_file}" ]]; then
--    echo "[warn] subject map not found for coverage warnings: ${map_file}"
--    return 0
--  fi
--
--  while IFS= read -r subject; do
--    local is_covered=0
--    for pattern in "${covered[@]}"; do
--      if [[ "${subject}" == "${pattern}" ]]; then
--        is_covered=1
--        break
--      fi
--    done
--    if [[ "${is_covered}" -eq 0 ]]; then
--      echo "[warn] SUBJECT_WITHOUT_TRIGGER_COVERAGE: ${subject}"
--      uncovered=$((uncovered + 1))
--    fi
--  done < <(sed -n 's/^- `\([^`]*\)`.*/\1/p' "${map_file}")
--
--  if [[ "${uncovered}" -eq 0 ]]; then
--    echo "[info] subject map coverage warnings: none"
--  fi
--}
--
--echo "[check] message bus websocket reachability pre-check"
--INGRESS_URL="${INGRESS_URL}" TIMEOUT_MS="${TIMEOUT_MS}" node <<'NODE'
--const ingressUrl = process.env.INGRESS_URL || 'http://localhost:8080';
--const timeoutMs = Number(process.env.TIMEOUT_MS || '20000');
--const wsUrl = ingressUrl.replace(/^http/i, 'ws') + '/nats-ws';
--
--if (typeof WebSocket !== 'function') {
--  console.error('[error] MESSAGE_BUS_UNREACHABLE: global WebSocket unavailable in this Node runtime');
--  process.exit(31);
--}
--
--const ws = new WebSocket(wsUrl);
--const timer = setTimeout(() => {
--  console.error(`[error] MESSAGE_BUS_UNREACHABLE: timeout connecting to ${wsUrl}`);
--  process.exit(31);
--}, Math.min(timeoutMs, 8000));
--
--ws.onopen = () => {
--  clearTimeout(timer);
--  ws.close();
--  console.log('[info] message bus websocket reachable');
--  process.exit(0);
--};
--
--ws.onerror = () => {
--  clearTimeout(timer);
--  console.error(`[error] MESSAGE_BUS_UNREACHABLE: websocket error for ${wsUrl}`);
--  process.exit(31);
--};
--NODE
--
--warn_uncovered_subjects \
--  "$(resolve_subject_map_path "${SUBJECT_MAP_FILE}")" \
--  "/trades" \
--  "/accounts/<accountId>/trades" \
--  "/accounts/<accountId>/positions" \
--  "pricing.<TICKER>"
--
--echo "[check] messaging flow assertions for state 008 subject map"
--INGRESS_URL="${INGRESS_URL}" \
--TRADE_SERVICE_URL="${TRADE_SERVICE_URL}" \
--ACCOUNT_ID="${ACCOUNT_ID}" \
--TIMEOUT_MS="${TIMEOUT_MS}" node <<'NODE'
--const ingressUrl = process.env.INGRESS_URL || 'http://localhost:8080';
--const tradeServiceUrl = process.env.TRADE_SERVICE_URL || 'http://localhost:18092';
--const accountId = Number(process.env.ACCOUNT_ID || '22214');
--const timeoutMs = Number(process.env.TIMEOUT_MS || '20000');
--const wsUrl = ingressUrl.replace(/^http/i, 'ws') + '/nats-ws';
--const security = 'IBM';
--const qty = 7000 + Math.floor(Math.random() * 500);
--
--const subjectExpectations = {
--  '/trades': (payload) => payload && payload.security === security && Number(payload.quantity) === qty && Number.isFinite(Number(payload.price)),
--  [`/accounts/${accountId}/trades`]: (payload) => payload && payload.security === security && Number(payload.quantity) === qty && payload.state === 'Settled',
--  [`/accounts/${accountId}/positions`]: (payload) => payload && payload.security === security && Number.isFinite(Number(payload.quantity)),
--  [`pricing.${security}`]: (payload) => payload && payload.ticker === security && Number.isFinite(Number(payload.price)) && Number.isFinite(Number(payload.openPrice)) && Number.isFinite(Number(payload.closePrice)),
--};
--
--if (typeof WebSocket !== 'function') {
--  console.error('[error] MESSAGE_BUS_UNREACHABLE: global WebSocket unavailable in this Node runtime');
--  process.exit(31);
--}
--
--let buffer = '';
--let pending = null;
--let submitted = false;
--const matched = new Set();
--const sidByTopic = new Map(Object.keys(subjectExpectations).map((topic, idx) => [topic, idx + 1]));
--
--function fail(code, message) {
--  console.error(`[error] ${code}: ${message}`);
--  process.exit(1);
--}
--
--function maybeDone() {
--  if (matched.size === Object.keys(subjectExpectations).length) {
--    console.log(`[info] messaging subjects validated: ${Array.from(matched).sort().join(', ')}`);
--    process.exit(0);
--  }
--}
--
--function handlePayload(subject, payload) {
--  const validator = subjectExpectations[subject];
--  if (!validator) {
--    return;
--  }
--  if (validator(payload)) {
--    matched.add(subject);
--    maybeDone();
--  }
--}
--
--function parseFrame(text, ws) {
--  buffer += text;
--  while (true) {
--    if (pending) {
--      const needed = pending.bytes + 2;
--      if (buffer.length < needed) {
--        return;
--      }
--      const payloadText = buffer.slice(0, pending.bytes);
--      buffer = buffer.slice(needed);
--      try {
--        const parsed = JSON.parse(payloadText);
--        const payload = parsed && typeof parsed === 'object' && parsed.payload ? parsed.payload : parsed;
--        handlePayload(pending.subject, payload);
--      } catch (_) {
--        // ignore non-json
--      }
--      pending = null;
--      continue;
--    }
--
--    const eol = buffer.indexOf('\r\n');
--    if (eol < 0) {
--      return;
--    }
--    const line = buffer.slice(0, eol);
--    buffer = buffer.slice(eol + 2);
--    if (!line) {
--      continue;
--    }
--    if (line.startsWith('PING')) {
--      ws.send('PONG\r\n');
--      continue;
--    }
--    if (line.startsWith('INFO') || line.startsWith('PONG')) {
--      continue;
--    }
--    if (line.startsWith('MSG ')) {
--      const parts = line.split(' ');
--      if (parts.length < 4) {
--        continue;
--      }
--      const subject = parts[1];
--      const bytes = Number(parts[parts.length - 1]);
--      if (!Number.isFinite(bytes)) {
--        continue;
--      }
--      pending = { subject, bytes };
--    }
--  }
--}
--
--async function submitTrade() {
--  if (submitted) return;
--  submitted = true;
--  const response = await fetch(`${tradeServiceUrl}/trade/`, {
--    method: 'POST',
--    headers: { 'Content-Type': 'application/json' },
--    body: JSON.stringify({ security, quantity: qty, accountId, side: 'Buy' }),
--  });
--  if (response.status !== 200) {
--    const body = await response.text();
--    fail('NO_MESSAGE_RECEIVED_ON_SUBJECT', `trade submit failed status=${response.status} body=${body}`);
--  }
--}
--
--const ws = new WebSocket(wsUrl);
--const timer = setTimeout(() => {
--  const missing = Object.keys(subjectExpectations).filter((subject) => !matched.has(subject));
--  fail('NO_MESSAGE_RECEIVED_ON_SUBJECT', `timed out; missing subjects: ${missing.join(', ')}`);
--}, timeoutMs);
--
--ws.onopen = async () => {
--  ws.send('CONNECT {"protocol":1,"verbose":false,"pedantic":false,"echo":false}\r\n');
--  for (const [topic, sid] of sidByTopic.entries()) {
--    ws.send(`SUB ${topic} ${sid}\r\n`);
--  }
--  ws.send('PING\r\n');
--  try {
--    await submitTrade();
--  } catch (err) {
--    clearTimeout(timer);
--    fail('NO_MESSAGE_RECEIVED_ON_SUBJECT', err.message);
--  }
--};
--
--ws.onmessage = async (event) => {
--  if (typeof event.data === 'string') {
--    parseFrame(event.data, ws);
--    return;
--  }
--  if (event.data instanceof Blob) {
--    parseFrame(await event.data.text(), ws);
--    return;
--  }
--  if (event.data instanceof ArrayBuffer) {
--    parseFrame(new TextDecoder().decode(new Uint8Array(event.data)), ws);
--  }
--};
--
--ws.onerror = () => {
--  clearTimeout(timer);
--  fail('MESSAGE_BUS_UNREACHABLE', `websocket error while connected to ${wsUrl}`);
--};
--
--process.on('exit', () => {
--  clearTimeout(timer);
--  try { ws.close(); } catch (_) {}
--});
--NODE
--
--echo "[done] state 008 messaging smoke tests passed"
-diff --git a/scripts/test-messaging-009-order-management-matcher.sh b/scripts/test-messaging-009-order-management-matcher.sh
-deleted file mode 100755
-index 2455327..0000000
---- a/scripts/test-messaging-009-order-management-matcher.sh
-+++ /dev/null
-@@ -1,129 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--INGRESS_URL="${1:-http://localhost:8080}"
--TRADE_SERVICE_URL="${2:-http://localhost:18092}"
--ACCOUNT_ID="${3:-22214}"
--ADMIN_ACCOUNT_ID="${4:-44044}"
--SUBJECT_MAP_FILE="${5:-specs/009-order-management-matcher/system/messaging-subject-map.md}"
--TIMEOUT_MS="${TIMEOUT_MS:-35000}"
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--WORKSPACE_ROOT="$(git -C "${REPO_ROOT}" rev-parse --show-toplevel 2>/dev/null || printf '%s' "${REPO_ROOT}")"
--
--resolve_subject_map_path() {
--  local candidate="$1"
--  if [[ -f "${candidate}" ]]; then
--    echo "${candidate}"
--    return
--  fi
--  if [[ -f "${REPO_ROOT}/${candidate}" ]]; then
--    echo "${REPO_ROOT}/${candidate}"
--    return
--  fi
--  if [[ -f "${WORKSPACE_ROOT}/${candidate}" ]]; then
--    echo "${WORKSPACE_ROOT}/${candidate}"
--    return
--  fi
--  echo "${WORKSPACE_ROOT}/${candidate}"
--}
--
--warn_uncovered_subjects() {
--  local map_file="$1"
--  shift
--  local covered=("$@")
--  local uncovered=0
--
--  if [[ ! -f "${map_file}" ]]; then
--    echo "[warn] subject map not found for coverage warnings: ${map_file}"
--    return 0
--  fi
--
--  while IFS= read -r subject; do
--    local is_covered=0
--    for pattern in "${covered[@]}"; do
--      if [[ "${subject}" == "${pattern}" ]]; then
--        is_covered=1
--        break
--      fi
--    done
--    if [[ "${is_covered}" -eq 0 ]]; then
--      echo "[warn] SUBJECT_WITHOUT_TRIGGER_COVERAGE: ${subject}"
--      uncovered=$((uncovered + 1))
--    fi
--  done < <(sed -n 's/^- `\([^`]*\)`.*/\1/p' "${map_file}")
--
--  if [[ "${uncovered}" -eq 0 ]]; then
--    echo "[info] subject map coverage warnings: none"
--  fi
--}
--
--echo "[check] message bus websocket reachability pre-check"
--INGRESS_URL="${INGRESS_URL}" TIMEOUT_MS="${TIMEOUT_MS}" node <<'NODE'
--const ingressUrl = process.env.INGRESS_URL || 'http://localhost:8080';
--const timeoutMs = Number(process.env.TIMEOUT_MS || '35000');
--const wsUrl = ingressUrl.replace(/^http/i, 'ws') + '/nats-ws';
--
--if (typeof WebSocket !== 'function') {
--  console.error('[error] MESSAGE_BUS_UNREACHABLE: global WebSocket unavailable in this Node runtime');
--  process.exit(31);
--}
--
--const ws = new WebSocket(wsUrl);
--const timer = setTimeout(() => {
--  console.error(`[error] MESSAGE_BUS_UNREACHABLE: timeout connecting to ${wsUrl}`);
--  process.exit(31);
--}, Math.min(timeoutMs, 8000));
--
--ws.onopen = () => {
--  clearTimeout(timer);
--  ws.close();
--  console.log('[info] message bus websocket reachable');
--  process.exit(0);
--};
--
--ws.onerror = () => {
--  clearTimeout(timer);
--  console.error(`[error] MESSAGE_BUS_UNREACHABLE: websocket error for ${wsUrl}`);
--  process.exit(31);
--};
--NODE
--
--warn_uncovered_subjects \
--  "$(resolve_subject_map_path "${SUBJECT_MAP_FILE}")" \
--  "/trades" \
--  "/accounts/<accountId>/trades" \
--  "/accounts/<accountId>/positions" \
--  "pricing.<TICKER>" \
--  "/accounts/<accountId>/orders" \
--  "/orders"
--
--echo "[check] messaging flow assertions for state 009 subject map"
--if ! TRADERX_LOCAL_RUNTIME_SCRIPT=1 TIMEOUT_MS="${TIMEOUT_MS}" \
--  "${REPO_ROOT}/scripts/test-messaging-008-pricing-awareness-market-data.sh" \
--  "${INGRESS_URL}" "${TRADE_SERVICE_URL}" "${ACCOUNT_ID}"; then
--  echo "[error] NO_MESSAGE_RECEIVED_ON_SUBJECT: baseline trade/position/pricing messaging assertions failed"
--  exit 1
--fi
--
--if ! TRADERX_LOCAL_RUNTIME_SCRIPT=1 TIMEOUT_MS="${TIMEOUT_MS}" \
--  "${REPO_ROOT}/scripts/test-order-create-pubsub-smoke.sh" \
--  "${INGRESS_URL}" "${ACCOUNT_ID}"; then
--  echo "[error] NO_MESSAGE_RECEIVED_ON_SUBJECT: missing NEW order publish events on /accounts/<accountId>/orders or /orders"
--  exit 1
--fi
--
--if ! TRADERX_LOCAL_RUNTIME_SCRIPT=1 TIMEOUT_MS="${TIMEOUT_MS}" \
--  "${REPO_ROOT}/scripts/test-realtime-order-stream-overlay.sh" \
--  "${INGRESS_URL}" "${ACCOUNT_ID}" "${ADMIN_ACCOUNT_ID}"; then
--  echo "[error] NO_MESSAGE_RECEIVED_ON_SUBJECT: missing FILLED/PARTIALLY_FILLED order stream events or dependent trade/position events"
--  exit 1
--fi
--
--echo "[done] state 009 messaging smoke tests passed"
-diff --git a/scripts/test-order-create-pubsub-smoke.sh b/scripts/test-order-create-pubsub-smoke.sh
-deleted file mode 100755
-index 6cd670a..0000000
---- a/scripts/test-order-create-pubsub-smoke.sh
-+++ /dev/null
-@@ -1,274 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--INGRESS_URL="${1:-http://localhost:8080}"
--ACCOUNT_ID="${2:-22214}"
--TIMEOUT_MS="${TIMEOUT_MS:-20000}"
--
--echo "[check] order create emits realtime events on account + /orders topics"
--INGRESS_URL="${INGRESS_URL}" \
--ACCOUNT_ID="${ACCOUNT_ID}" \
--TIMEOUT_MS="${TIMEOUT_MS}" node <<'NODE'
--const ingressUrl = process.env.INGRESS_URL || 'http://localhost:8080';
--const accountId = Number(process.env.ACCOUNT_ID || '22214');
--const timeoutMs = Number(process.env.TIMEOUT_MS || '20000');
--const wsUrl = ingressUrl.replace(/^http/i, 'ws') + '/nats-ws';
--
--if (typeof WebSocket !== 'function') {
--  console.error('[error] global WebSocket is unavailable in this Node runtime');
--  process.exit(1);
--}
--
--const accountOrdersTopic = `/accounts/${accountId}/orders`;
--const allOrdersTopic = '/orders';
--
--let expectedOrderId = null;
--let seenAccountCreate = false;
--let seenAllCreate = false;
--const accountNewOrderIds = new Set();
--const allNewOrderIds = new Set();
--let buffer = '';
--let pending = null;
--let closed = false;
--let settled = false;
--
--function fail(message) {
--  if (settled) {
--    return;
--  }
--  settled = true;
--  console.error(`[error] ${message}`);
--  process.exit(1);
--}
--
--function pass(message) {
--  if (settled) {
--    return;
--  }
--  settled = true;
--  console.log(`[info] ${message}`);
--  process.exit(0);
--}
--
--function maybeDone() {
--  if (expectedOrderId && seenAccountCreate && seenAllCreate) {
--    pass(`order ${expectedOrderId} published on ${accountOrdersTopic} and ${allOrdersTopic}`);
--  }
--}
--
--function parsePayload(payloadText) {
--  try {
--    const parsed = JSON.parse(payloadText);
--    if (parsed && typeof parsed === 'object' && parsed.payload) {
--      return parsed.payload;
--    }
--    return parsed;
--  } catch (err) {
--    return null;
--  }
--}
--
--function handleMessage(subject, payload) {
--  if (!payload || typeof payload !== 'object') {
--    return;
--  }
--
--  const orderId = String(payload.orderId || '');
--  if (!orderId || payload.status !== 'NEW') {
--    return;
--  }
--
--  if (subject === accountOrdersTopic) {
--    accountNewOrderIds.add(orderId);
--  }
--  if (subject === allOrdersTopic) {
--    allNewOrderIds.add(orderId);
--  }
--
--  if (!expectedOrderId) {
--    return;
--  }
--
--  if (orderId !== expectedOrderId) {
--    return;
--  }
--
--  if (subject === accountOrdersTopic) {
--    seenAccountCreate = true;
--  }
--  if (subject === allOrdersTopic) {
--    seenAllCreate = true;
--  }
--
--  maybeDone();
--}
--
--function parseFrameChunk(chunk, ws) {
--  buffer += chunk;
--
--  while (true) {
--    if (pending) {
--      const needed = pending.bytes + 2;
--      if (buffer.length < needed) {
--        return;
--      }
--      const payloadText = buffer.slice(0, pending.bytes);
--      buffer = buffer.slice(needed);
--      const payload = parsePayload(payloadText);
--      handleMessage(pending.subject, payload);
--      pending = null;
--      continue;
--    }
--
--    const eol = buffer.indexOf('\r\n');
--    if (eol < 0) {
--      return;
--    }
--
--    const line = buffer.slice(0, eol);
--    buffer = buffer.slice(eol + 2);
--    if (!line) {
--      continue;
--    }
--
--    if (line.startsWith('PING')) {
--      ws.send('PONG\r\n');
--      continue;
--    }
--
--    if (line.startsWith('INFO') || line.startsWith('PONG')) {
--      continue;
--    }
--
--    if (line.startsWith('MSG ')) {
--      const parts = line.split(' ');
--      if (parts.length < 4) {
--        continue;
--      }
--      const subject = parts[1];
--      const bytes = Number(parts[parts.length - 1]);
--      if (!Number.isFinite(bytes)) {
--        continue;
--      }
--      pending = { subject, bytes };
--    }
--  }
--}
--
--async function requestJson(path, options, expectedStatus) {
--  const response = await fetch(`${ingressUrl}${path}`, options);
--  const text = await response.text();
--  let body = {};
--  try {
--    body = text ? JSON.parse(text) : {};
--  } catch (err) {
--    fail(`invalid JSON response for ${path}: ${text}`);
--  }
--  if (response.status !== expectedStatus) {
--    fail(`expected ${expectedStatus} from ${path}, got ${response.status}; body=${text}`);
--  }
--  return body;
--}
--
--async function main() {
--  const ws = new WebSocket(wsUrl);
--
--  const connectTimer = setTimeout(() => {
--    if (!closed) {
--      fail(`timeout connecting to ${wsUrl}`);
--    }
--  }, 8000);
--
--  ws.onopen = async () => {
--    clearTimeout(connectTimer);
--
--    ws.send('CONNECT {"protocol":1,"verbose":false,"pedantic":false,"echo":false}\r\n');
--    ws.send(`SUB ${accountOrdersTopic} 1\r\n`);
--    ws.send(`SUB ${allOrdersTopic} 2\r\n`);
--    ws.send('PING\r\n');
--
--    const uniqueQty = Math.floor(Math.random() * 1000) + 1;
--    const createPayload = {
--      accountId,
--      security: 'IBM',
--      side: 'Buy',
--      quantity: uniqueQty,
--      limitPrice: 188.125
--    };
--
--    const createOrder = await requestJson(
--      '/order-matcher/orders',
--      {
--        method: 'POST',
--        headers: { 'Content-Type': 'application/json' },
--        body: JSON.stringify(createPayload)
--      },
--      201
--    );
--
--    expectedOrderId = String(createOrder.orderId || '');
--    if (!expectedOrderId) {
--      fail('create order response missing orderId');
--    }
--
--    seenAccountCreate = accountNewOrderIds.has(expectedOrderId);
--    seenAllCreate = allNewOrderIds.has(expectedOrderId);
--    maybeDone();
--  };
--
--  ws.onmessage = async (event) => {
--    try {
--      if (typeof event.data === 'string') {
--        parseFrameChunk(event.data, ws);
--        return;
--      }
--      if (event.data instanceof Blob) {
--        parseFrameChunk(await event.data.text(), ws);
--        return;
--      }
--      if (event.data instanceof ArrayBuffer) {
--        parseFrameChunk(new TextDecoder().decode(new Uint8Array(event.data)), ws);
--        return;
--      }
--      if (ArrayBuffer.isView(event.data)) {
--        parseFrameChunk(
--          new TextDecoder().decode(
--            new Uint8Array(event.data.buffer, event.data.byteOffset, event.data.byteLength)
--          ),
--          ws
--        );
--      }
--    } catch (err) {
--      fail(`failed parsing websocket frame: ${err instanceof Error ? err.message : String(err)}`);
--    }
--  };
--
--  ws.onerror = () => {
--    fail(`websocket error while connected to ${wsUrl}`);
--  };
--
--  ws.onclose = () => {
--    closed = true;
--    if (!settled) {
--      fail('websocket closed before required events were observed');
--    }
--  };
--
--  setTimeout(() => {
--    if (!settled) {
--      fail(`timeout waiting for NEW order publish on ${accountOrdersTopic} and ${allOrdersTopic}`);
--    }
--  }, timeoutMs);
--}
--
--main().catch((err) => fail(err instanceof Error ? err.message : String(err)));
--NODE
--
--echo "[done] order create realtime publish smoke passed"
-diff --git a/scripts/test-people-service-overlay.sh b/scripts/test-people-service-overlay.sh
-deleted file mode 100755
-index b9ec7cf..0000000
---- a/scripts/test-people-service-overlay.sh
-+++ /dev/null
-@@ -1,72 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--ORIGIN="${1:-http://localhost:18093}"
--BASE_URL="${2:-http://localhost:18089}"
--ACCOUNT_USER_URL="${3:-http://localhost:18088/accountuser/}"
--REQUEST_ORIGIN="$(echo "${BASE_URL}" | sed -E 's#^(https?://[^/]+).*$#\1#')"
--NORMALIZED_ORIGIN="${ORIGIN%/}"
--NORMALIZED_REQUEST_ORIGIN="${REQUEST_ORIGIN%/}"
--
--echo "[check] CORS header from ${BASE_URL}/People/GetMatchingPeople for origin ${ORIGIN}"
--headers="$(curl -sS -i -H "Origin: ${ORIGIN}" "${BASE_URL}/People/GetMatchingPeople?SearchText=user&Take=1" | sed -n '1,30p')"
--echo "${headers}"
--
--cors_header="$(printf '%s\n' "${headers}" | awk -F': ' 'tolower($1)=="access-control-allow-origin" {print $2}' | tr -d '\r' || true)"
--if [[ -z "${cors_header}" ]]; then
--  if [[ "${NORMALIZED_ORIGIN}" == "${NORMALIZED_REQUEST_ORIGIN}" ]]; then
--    echo "[info] Access-Control-Allow-Origin header omitted for same-origin request (${NORMALIZED_ORIGIN}); continuing"
--  else
--    echo "[error] missing Access-Control-Allow-Origin header"
--    exit 1
--  fi
--fi
--
--if [[ -n "${cors_header}" && "${cors_header}" != "*" && "${cors_header}" != "${ORIGIN}" ]]; then
--  echo "[error] unexpected Access-Control-Allow-Origin value: ${cors_header}"
--  exit 1
--fi
--
--echo "[check] known person lookup"
--person_json="$(curl -sS "${BASE_URL}/People/GetPerson?LogonId=user01")"
--echo "${person_json}" | jq
--logon_id="$(echo "${person_json}" | jq -r '.logonId')"
--if [[ "${logon_id}" != "user01" ]]; then
--  echo "[error] expected logonId=user01, got ${logon_id}"
--  exit 1
--fi
--
--echo "[check] matching people response shape"
--matching_json="$(curl -sS "${BASE_URL}/People/GetMatchingPeople?SearchText=user&Take=5")"
--echo "${matching_json}" | jq
--matching_count="$(echo "${matching_json}" | jq '.people | length')"
--if [[ "${matching_count}" -lt 1 ]]; then
--  echo "[error] expected at least one matching person, got ${matching_count}"
--  exit 1
--fi
--
--echo "[check] validate known person"
--known_validate_http_code="$(curl -sS -o /tmp/people-service-validate-known.out -w "%{http_code}" "${BASE_URL}/People/ValidatePerson?LogonId=user01")"
--if [[ "${known_validate_http_code}" != "200" ]]; then
--  echo "[error] expected 200 for known validation, got ${known_validate_http_code}"
--  exit 1
--fi
--
--echo "[check] unknown person returns 404"
--unknown_http_code="$(curl -sS -o /tmp/people-service-404.out -w "%{http_code}" "${BASE_URL}/People/GetPerson?LogonId=DOES_NOT_EXIST")"
--if [[ "${unknown_http_code}" != "404" ]]; then
--  echo "[error] expected 404 for unknown person lookup, got ${unknown_http_code}"
--  exit 1
--fi
--
--echo "[check] account-service accountuser endpoint still reachable"
--curl -sS -i "${ACCOUNT_USER_URL}" | sed -n '1,20p'
--
--echo "[done] people-service overlay smoke tests passed"
-diff --git a/scripts/test-position-blotter-upsert-contract.sh b/scripts/test-position-blotter-upsert-contract.sh
-deleted file mode 100755
-index 571885f..0000000
---- a/scripts/test-position-blotter-upsert-contract.sh
-+++ /dev/null
-@@ -1,45 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--WEB_ROOT="${1:-${GENERATED_ROOT}/code/target-generated/web-front-end/angular}"
--if [[ ! -d "${WEB_ROOT}" ]]; then
--  ALT_WEB_ROOT="${GENERATED_ROOT}/code/components/web-front-end-angular-specfirst"
--  if [[ -d "${ALT_WEB_ROOT}" ]]; then
--    WEB_ROOT="${ALT_WEB_ROOT}"
--  fi
--fi
--POSITION_BLOTTER_TS="${WEB_ROOT}/main/app/trade/position-blotter/position-blotter.component.ts"
--
--if [[ ! -f "${POSITION_BLOTTER_TS}" ]]; then
--  echo "[error] position blotter source not found: ${POSITION_BLOTTER_TS}"
--  exit 1
--fi
--
--echo "[check] position blotter realtime upsert contract"
--if ! grep -Eq "getRowNode\\(this\\.toRowId\\(security\\)\\)" "${POSITION_BLOTTER_TS}"; then
--  echo "[error] expected in-place row lookup by position row-id key"
--  exit 1
--fi
--
--if ! grep -Eq "return this\\.toRowId\\(params\\.data\\.security\\);" "${POSITION_BLOTTER_TS}"; then
--  echo "[error] expected getRowId to use the same row-id key strategy"
--  exit 1
--fi
--
--echo "[done] position blotter upsert contract check passed"
-diff --git a/scripts/test-position-service-overlay.sh b/scripts/test-position-service-overlay.sh
-deleted file mode 100755
-index ce8e2ad..0000000
---- a/scripts/test-position-service-overlay.sh
-+++ /dev/null
-@@ -1,68 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--ORIGIN="${1:-http://localhost:18093}"
--BASE_URL="${2:-http://localhost:18090}"
--REQUEST_ORIGIN="$(echo "${BASE_URL}" | sed -E 's#^(https?://[^/]+).*$#\1#')"
--NORMALIZED_ORIGIN="${ORIGIN%/}"
--NORMALIZED_REQUEST_ORIGIN="${REQUEST_ORIGIN%/}"
--
--echo "[check] CORS header from ${BASE_URL}/positions/22214 for origin ${ORIGIN}"
--headers="$(curl -sS -i -H "Origin: ${ORIGIN}" "${BASE_URL}/positions/22214" | sed -n '1,30p')"
--echo "${headers}"
--
--cors_header="$(printf '%s\n' "${headers}" | awk -F': ' 'tolower($1)=="access-control-allow-origin" {print $2}' | tr -d '\r' || true)"
--if [[ -z "${cors_header}" ]]; then
--  if [[ "${NORMALIZED_ORIGIN}" == "${NORMALIZED_REQUEST_ORIGIN}" ]]; then
--    echo "[info] Access-Control-Allow-Origin header omitted for same-origin request (${NORMALIZED_ORIGIN}); continuing"
--  else
--    echo "[error] missing Access-Control-Allow-Origin header"
--    exit 1
--  fi
--fi
--
--if [[ -n "${cors_header}" && "${cors_header}" != "*" && "${cors_header}" != "${ORIGIN}" ]]; then
--  echo "[error] unexpected Access-Control-Allow-Origin value: ${cors_header}"
--  exit 1
--fi
--
--echo "[check] positions by account"
--positions_json="$(curl -sS "${BASE_URL}/positions/22214")"
--echo "${positions_json}" | jq '.[0]'
--positions_count="$(echo "${positions_json}" | jq 'length')"
--if [[ "${positions_count}" -lt 1 ]]; then
--  echo "[error] expected at least one position for account 22214"
--  exit 1
--fi
--
--echo "[check] trades by account"
--trades_json="$(curl -sS "${BASE_URL}/trades/22214")"
--echo "${trades_json}" | jq '.[0]'
--trades_count="$(echo "${trades_json}" | jq 'length')"
--if [[ "${trades_count}" -lt 1 ]]; then
--  echo "[error] expected at least one trade for account 22214"
--  exit 1
--fi
--
--echo "[check] health ready"
--ready_value="$(curl -sS "${BASE_URL}/health/ready" | jq -r '.')"
--if [[ "${ready_value}" != "true" ]]; then
--  echo "[error] expected /health/ready to be true, got ${ready_value}"
--  exit 1
--fi
--
--echo "[check] health alive"
--alive_value="$(curl -sS "${BASE_URL}/health/alive" | jq -r '.')"
--if [[ "${alive_value}" != "true" ]]; then
--  echo "[error] expected /health/alive to be true, got ${alive_value}"
--  exit 1
--fi
--
--echo "[done] position-service overlay smoke tests passed"
-diff --git a/scripts/test-realtime-account-stream-overlay.sh b/scripts/test-realtime-account-stream-overlay.sh
-deleted file mode 100755
-index 408470c..0000000
---- a/scripts/test-realtime-account-stream-overlay.sh
-+++ /dev/null
-@@ -1,123 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--TRADE_SERVICE_URL="${1:-http://localhost:18092}"
--TRADE_FEED_URL="${2:-http://localhost:18086}"
--ACCOUNT_ID="${3:-22214}"
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--DEFAULT_SOCKET_IO_CLIENT_PATH="$("${REPO_ROOT}/scripts/lib/resolve-socketio-client-path.sh")"
--
--echo "[check] realtime account stream over Socket.IO after trade submit"
--TRADE_SERVICE_URL="${TRADE_SERVICE_URL}" \
--TRADE_FEED_URL="${TRADE_FEED_URL}" \
--ACCOUNT_ID="${ACCOUNT_ID}" \
--SOCKET_IO_CLIENT_PATH="${SOCKET_IO_CLIENT_PATH:-${DEFAULT_SOCKET_IO_CLIENT_PATH}}" node <<'NODE'
--const tradeServiceUrl = process.env.TRADE_SERVICE_URL || 'http://localhost:18092';
--const tradeFeedUrl = process.env.TRADE_FEED_URL || 'http://localhost:18086';
--const accountId = Number(process.env.ACCOUNT_ID || '22214');
--const clientModulePath = process.env.SOCKET_IO_CLIENT_PATH;
--const security = 'IBM';
--const qty = 8000 + Math.floor(Math.random() * 500);
--const tradeTopic = `/accounts/${accountId}/trades`;
--const positionTopic = `/accounts/${accountId}/positions`;
--const timeoutMs = 20000;
--
--let createClient;
--try {
--  createClient = require(clientModulePath).io;
--} catch (err) {
--  try {
--    createClient = require('socket.io-client').io;
--  } catch (inner) {
--    console.error('[error] socket.io-client module not found');
--    console.error('[hint] set SOCKET_IO_CLIENT_PATH to a socket.io-client install path');
--    process.exit(1);
--  }
--}
--
--function fail(message) {
--  console.error(`[error] ${message}`);
--  process.exit(1);
--}
--
--async function waitForConnect(client, label) {
--  await Promise.race([
--    new Promise((resolve, reject) => {
--      client.on('connect', resolve);
--      client.on('connect_error', (err) => reject(new Error(`${label} connect_error: ${err.message}`)));
--    }),
--    new Promise((_, reject) => setTimeout(() => reject(new Error(`timeout: ${label} connect`)), 8000)),
--  ]);
--}
--
--async function main() {
--  let sawTrade = false;
--  let sawPosition = false;
--  const subscriber = createClient(tradeFeedUrl, { transports: ['websocket'] });
--
--  const done = () => {
--    if (sawTrade && sawPosition) {
--      console.log('[info] account trade/position realtime updates received via Socket.IO');
--      subscriber.disconnect();
--      process.exit(0);
--    }
--  };
--
--  subscriber.on('publish', (message) => {
--    if (!message || !message.topic || !message.payload) {
--      return;
--    }
--    if (
--      message.topic === tradeTopic &&
--      message.payload.security === security &&
--      Number(message.payload.quantity) === qty &&
--      message.payload.state === 'Settled'
--    ) {
--      sawTrade = true;
--    }
--    if (
--      message.topic === positionTopic &&
--      message.payload.security === security &&
--      Number.isFinite(Number(message.payload.quantity))
--    ) {
--      sawPosition = true;
--    }
--    done();
--  });
--
--  await waitForConnect(subscriber, 'subscriber');
--  subscriber.emit('subscribe', tradeTopic);
--  subscriber.emit('subscribe', positionTopic);
--
--  const response = await fetch(`${tradeServiceUrl}/trade/`, {
--    method: 'POST',
--    headers: { 'Content-Type': 'application/json' },
--    body: JSON.stringify({
--      security,
--      quantity: qty,
--      accountId,
--      side: 'Buy',
--    }),
--  });
--
--  if (response.status !== 200) {
--    const body = await response.text();
--    fail(`expected 200 from trade submit, got ${response.status}; body=${body}`);
--  }
--
--  setTimeout(() => {
--    fail(`timed out waiting for realtime account updates (trade=${sawTrade}, position=${sawPosition})`);
--  }, timeoutMs);
--}
--
--main().catch((err) => fail(err.message));
--NODE
--
--echo "[done] realtime account stream overlay test passed"
-diff --git a/scripts/test-realtime-order-stream-overlay.sh b/scripts/test-realtime-order-stream-overlay.sh
-deleted file mode 100755
-index 27579cd..0000000
---- a/scripts/test-realtime-order-stream-overlay.sh
-+++ /dev/null
-@@ -1,374 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--INGRESS_URL="${1:-http://localhost:8080}"
--USER_ACCOUNT_ID="${2:-22214}"
--ADMIN_ACCOUNT_ID="${3:-44044}"
--TIMEOUT_MS="${TIMEOUT_MS:-35000}"
--
--echo "[check] realtime order/trade/position streams over NATS websocket"
--INGRESS_URL="${INGRESS_URL}" \
--USER_ACCOUNT_ID="${USER_ACCOUNT_ID}" \
--ADMIN_ACCOUNT_ID="${ADMIN_ACCOUNT_ID}" \
--TIMEOUT_MS="${TIMEOUT_MS}" node <<'NODE'
--const ingressUrl = process.env.INGRESS_URL || 'http://localhost:8080';
--const userAccountId = Number(process.env.USER_ACCOUNT_ID || '22214');
--const adminAccountId = Number(process.env.ADMIN_ACCOUNT_ID || '44044');
--const timeoutMs = Number(process.env.TIMEOUT_MS || '35000');
--const wsUrl = ingressUrl.replace(/^http/i, 'ws') + '/nats-ws';
--
--if (typeof WebSocket !== 'function') {
--  console.error('[error] global WebSocket is unavailable in this Node runtime');
--  process.exit(1);
--}
--
--const userOrdersTopic = `/accounts/${userAccountId}/orders`;
--const adminOrdersTopic = `/accounts/${adminAccountId}/orders`;
--const allOrdersTopic = '/orders';
--const adminTradesTopic = `/accounts/${adminAccountId}/trades`;
--const adminPositionsTopic = `/accounts/${adminAccountId}/positions`;
--
--const sidByTopic = new Map([
--  [userOrdersTopic, 1],
--  [adminOrdersTopic, 2],
--  [allOrdersTopic, 3],
--  [adminTradesTopic, 4],
--  [adminPositionsTopic, 5],
--]);
--
--let userOrderId = null;
--let adminOrderId = null;
--let buffer = '';
--let pending = null;
--const orderIdsBySubjectStatus = new Map();
--
--const seen = {
--  userCreateAccount: false,
--  userCreateAll: false,
--  userCancelAccount: false,
--  userCancelAll: false,
--  adminFillAccount: false,
--  adminFillAll: false,
--  adminTrade: false,
--  adminPosition: false,
--};
--
--function fail(message) {
--  console.error(`[error] ${message}`);
--  process.exit(1);
--}
--
--function trackOrderEvent(subject, payload) {
--  const orderId = String(payload.orderId || '');
--  const status = String(payload.status || '');
--  if (!orderId || !status) {
--    return;
--  }
--  const key = `${subject}|${status}`;
--  let orderIds = orderIdsBySubjectStatus.get(key);
--  if (!orderIds) {
--    orderIds = new Set();
--    orderIdsBySubjectStatus.set(key, orderIds);
--  }
--  orderIds.add(orderId);
--}
--
--function hasOrderEvent(subject, status, orderId) {
--  if (!orderId) {
--    return false;
--  }
--  const key = `${subject}|${status}`;
--  const orderIds = orderIdsBySubjectStatus.get(key);
--  return Boolean(orderIds && orderIds.has(String(orderId)));
--}
--
--function syncSeenFlagsFromTrackedEvents() {
--  if (userOrderId) {
--    if (hasOrderEvent(userOrdersTopic, 'NEW', userOrderId)) {
--      seen.userCreateAccount = true;
--    }
--    if (hasOrderEvent(allOrdersTopic, 'NEW', userOrderId)) {
--      seen.userCreateAll = true;
--    }
--    if (hasOrderEvent(userOrdersTopic, 'CANCELED', userOrderId)) {
--      seen.userCancelAccount = true;
--    }
--    if (hasOrderEvent(allOrdersTopic, 'CANCELED', userOrderId)) {
--      seen.userCancelAll = true;
--    }
--  }
--
--  if (adminOrderId) {
--    if (hasOrderEvent(adminOrdersTopic, 'FILLED', adminOrderId)) {
--      seen.adminFillAccount = true;
--    }
--    if (hasOrderEvent(allOrdersTopic, 'FILLED', adminOrderId)) {
--      seen.adminFillAll = true;
--    }
--  }
--}
--
--async function requestJson(path, options, expectedStatus) {
--  const response = await fetch(`${ingressUrl}${path}`, options);
--  const text = await response.text();
--  let body = {};
--  try {
--    body = text ? JSON.parse(text) : {};
--  } catch (err) {
--    fail(`invalid JSON response for ${path}: ${text}`);
--  }
--  if (response.status !== expectedStatus) {
--    fail(`expected ${expectedStatus} from ${path}, got ${response.status}; body=${text}`);
--  }
--  return body;
--}
--
--function waitFor(checkFn, label, timeout = timeoutMs) {
--  return new Promise((resolve, reject) => {
--    const start = Date.now();
--    const timer = setInterval(() => {
--      if (checkFn()) {
--        clearInterval(timer);
--        resolve();
--        return;
--      }
--      if (Date.now() - start > timeout) {
--        clearInterval(timer);
--        reject(new Error(`timeout waiting for ${label}`));
--      }
--    }, 100);
--  });
--}
--
--function normalizePayload(payloadText) {
--  try {
--    const parsed = JSON.parse(payloadText);
--    if (parsed && typeof parsed === 'object' && parsed.payload) {
--      return parsed.payload;
--    }
--    return parsed;
--  } catch (err) {
--    return null;
--  }
--}
--
--function handleMessage(subject, payload) {
--  if (!payload || typeof payload !== 'object') {
--    return;
--  }
--
--  trackOrderEvent(subject, payload);
--  syncSeenFlagsFromTrackedEvents();
--
--  if (userOrderId && payload.orderId === userOrderId) {
--    if (subject === userOrdersTopic && payload.status === 'NEW') {
--      seen.userCreateAccount = true;
--    }
--    if (subject === allOrdersTopic && payload.status === 'NEW') {
--      seen.userCreateAll = true;
--    }
--    if (subject === userOrdersTopic && payload.status === 'CANCELED') {
--      seen.userCancelAccount = true;
--    }
--    if (subject === allOrdersTopic && payload.status === 'CANCELED') {
--      seen.userCancelAll = true;
--    }
--  }
--
--  if (adminOrderId && payload.orderId === adminOrderId) {
--    if (subject === adminOrdersTopic && payload.status === 'FILLED') {
--      seen.adminFillAccount = true;
--    }
--    if (subject === allOrdersTopic && payload.status === 'FILLED') {
--      seen.adminFillAll = true;
--    }
--  }
--
--  if (
--    subject === adminTradesTopic &&
--    payload.security === 'JPM' &&
--    payload.side === 'Sell' &&
--    Number(payload.quantity) === 11
--  ) {
--    seen.adminTrade = true;
--  }
--
--  if (
--    subject === adminPositionsTopic &&
--    payload.security === 'JPM' &&
--    Number.isFinite(Number(payload.quantity))
--  ) {
--    seen.adminPosition = true;
--  }
--}
--
--function parseFrame(text, ws) {
--  buffer += text;
--  while (true) {
--    if (pending) {
--      const needed = pending.bytes + 2;
--      if (buffer.length < needed) {
--        return;
--      }
--      const payloadText = buffer.slice(0, pending.bytes);
--      buffer = buffer.slice(needed);
--      const payload = normalizePayload(payloadText);
--      handleMessage(pending.subject, payload);
--      pending = null;
--      continue;
--    }
--
--    const eol = buffer.indexOf('\r\n');
--    if (eol < 0) {
--      return;
--    }
--    const line = buffer.slice(0, eol);
--    buffer = buffer.slice(eol + 2);
--    if (!line) {
--      continue;
--    }
--    if (line.startsWith('PING')) {
--      ws.send('PONG\r\n');
--      continue;
--    }
--    if (line.startsWith('INFO') || line.startsWith('PONG')) {
--      continue;
--    }
--    if (line.startsWith('MSG ')) {
--      const parts = line.split(' ');
--      if (parts.length < 4) {
--        continue;
--      }
--      const subject = parts[1];
--      const bytes = Number(parts[parts.length - 1]);
--      if (!Number.isFinite(bytes)) {
--        continue;
--      }
--      pending = { subject, bytes };
--    }
--  }
--}
--
--async function main() {
--  const ws = new WebSocket(wsUrl);
--
--  await Promise.race([
--    new Promise((resolve, reject) => {
--      ws.onopen = resolve;
--      ws.onerror = () => reject(new Error(`websocket error while connecting to ${wsUrl}`));
--    }),
--    new Promise((_, reject) => setTimeout(() => reject(new Error(`timeout connecting to ${wsUrl}`)), 8000)),
--  ]);
--
--  ws.onmessage = async (event) => {
--    if (typeof event.data === 'string') {
--      parseFrame(event.data, ws);
--      return;
--    }
--    if (event.data instanceof Blob) {
--      parseFrame(await event.data.text(), ws);
--      return;
--    }
--    if (event.data instanceof ArrayBuffer) {
--      parseFrame(new TextDecoder().decode(new Uint8Array(event.data)), ws);
--    }
--  };
--
--  ws.onerror = () => {
--    fail(`websocket error while connected to ${wsUrl}`);
--  };
--
--  ws.send('CONNECT {"protocol":1,"verbose":false,"pedantic":false,"echo":false}\r\n');
--  for (const [topic, sid] of sidByTopic.entries()) {
--    ws.send(`SUB ${topic} ${sid}\r\n`);
--  }
--  ws.send('PING\r\n');
--
--  const userCreate = await requestJson(
--    '/order-matcher/orders',
--    {
--      method: 'POST',
--      headers: { 'Content-Type': 'application/json' },
--      body: JSON.stringify({
--        accountId: userAccountId,
--        security: 'IBM',
--        side: 'Buy',
--        quantity: 33,
--        // Keep this non-marketable so cancel-event assertions do not race auto-fill ticks.
--        limitPrice: 1.0,
--      }),
--    },
--    201
--  );
--  userOrderId = userCreate.orderId;
--  if (!userOrderId) {
--    fail('user order create response missing orderId');
--  }
--  syncSeenFlagsFromTrackedEvents();
--
--  await waitFor(() => seen.userCreateAccount && seen.userCreateAll, 'user create order events');
--
--  await requestJson(
--    `/order-matcher/orders/${userOrderId}/cancel`,
--    {
--      method: 'POST',
--      headers: { 'Content-Type': 'application/json' },
--      body: '{}',
--    },
--    200
--  );
--
--  await waitFor(() => seen.userCancelAccount && seen.userCancelAll, 'user cancel order events');
--
--  const adminCreate = await requestJson(
--    '/order-matcher/orders',
--    {
--      method: 'POST',
--      headers: { 'Content-Type': 'application/json' },
--      body: JSON.stringify({
--        accountId: adminAccountId,
--        security: 'JPM',
--        side: 'Sell',
--        quantity: 11,
--        limitPrice: 191.875,
--      }),
--    },
--    201
--  );
--  adminOrderId = adminCreate.orderId;
--  if (!adminOrderId) {
--    fail('admin order create response missing orderId');
--  }
--  syncSeenFlagsFromTrackedEvents();
--
--  await requestJson(
--    `/order-matcher/orders/${adminOrderId}/force-fill`,
--    {
--      method: 'POST',
--      headers: { 'Content-Type': 'application/json' },
--      body: '{}',
--    },
--    200
--  );
--
--  await waitFor(
--    () => seen.adminFillAccount && seen.adminFillAll && seen.adminTrade && seen.adminPosition,
--    'admin force-fill order/trade/position realtime events'
--  );
--
--  console.log('[info] realtime order streams validated for create/cancel/force-fill');
--  console.log('[info] cross-stream causality validated for order -> trade -> position');
--  ws.close();
--}
--
--main().catch((err) => fail(err.message));
--NODE
--
--echo "[done] realtime order stream overlay test passed"
-diff --git a/scripts/test-reference-data-overlay.sh b/scripts/test-reference-data-overlay.sh
-deleted file mode 100755
-index a006f89..0000000
---- a/scripts/test-reference-data-overlay.sh
-+++ /dev/null
-@@ -1,51 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--ORIGIN="${1:-http://localhost:18093}"
--BASE_URL="${2:-http://localhost:18085}"
--# Spec-backed generated reference universe is intentionally compact (curated sample set).
--# Allow callers to override, but default to the current generated baseline size floor.
--MIN_STOCK_COUNT="${3:-20}"
--
--echo "[check] CORS header from ${BASE_URL}/stocks for origin ${ORIGIN}"
--headers="$(curl -sS -i -H "Origin: ${ORIGIN}" "${BASE_URL}/stocks" | sed -n '1,30p')"
--echo "${headers}"
--
--cors_header="$(printf '%s\n' "${headers}" | awk -F': ' 'tolower($1)=="access-control-allow-origin" {print $2}' | tr -d '\r' || true)"
--if [[ -z "${cors_header}" ]]; then
--  echo "[error] missing Access-Control-Allow-Origin header"
--  exit 1
--fi
--
--if [[ "${cors_header}" != "*" && "${cors_header}" != "${ORIGIN}" ]]; then
--  echo "[error] unexpected Access-Control-Allow-Origin value: ${cors_header}"
--  exit 1
--fi
--
--echo "[check] stocks list size"
--stocks_count="$(curl -sS "${BASE_URL}/stocks" | jq 'length')"
--echo "[info] stock count=${stocks_count}"
--if [[ "${stocks_count}" -lt "${MIN_STOCK_COUNT}" ]]; then
--  echo "[error] expected at least ${MIN_STOCK_COUNT} symbols, got ${stocks_count}"
--  exit 1
--fi
--
--echo "[check] known ticker lookup"
--ibm_json="$(curl -sS "${BASE_URL}/stocks/IBM")"
--echo "${ibm_json}" | jq
--
--echo "[check] unknown ticker returns 404"
--http_code="$(curl -sS -o /tmp/reference-data-404.out -w "%{http_code}" "${BASE_URL}/stocks/DOES_NOT_EXIST")"
--if [[ "${http_code}" != "404" ]]; then
--  echo "[error] expected 404 for unknown ticker, got ${http_code}"
--  exit 1
--fi
--
--echo "[done] reference-data overlay smoke tests passed"
-diff --git a/scripts/test-state-002-edge-proxy.ps1 b/scripts/test-state-002-edge-proxy.ps1
-deleted file mode 100644
-index dea1e9b..0000000
---- a/scripts/test-state-002-edge-proxy.ps1
-+++ /dev/null
-@@ -1,73 +0,0 @@
--#!/usr/bin/env pwsh
--Set-StrictMode -Version Latest
--$ErrorActionPreference = 'Stop'
--
--$env:TRADERX_LOCAL_RUNTIME_SCRIPT = '1'
--$env:TRADERX_SKIP_GENERATE = '1'
--if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('TRADERX_GENERATED_ROOT'))) {
--  $env:TRADERX_GENERATED_ROOT = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
--}
--
--param([string]$EdgeUrl = 'http://localhost:18080')
--
--. "$PSScriptRoot/lib/runtime-common.ps1"
--. "$PSScriptRoot/lib/generated-state-detection.ps1"
--
--$repoRoot = Get-TraderxRepoRoot -ScriptPath $PSCommandPath
--$generatedRoot = Get-TraderxGeneratedRoot -RepoRoot $repoRoot
--Use-GeneratedRuntimeScript -ScriptPath $PSCommandPath -GeneratedRoot $generatedRoot -RepoRoot $repoRoot -ScriptArgs $args
--
--$expectedState = '002-edge-proxy-uncontainerized'
--
--Write-Host '[check] generated output state metadata'
--$status = Report-GeneratedState -ExpectedState $expectedState -GeneratedRoot $generatedRoot
--if ($status -ne 0) {
--  Write-Host "[error] generated output does not match expected state $expectedState"
--  exit 1
--}
--
--$httpClient = [System.Net.Http.HttpClient]::new()
--try {
--  Write-Host '[check] edge-proxy health endpoint'
--  $health = $httpClient.GetAsync("$EdgeUrl/health").GetAwaiter().GetResult()
--  Write-Host ("HTTP {0}" -f [int]$health.StatusCode)
--
--  Write-Host '[check] proxied UI root'
--  $ui = $httpClient.GetAsync("$EdgeUrl/").GetAwaiter().GetResult()
--  Write-Host ("HTTP {0}" -f [int]$ui.StatusCode)
--
--  Write-Host '[check] proxied account-service endpoint'
--  $account = $httpClient.GetAsync("$EdgeUrl/account-service/account/22214").GetAwaiter().GetResult()
--  Write-Host ("HTTP {0}" -f [int]$account.StatusCode)
--  if ([int]$account.StatusCode -ne 200) {
--    throw "[error] expected 200 from proxied account-service endpoint"
--  }
--
--  Write-Host '[check] proxied reference-data endpoint'
--  $stocks = $httpClient.GetAsync("$EdgeUrl/reference-data/stocks").GetAwaiter().GetResult()
--  Write-Host ("HTTP {0}" -f [int]$stocks.StatusCode)
--  if ([int]$stocks.StatusCode -ne 200) {
--    throw "[error] expected 200 from proxied reference-data endpoint"
--  }
--
--  Write-Host '[check] proxied trade-service unknown ticker validation'
--  $payload = '{"security":"NOTREAL","quantity":1,"accountId":22214,"side":"Buy"}'
--  $content = [System.Net.Http.StringContent]::new($payload, [System.Text.Encoding]::UTF8, 'application/json')
--  $trade = $httpClient.PostAsync("$EdgeUrl/trade-service/trade", $content).GetAwaiter().GetResult()
--  $tradeBody = $trade.Content.ReadAsStringAsync().GetAwaiter().GetResult()
--  Write-Host $tradeBody
--  if ([int]$trade.StatusCode -ne 404) {
--    throw "[error] expected 404 for unknown ticker via edge proxy, got $([int]$trade.StatusCode)"
--  }
--}
--finally {
--  $httpClient.Dispose()
--}
--
--Write-Host '[check] web-front-end state-aware UX contract'
--& (Join-Path $repoRoot 'scripts/test-web-angular-baseline-ux-contract.ps1') (Join-Path $generatedRoot 'code/target-generated/web-front-end/angular')
--if ($LASTEXITCODE -ne 0) {
--  exit $LASTEXITCODE
--}
--
--Write-Host '[done] state 002 edge-proxy smoke tests passed'
-diff --git a/scripts/test-state-002-edge-proxy.sh b/scripts/test-state-002-edge-proxy.sh
-deleted file mode 100755
-index 4eb6d1b..0000000
---- a/scripts/test-state-002-edge-proxy.sh
-+++ /dev/null
-@@ -1,69 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--
--EDGE_URL="${1:-http://localhost:18080}"
--EXPECTED_STATE="002-edge-proxy-uncontainerized"
--
--source "${REPO_ROOT}/scripts/lib/generated-state-detection.sh"
--echo "[check] generated output state metadata"
--traderx_report_generated_state "${EXPECTED_STATE}" "${GENERATED_ROOT}" >/dev/null || {
--  echo "[error] generated output does not match expected state ${EXPECTED_STATE}"
--  exit 1
--}
--
--echo "[check] edge-proxy health endpoint"
--curl -sS -i "${EDGE_URL}/health" | sed -n '1,20p'
--
--echo "[check] proxied UI root"
--curl -sS -i "${EDGE_URL}/" | sed -n '1,20p'
--
--echo "[check] proxied account-service endpoint"
--account_headers="$(curl -sS -i "${EDGE_URL}/account-service/account/22214" | sed -n '1,25p')"
--echo "${account_headers}"
--printf '%s\n' "${account_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from proxied account-service endpoint"
--  exit 1
--}
--
--echo "[check] proxied reference-data endpoint"
--stocks_headers="$(curl -sS -i "${EDGE_URL}/reference-data/stocks" | sed -n '1,25p')"
--echo "${stocks_headers}"
--printf '%s\n' "${stocks_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from proxied reference-data endpoint"
--  exit 1
--}
--
--echo "[check] proxied trade-service unknown ticker validation"
--status_code="$(curl -sS -o /tmp/traderx-state-002-trade.out -w "%{http_code}" \
--  -H "Content-Type: application/json" \
--  -d '{"security":"NOTREAL","quantity":1,"accountId":22214,"side":"Buy"}' \
--  "${EDGE_URL}/trade-service/trade")"
--cat /tmp/traderx-state-002-trade.out
--echo
--rm -f /tmp/traderx-state-002-trade.out
--if [[ "${status_code}" != "404" ]]; then
--  echo "[error] expected 404 for unknown ticker via edge proxy, got ${status_code}"
--  exit 1
--fi
--
--echo "[check] web-front-end state-aware UX contract"
--"${REPO_ROOT}/scripts/test-web-angular-baseline-ux-contract.sh" "${GENERATED_ROOT}/code/target-generated/web-front-end/angular"
--
--echo "[done] state 002 edge-proxy smoke tests passed"
-diff --git a/scripts/test-state-003-agentic-harness-foundation.ps1 b/scripts/test-state-003-agentic-harness-foundation.ps1
-deleted file mode 100644
-index 3b4d6ac..0000000
---- a/scripts/test-state-003-agentic-harness-foundation.ps1
-+++ /dev/null
-@@ -1,78 +0,0 @@
--#!/usr/bin/env pwsh
--Set-StrictMode -Version Latest
--$ErrorActionPreference = 'Stop'
--
--$env:TRADERX_LOCAL_RUNTIME_SCRIPT = '1'
--$env:TRADERX_SKIP_GENERATE = '1'
--if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('TRADERX_GENERATED_ROOT'))) {
--  $env:TRADERX_GENERATED_ROOT = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
--}
--
--param([string]$EdgeUrl = 'http://localhost:18080')
--
--. "$PSScriptRoot/lib/runtime-common.ps1"
--
--$repoRoot = Get-TraderxRepoRoot -ScriptPath $PSCommandPath
--$generatedRoot = Get-TraderxGeneratedRoot -RepoRoot $repoRoot
--$target = Join-Path $generatedRoot 'code/target-generated'
--Use-GeneratedRuntimeScript -ScriptPath $PSCommandPath -GeneratedRoot $generatedRoot -RepoRoot $repoRoot -ScriptArgs $args
--
--$httpClient = [System.Net.Http.HttpClient]::new()
--try {
--  Write-Host '[check] edge-proxy health endpoint'
--  $health = $httpClient.GetAsync("$EdgeUrl/health").GetAwaiter().GetResult()
--  Write-Host ("HTTP {0}" -f [int]$health.StatusCode)
--
--  Write-Host '[check] proxied UI root'
--  $ui = $httpClient.GetAsync("$EdgeUrl/").GetAwaiter().GetResult()
--  Write-Host ("HTTP {0}" -f [int]$ui.StatusCode)
--
--  Write-Host '[check] proxied account-service endpoint'
--  $account = $httpClient.GetAsync("$EdgeUrl/account-service/account/22214").GetAwaiter().GetResult()
--  Write-Host ("HTTP {0}" -f [int]$account.StatusCode)
--  if ([int]$account.StatusCode -ne 200) {
--    throw '[error] expected 200 from proxied account-service endpoint'
--  }
--
--  Write-Host '[check] proxied reference-data endpoint'
--  $stocks = $httpClient.GetAsync("$EdgeUrl/reference-data/stocks").GetAwaiter().GetResult()
--  Write-Host ("HTTP {0}" -f [int]$stocks.StatusCode)
--  if ([int]$stocks.StatusCode -ne 200) {
--    throw '[error] expected 200 from proxied reference-data endpoint'
--  }
--
--  Write-Host '[check] proxied trade-service unknown ticker validation'
--  $payload = '{"security":"NOTREAL","quantity":1,"accountId":22214,"side":"Buy"}'
--  $content = [System.Net.Http.StringContent]::new($payload, [System.Text.Encoding]::UTF8, 'application/json')
--  $trade = $httpClient.PostAsync("$EdgeUrl/trade-service/trade", $content).GetAwaiter().GetResult()
--  $tradeBody = $trade.Content.ReadAsStringAsync().GetAwaiter().GetResult()
--  Write-Host $tradeBody
--  if ([int]$trade.StatusCode -ne 404) {
--    throw "[error] expected 404 for unknown ticker via edge proxy, got $([int]$trade.StatusCode)"
--  }
--}
--finally {
--  $httpClient.Dispose()
--}
--
--Write-Host '[check] web-front-end state-aware UX contract'
--& (Join-Path $repoRoot 'scripts/test-web-angular-baseline-ux-contract.ps1') (Join-Path $generatedRoot 'code/target-generated/web-front-end/angular')
--if ($LASTEXITCODE -ne 0) {
--  exit $LASTEXITCODE
--}
--
--foreach ($required in @('AGENTS.md', 'ARCHITECTURE.md', 'CONTRIBUTING.md')) {
--  $path = Join-Path $target $required
--  if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
--    Write-Host "[error] missing generated harness file: $path"
--    exit 1
--  }
--}
--
--$contribPath = Join-Path $target 'CONTRIBUTING.md'
--if (-not (Select-String -LiteralPath $contribPath -Pattern 'specs/|state packs|generated snapshots are outputs' -Quiet)) {
--  Write-Host '[error] CONTRIBUTING.md missing upstream contribution policy guidance'
--  exit 1
--}
--
--Write-Host '[done] state 003 edge-proxy + harness checks passed'
-diff --git a/scripts/test-state-003-agentic-harness-foundation.sh b/scripts/test-state-003-agentic-harness-foundation.sh
-deleted file mode 100755
-index 2b1ec86..0000000
---- a/scripts/test-state-003-agentic-harness-foundation.sh
-+++ /dev/null
-@@ -1,74 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--TARGET="${GENERATED_ROOT}/code/target-generated"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--
--EDGE_URL="${1:-http://localhost:18080}"
--
--echo "[check] edge-proxy health endpoint"
--curl -sS -i "${EDGE_URL}/health" | sed -n '1,20p'
--
--echo "[check] proxied UI root"
--curl -sS -i "${EDGE_URL}/" | sed -n '1,20p'
--
--echo "[check] proxied account-service endpoint"
--account_headers="$(curl -sS -i "${EDGE_URL}/account-service/account/22214" | sed -n '1,25p')"
--echo "${account_headers}"
--printf '%s\n' "${account_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from proxied account-service endpoint"
--  exit 1
--}
--
--echo "[check] proxied reference-data endpoint"
--stocks_headers="$(curl -sS -i "${EDGE_URL}/reference-data/stocks" | sed -n '1,25p')"
--echo "${stocks_headers}"
--printf '%s\n' "${stocks_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from proxied reference-data endpoint"
--  exit 1
--}
--
--echo "[check] proxied trade-service unknown ticker validation"
--status_code="$(curl -sS -o /tmp/traderx-state-003-trade.out -w "%{http_code}" \
--  -H "Content-Type: application/json" \
--  -d '{"security":"NOTREAL","quantity":1,"accountId":22214,"side":"Buy"}' \
--  "${EDGE_URL}/trade-service/trade")"
--cat /tmp/traderx-state-003-trade.out
--echo
--rm -f /tmp/traderx-state-003-trade.out
--if [[ "${status_code}" != "404" ]]; then
--  echo "[error] expected 404 for unknown ticker via edge proxy, got ${status_code}"
--  exit 1
--fi
--
--echo "[check] web-front-end state-aware UX contract"
--"${REPO_ROOT}/scripts/test-web-angular-baseline-ux-contract.sh" "${GENERATED_ROOT}/code/target-generated/web-front-end/angular"
--
--for required in AGENTS.md ARCHITECTURE.md CONTRIBUTING.md; do
--  if [[ ! -f "${TARGET}/${required}" ]]; then
--    echo "[error] missing generated harness file: ${TARGET}/${required}"
--    exit 1
--  fi
--done
--
--if ! rg -q "specs/|state packs|generated snapshots are outputs" "${TARGET}/CONTRIBUTING.md"; then
--  echo "[error] CONTRIBUTING.md missing upstream contribution policy guidance"
--  exit 1
--fi
--
--echo "[done] state 003 edge-proxy + harness checks passed"
 diff --git a/scripts/test-state-004-containerized.sh b/scripts/test-state-004-containerized.sh
-deleted file mode 100755
-index 64d0dbe..0000000
+index 64d0dbe..75f6b6f 100755
 --- a/scripts/test-state-004-containerized.sh
-+++ /dev/null
-@@ -1,118 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
++++ b/scripts/test-state-004-containerized.sh
+@@ -1,13 +1,6 @@
+ #!/usr/bin/env bash
+ set -euo pipefail
+ 
 -export TRADERX_LOCAL_RUNTIME_SCRIPT=1
 -export TRADERX_SKIP_GENERATE=1
 -if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
@@ -14242,3124 +13820,9 @@ index 64d0dbe..0000000
 -  export TRADERX_GENERATED_ROOT
 -fi
 -
--INGRESS_URL="${1:-http://localhost:8080}"
--ORIGIN="${2:-http://localhost:8080}"
--COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-004}"
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--EXPECTED_STATE="004-containerized-compose-runtime"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--COMPOSE_FILE="${GENERATED_ROOT}/code/target-generated/containerized-compose/docker-compose.yml"
--source "${REPO_ROOT}/scripts/lib/generated-state-detection.sh"
--
--echo "[check] generated output state metadata"
--traderx_report_generated_state "${EXPECTED_STATE}" "${GENERATED_ROOT}" >/dev/null || {
--  echo "[error] generated output does not match expected state ${EXPECTED_STATE}"
--  exit 1
--}
--
--if ! command -v docker >/dev/null 2>&1; then
--  echo "[error] docker command not found"
--  exit 1
--fi
--
--if [[ ! -f "${COMPOSE_FILE}" ]]; then
--  echo "[error] compose file not found: ${COMPOSE_FILE}"
--  echo "[hint] run: bash pipeline/generate-state.sh 004-containerized-compose-runtime"
--  exit 1
--fi
--
--echo "[check] compose services running"
--docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps
--running_services="$(docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps --status running --services | wc -l | tr -d ' ')"
--if [[ "${running_services}" -lt 10 ]]; then
--  echo "[error] expected 10+ running services, got ${running_services}"
--  exit 1
--fi
--
--echo "[check] nginx ingress health endpoint"
--health_headers="$(curl -sS -i "${INGRESS_URL}/health" | sed -n '1,20p')"
--echo "${health_headers}"
--printf '%s\n' "${health_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress /health"
--  exit 1
--}
--
--echo "[check] ingress UI root"
--ui_headers="$(curl -sS -i "${INGRESS_URL}/" | sed -n '1,20p')"
--echo "${ui_headers}"
--printf '%s\n' "${ui_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress UI root"
--  exit 1
--}
--
--echo "[check] ingress account-service proxy endpoint"
--account_headers="$(curl -sS -i "${INGRESS_URL}/account-service/account/22214" | sed -n '1,25p')"
--echo "${account_headers}"
--printf '%s\n' "${account_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress proxied account-service endpoint"
--  exit 1
--}
--
--echo "[check] ingress reference-data proxy endpoint"
--stocks_headers="$(curl -sS -i "${INGRESS_URL}/reference-data/stocks" | sed -n '1,25p')"
--echo "${stocks_headers}"
--printf '%s\n' "${stocks_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress proxied reference-data endpoint"
--  exit 1
--}
--
--echo "[check] ingress socket.io polling handshake endpoint"
--socket_headers="$(curl -sS -i "${INGRESS_URL}/socket.io/?EIO=4&transport=polling" | sed -n '1,30p')"
--echo "${socket_headers}"
--printf '%s\n' "${socket_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress socket.io polling handshake endpoint"
--  exit 1
--}
--
--echo "[check] ingress trade-service unknown ticker validation"
--status_code="$(curl -sS -o /tmp/traderx-state-004-trade.out -w "%{http_code}" \
--  -H "Content-Type: application/json" \
--  -d '{"security":"NOTREAL","quantity":1,"accountId":22214,"side":"Buy"}' \
--  "${INGRESS_URL}/trade-service/trade")"
--cat /tmp/traderx-state-004-trade.out
--echo
--rm -f /tmp/traderx-state-004-trade.out
--if [[ "${status_code}" != "404" ]]; then
--  echo "[error] expected 404 for unknown ticker through ingress, got ${status_code}"
--  exit 1
--fi
--
--echo "[check] baseline service smoke suite in containerized runtime"
--"${REPO_ROOT}/scripts/test-reference-data-overlay.sh" "${ORIGIN}" "http://localhost:18085"
--"${REPO_ROOT}/scripts/test-database-overlay.sh" "18082" "18083" "http://localhost:18084/" "http://localhost:18088/account/22214"
--"${REPO_ROOT}/scripts/test-people-service-overlay.sh" "${ORIGIN}" "http://localhost:18089" "http://localhost:18088/accountuser/"
--"${REPO_ROOT}/scripts/test-account-service-overlay.sh" "${ORIGIN}" "http://localhost:18088"
--"${REPO_ROOT}/scripts/test-position-service-overlay.sh" "${ORIGIN}" "http://localhost:18090"
--"${REPO_ROOT}/scripts/test-trade-feed-overlay.sh" "http://localhost:18086"
--"${REPO_ROOT}/scripts/test-trade-processor-overlay.sh" "${ORIGIN}" "http://localhost:18091" "http://localhost:18090" "http://localhost:18086"
--"${REPO_ROOT}/scripts/test-trade-service-overlay.sh" "${ORIGIN}" "http://localhost:18092" "http://localhost:18090"
--"${REPO_ROOT}/scripts/test-realtime-account-stream-overlay.sh" "http://localhost:18092" "${INGRESS_URL}" "22214"
--"${REPO_ROOT}/scripts/test-web-angular-overlay.sh" "${INGRESS_URL}"
--"${REPO_ROOT}/scripts/test-web-angular-baseline-ux-contract.sh" "${GENERATED_ROOT}/code/target-generated/web-front-end/angular"
--
--echo "[done] state 004 containerized compose smoke tests passed"
-diff --git a/scripts/test-state-005-postgres-database-replacement.sh b/scripts/test-state-005-postgres-database-replacement.sh
-deleted file mode 100755
-index bfc886c..0000000
---- a/scripts/test-state-005-postgres-database-replacement.sh
-+++ /dev/null
-@@ -1,126 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--INGRESS_URL="${1:-http://localhost:8080}"
--ORIGIN="${2:-http://localhost:8080}"
--COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-005}"
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--COMPOSE_FILE="${GENERATED_ROOT}/code/target-generated/postgres-database-replacement/docker-compose.yml"
--
--if ! command -v docker >/dev/null 2>&1; then
--  echo "[error] docker command not found"
--  exit 1
--fi
--
--if [[ ! -f "${COMPOSE_FILE}" ]]; then
--  echo "[error] compose file not found: ${COMPOSE_FILE}"
--  echo "[hint] run: bash pipeline/generate-state.sh 005-postgres-database-replacement"
--  exit 1
--fi
--
--echo "[check] compose services running"
--docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps
--running_services="$(docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps --status running --services | wc -l | tr -d ' ')"
--if [[ "${running_services}" -lt 10 ]]; then
--  echo "[error] expected 10+ running services, got ${running_services}"
--  exit 1
--fi
--
--echo "[check] postgres port 18083"
--nc -z localhost 18083
--
--echo "[check] postgres readiness"
--docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" exec -T database \
--  pg_isready -U traderx -d traderx
--
--echo "[check] postgres baseline data loaded"
--accounts_count="$(docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" exec -T database \
--  psql -U traderx -d traderx -tAc "select count(*) from accounts;" | tr -d '[:space:]')"
--if [[ -z "${accounts_count}" || "${accounts_count}" -lt 7 ]]; then
--  echo "[error] expected baseline accounts in postgres, got count=${accounts_count:-0}"
--  exit 1
--fi
--
--echo "[check] nginx ingress health endpoint"
--health_headers="$(curl -sS -i "${INGRESS_URL}/health" | sed -n '1,20p')"
--echo "${health_headers}"
--printf '%s\n' "${health_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress /health"
--  exit 1
--}
--
--echo "[check] ingress UI root"
--ui_headers="$(curl -sS -i "${INGRESS_URL}/" | sed -n '1,20p')"
--echo "${ui_headers}"
--printf '%s\n' "${ui_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress UI root"
--  exit 1
--}
--
--echo "[check] ingress account-service proxy endpoint"
--account_headers="$(curl -sS -i "${INGRESS_URL}/account-service/account/22214" | sed -n '1,25p')"
--echo "${account_headers}"
--printf '%s\n' "${account_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress proxied account-service endpoint"
--  exit 1
--}
--
--echo "[check] ingress reference-data proxy endpoint"
--stocks_headers="$(curl -sS -i "${INGRESS_URL}/reference-data/stocks" | sed -n '1,25p')"
--echo "${stocks_headers}"
--printf '%s\n' "${stocks_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress proxied reference-data endpoint"
--  exit 1
--}
--
--echo "[check] ingress socket.io polling handshake endpoint"
--socket_headers="$(curl -sS -i "${INGRESS_URL}/socket.io/?EIO=4&transport=polling" | sed -n '1,30p')"
--echo "${socket_headers}"
--printf '%s\n' "${socket_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress socket.io polling handshake endpoint"
--  exit 1
--}
--
--echo "[check] ingress trade-service unknown ticker validation"
--status_code="$(curl -sS -o /tmp/traderx-state-005-trade.out -w "%{http_code}" \
--  -H "Content-Type: application/json" \
--  -d '{"security":"NOTREAL","quantity":1,"accountId":22214,"side":"Buy"}' \
--  "${INGRESS_URL}/trade-service/trade")"
--cat /tmp/traderx-state-005-trade.out
--echo
--rm -f /tmp/traderx-state-005-trade.out
--if [[ "${status_code}" != "404" ]]; then
--  echo "[error] expected 404 for unknown ticker through ingress, got ${status_code}"
--  exit 1
--fi
--
--echo "[check] baseline service smoke suite in postgres runtime"
--"${REPO_ROOT}/scripts/test-reference-data-overlay.sh" "${ORIGIN}" "http://localhost:18085"
--"${REPO_ROOT}/scripts/test-people-service-overlay.sh" "${ORIGIN}" "http://localhost:18089" "http://localhost:18088/accountuser/"
--"${REPO_ROOT}/scripts/test-account-service-overlay.sh" "${ORIGIN}" "http://localhost:18088"
--"${REPO_ROOT}/scripts/test-position-service-overlay.sh" "${ORIGIN}" "http://localhost:18090"
--"${REPO_ROOT}/scripts/test-trade-feed-overlay.sh" "http://localhost:18086"
--"${REPO_ROOT}/scripts/test-trade-processor-overlay.sh" "${ORIGIN}" "http://localhost:18091" "http://localhost:18090" "http://localhost:18086"
--"${REPO_ROOT}/scripts/test-trade-service-overlay.sh" "${ORIGIN}" "http://localhost:18092" "http://localhost:18090"
--"${REPO_ROOT}/scripts/test-realtime-account-stream-overlay.sh" "http://localhost:18092" "${INGRESS_URL}" "22214"
--"${REPO_ROOT}/scripts/test-web-angular-overlay.sh" "${INGRESS_URL}"
--
--echo "[check] web-front-end state-aware UX contract"
--"${REPO_ROOT}/scripts/test-web-angular-baseline-ux-contract.sh" "${GENERATED_ROOT}/code/target-generated/web-front-end/angular"
--
--echo "[done] state 005 postgres-database runtime smoke tests passed"
-diff --git a/scripts/test-state-006-messaging-nats-replacement.sh b/scripts/test-state-006-messaging-nats-replacement.sh
-deleted file mode 100755
-index 972eb1c..0000000
---- a/scripts/test-state-006-messaging-nats-replacement.sh
-+++ /dev/null
-@@ -1,359 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--INGRESS_URL="${1:-http://localhost:8080}"
--ORIGIN="${2:-http://localhost:8080}"
--COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-006}"
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--COMPOSE_FILE="${TRADERX_COMPOSE_FILE:-${GENERATED_ROOT}/code/target-generated/messaging-nats-replacement/docker-compose.yml}"
--
--if ! command -v docker >/dev/null 2>&1; then
--  echo "[error] docker command not found"
--  exit 1
--fi
--
--if [[ ! -f "${COMPOSE_FILE}" ]]; then
--  echo "[error] compose file not found: ${COMPOSE_FILE}"
--  echo "[hint] run: bash pipeline/generate-state.sh 006-messaging-nats-replacement"
--  exit 1
--fi
--
--check_message_bus_health_endpoint() {
--  local endpoint="$1"
--  local component="$2"
--  local payload
--  payload="$(curl -fsS "${endpoint}")"
--
--  local top_status
--  top_status="$(echo "${payload}" | jq -r '.status // empty')"
--  if [[ "${top_status}" != "ok" ]]; then
--    echo "[error] ${component} system health is not ok at ${endpoint}: status=${top_status}"
--    echo "${payload}"
--    exit 1
--  fi
--
--  local statuses
--  statuses="$(echo "${payload}" | jq -r '
--    if (.messageBus | type) != "object" then
--      empty
--    elif ((.messageBus | has("publisher")) or (.messageBus | has("subscriber"))) then
--      [.messageBus.publisher.status?, .messageBus.subscriber.status?] | .[]
--    else
--      .messageBus.status // empty
--    end
--  ')"
--
--  if [[ -z "${statuses//[$'\n\r\t ']}" ]]; then
--    echo "[error] ${component} system health missing messageBus status payload at ${endpoint}"
--    echo "${payload}"
--    exit 1
--  fi
--
--  while IFS= read -r bus_status; do
--    [[ -z "${bus_status}" ]] && continue
--    if [[ "${bus_status}" != "connected" ]]; then
--      echo "[error] ${component} message bus is not connected at ${endpoint}: status=${bus_status}"
--      echo "${payload}"
--      exit 1
--    fi
--  done <<< "${statuses}"
--}
--
--echo "[check] compose services running"
--docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps
--running_services="$(docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps --status running --services | wc -l | tr -d ' ')"
--if [[ "${running_services}" -lt 10 ]]; then
--  echo "[error] expected 10+ running services, got ${running_services}"
--  exit 1
--fi
--
--if docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps --services | grep -q '^trade-feed$'; then
--  echo "[error] state 006 runtime must not contain trade-feed service"
--  exit 1
--fi
--
--echo "[check] postgres readiness"
--docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" exec -T database \
--  pg_isready -U traderx -d traderx
--
--echo "[check] postgres baseline data loaded"
--accounts_count="$(docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" exec -T database \
--  psql -U traderx -d traderx -tAc "select count(*) from accounts;" | tr -d '[:space:]')"
--if [[ -z "${accounts_count}" || "${accounts_count}" -lt 7 ]]; then
--  echo "[error] expected baseline accounts in postgres, got count=${accounts_count:-0}"
--  exit 1
--fi
--
--echo "[check] nginx ingress health endpoint"
--health_headers="$(curl -sS -i "${INGRESS_URL}/health" | sed -n '1,20p')"
--echo "${health_headers}"
--printf '%s\n' "${health_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress /health"
--  exit 1
--}
--
--echo "[check] ingress UI root"
--ui_headers="$(curl -sS -i "${INGRESS_URL}/" | sed -n '1,20p')"
--echo "${ui_headers}"
--printf '%s\n' "${ui_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress UI root"
--  exit 1
--}
--
--echo "[check] NATS broker monitor endpoint"
--nats_varz_headers="$(curl -sS -i "http://localhost:8222/varz" | sed -n '1,30p')"
--echo "${nats_varz_headers}"
--printf '%s\n' "${nats_varz_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from NATS monitor endpoint"
--  exit 1
--}
--curl -sS "http://localhost:8222/varz" | jq -e '.server_id and .max_payload and .proto' >/dev/null || {
--  echo "[error] NATS /varz payload missing required keys"
--  exit 1
--}
--
--echo "[check] ingress websocket upgrade route to NATS"
--ws_headers="$(
--  curl -sS -i --max-time 5 \
--    -H "Connection: Upgrade" \
--    -H "Upgrade: websocket" \
--    -H "Sec-WebSocket-Version: 13" \
--    -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
--    "${INGRESS_URL}/nats-ws" 2>/dev/null | sed -n '1,30p' || true
--)"
--echo "${ws_headers}"
--printf '%s\n' "${ws_headers}" | grep -Eq "HTTP/1\\.[01] 101|HTTP/2 101" || {
--  echo "[error] expected websocket 101 response from ${INGRESS_URL}/nats-ws"
--  exit 1
--}
--
--echo "[check] message bus connectivity pre-check via /system/health"
--check_message_bus_health_endpoint "${INGRESS_URL}/trade-service/system/health" "trade-service"
--check_message_bus_health_endpoint "${INGRESS_URL}/trade-processor/system/health" "trade-processor"
--
--echo "[check] service metrics expose traderx_messagebus_connected gauge"
--trade_service_metrics="$(curl -fsS "${INGRESS_URL}/trade-service/actuator/prometheus")"
--printf '%s\n' "${trade_service_metrics}" | rg -q 'traderx_messagebus_connected\{component="trade-service",role="publisher"\} 1(\.0+)?$' || {
--  echo "[error] missing connected trade-service message bus gauge"
--  exit 1
--}
--trade_processor_metrics="$(curl -fsS "${INGRESS_URL}/trade-processor/actuator/prometheus")"
--printf '%s\n' "${trade_processor_metrics}" | rg -q 'traderx_messagebus_connected\{component="trade-processor",role="publisher"\} 1(\.0+)?$' || {
--  echo "[error] missing connected trade-processor publisher gauge"
--  exit 1
--}
--printf '%s\n' "${trade_processor_metrics}" | rg -q 'traderx_messagebus_connected\{component="trade-processor",role="subscriber"\} 1(\.0+)?$' || {
--  echo "[error] missing connected trade-processor subscriber gauge"
--  exit 1
--}
--echo "[info] message bus gauges exported by trade-service and trade-processor"
--
--echo "[check] account realtime stream over NATS websocket after trade submit"
--INGRESS_URL="${INGRESS_URL}" TRADE_SERVICE_URL="http://localhost:18092" ACCOUNT_ID="22214" node <<'NODE'
--const ingressUrl = process.env.INGRESS_URL || 'http://localhost:8080';
--const tradeServiceUrl = process.env.TRADE_SERVICE_URL || 'http://localhost:18092';
--const accountId = Number(process.env.ACCOUNT_ID || '22214');
--const wsUrl = ingressUrl.replace(/^http/i, 'ws') + '/nats-ws';
--const tradeTopic = `/accounts/${accountId}/trades`;
--const positionTopic = `/accounts/${accountId}/positions`;
--const qty = 7000 + Math.floor(Math.random() * 500);
--const security = 'IBM';
--const timeoutMs = 20000;
--
--if (typeof WebSocket !== 'function') {
--  console.error('[error] global WebSocket is unavailable in this Node runtime');
--  process.exit(1);
--}
--
--let buffer = '';
--let pending = null;
--let sawTrade = false;
--let sawPosition = false;
--let submitted = false;
--const sidByTopic = new Map([
--  [tradeTopic, 1],
--  [positionTopic, 2],
--]);
--
--function fail(message) {
--  console.error(`[error] ${message}`);
--  process.exit(1);
--}
--
--function maybeDone() {
--  if (sawTrade && sawPosition) {
--    console.log('[info] account trade/position realtime updates received via NATS websocket');
--    process.exit(0);
--  }
--}
--
--function parseFrame(text, ws) {
--  buffer += text;
--  while (true) {
--    if (pending) {
--      const needed = pending.bytes + 2;
--      if (buffer.length < needed) {
--        return;
--      }
--      const payloadText = buffer.slice(0, pending.bytes);
--      buffer = buffer.slice(needed);
--      try {
--        const parsed = JSON.parse(payloadText);
--        const payload = parsed && typeof parsed === 'object' && parsed.payload ? parsed.payload : parsed;
--        if (pending.subject === tradeTopic &&
--            payload &&
--            payload.security === security &&
--            Number(payload.quantity) === qty &&
--            payload.state === 'Settled') {
--          sawTrade = true;
--        }
--        if (pending.subject === positionTopic &&
--            payload &&
--            payload.security === security &&
--            Number.isFinite(Number(payload.quantity))) {
--          sawPosition = true;
--        }
--        maybeDone();
--      } catch (err) {
--        // Ignore unrelated / non-JSON payloads.
--      }
--      pending = null;
--      continue;
--    }
--
--    const eol = buffer.indexOf('\r\n');
--    if (eol < 0) {
--      return;
--    }
--    const line = buffer.slice(0, eol);
--    buffer = buffer.slice(eol + 2);
--    if (!line) {
--      continue;
--    }
--    if (line.startsWith('PING')) {
--      ws.send('PONG\r\n');
--      continue;
--    }
--    if (line.startsWith('INFO') || line.startsWith('PONG')) {
--      continue;
--    }
--    if (line.startsWith('MSG ')) {
--      const parts = line.split(' ');
--      if (parts.length < 4) {
--        continue;
--      }
--      const subject = parts[1];
--      const bytes = Number(parts[parts.length - 1]);
--      if (!Number.isFinite(bytes)) {
--        continue;
--      }
--      pending = { subject, bytes };
--    }
--  }
--}
--
--async function submitTrade() {
--  if (submitted) {
--    return;
--  }
--  submitted = true;
--  const response = await fetch(`${tradeServiceUrl}/trade/`, {
--    method: 'POST',
--    headers: { 'Content-Type': 'application/json' },
--    body: JSON.stringify({
--      security,
--      quantity: qty,
--      accountId,
--      side: 'Buy',
--    }),
--  });
--  if (response.status !== 200) {
--    const body = await response.text();
--    fail(`expected 200 from trade submit, got ${response.status}; body=${body}`);
--  }
--}
--
--const timer = setTimeout(() => {
--  fail(`timed out waiting for realtime account updates (trade=${sawTrade}, position=${sawPosition})`);
--}, timeoutMs);
--
--const ws = new WebSocket(wsUrl);
--ws.onopen = async () => {
--  ws.send('CONNECT {"protocol":1,"verbose":false,"pedantic":false,"echo":false}\r\n');
--  for (const [topic, sid] of sidByTopic.entries()) {
--    ws.send(`SUB ${topic} ${sid}\r\n`);
--  }
--  ws.send('PING\r\n');
--  try {
--    await submitTrade();
--  } catch (err) {
--    clearTimeout(timer);
--    fail(`trade submit failed: ${err.message}`);
--  }
--};
--
--ws.onmessage = async (event) => {
--  if (typeof event.data === 'string') {
--    parseFrame(event.data, ws);
--    return;
--  }
--  if (event.data instanceof Blob) {
--    parseFrame(await event.data.text(), ws);
--    return;
--  }
--  if (event.data instanceof ArrayBuffer) {
--    parseFrame(new TextDecoder().decode(new Uint8Array(event.data)), ws);
--  }
--};
--
--ws.onerror = () => {
--  clearTimeout(timer);
--  fail(`websocket error while connected to ${wsUrl}`);
--};
--
--process.on('exit', () => {
--  clearTimeout(timer);
--  try { ws.close(); } catch (_) {}
--});
--NODE
--
--echo "[check] ingress trade-service unknown ticker validation"
--status_code="$(curl -sS -o /tmp/traderx-state-006-trade.out -w "%{http_code}" \
--  -H "Content-Type: application/json" \
--  -d '{"security":"NOTREAL","quantity":1,"accountId":22214,"side":"Buy"}' \
--  "${INGRESS_URL}/trade-service/trade")"
--cat /tmp/traderx-state-006-trade.out
--echo
--rm -f /tmp/traderx-state-006-trade.out
--if [[ "${status_code}" != "404" ]]; then
--  echo "[error] expected 404 for unknown ticker through ingress, got ${status_code}"
--  exit 1
--fi
--
--echo "[check] baseline component smoke suite in state 006 runtime"
--"${REPO_ROOT}/scripts/test-reference-data-overlay.sh" "${ORIGIN}" "http://localhost:18085"
--"${REPO_ROOT}/scripts/test-people-service-overlay.sh" "${ORIGIN}" "http://localhost:18089" "http://localhost:18088/accountuser/"
--"${REPO_ROOT}/scripts/test-account-service-overlay.sh" "${ORIGIN}" "http://localhost:18088"
--"${REPO_ROOT}/scripts/test-position-service-overlay.sh" "${ORIGIN}" "http://localhost:18090"
--"${REPO_ROOT}/scripts/test-trade-service-overlay.sh" "${ORIGIN}" "http://localhost:18092" "http://localhost:18090"
--"${REPO_ROOT}/scripts/test-web-angular-overlay.sh" "${INGRESS_URL}"
--
--echo "[check] web-front-end state-aware UX contract"
--"${REPO_ROOT}/scripts/test-web-angular-baseline-ux-contract.sh" "${GENERATED_ROOT}/code/target-generated/web-front-end/angular"
--
--echo "[done] state 006 messaging-nats runtime smoke tests passed"
-diff --git a/scripts/test-state-007-observability-lgtm-compose.sh b/scripts/test-state-007-observability-lgtm-compose.sh
-deleted file mode 100755
-index 4e982cb..0000000
---- a/scripts/test-state-007-observability-lgtm-compose.sh
-+++ /dev/null
-@@ -1,210 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--INGRESS_URL="${1:-http://localhost:8080}"
--ORIGIN="${2:-http://localhost:8080}"
--COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-007}"
--GRAFANA_PORT="${GRAFANA_PORT:-3001}"
--GRAFANA_ADMIN_USER="${TRADERX_GRAFANA_ADMIN_USER:-traderx-admin}"
--GRAFANA_ADMIN_PASSWORD="${TRADERX_GRAFANA_ADMIN_PASSWORD:-traderx-state-007}"
--GRAFANA_ADMIN_AUTH="${GRAFANA_ADMIN_USER}:${GRAFANA_ADMIN_PASSWORD}"
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--COMPOSE_FILE="${GENERATED_ROOT}/code/target-generated/observability-lgtm-compose/docker-compose.yml"
--
--if ! command -v docker >/dev/null 2>&1; then
--  echo "[error] docker command not found"
--  exit 1
--fi
--
--if [[ ! -f "${COMPOSE_FILE}" ]]; then
--  echo "[error] compose file not found: ${COMPOSE_FILE}"
--  echo "[hint] run: bash pipeline/generate-state.sh 007-observability-lgtm-compose"
--  exit 1
--fi
--
--echo "[check] compose services running"
--docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps
--running_services="$(docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps --status running --services | wc -l | tr -d ' ')"
--if [[ "${running_services}" -lt 17 ]]; then
--  echo "[error] expected 17+ running services, got ${running_services}"
--  exit 1
--fi
--
--if ! docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps --services | grep -q '^nats-broker$'; then
--  echo "[error] state 007 must include nats-broker from state 006 lineage"
--  exit 1
--fi
--
--if docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps --services | grep -q '^trade-feed$'; then
--  echo "[error] state 007 must not include legacy trade-feed service"
--  exit 1
--fi
--
--echo "[check] observability endpoints"
--for endpoint in \
--  "http://localhost:${GRAFANA_PORT}/api/health" \
--  "http://localhost:9090/-/ready" \
--  "http://localhost:3100/ready" \
--  "http://localhost:3200/ready" \
--  "http://localhost:13133/"; do
--  headers="$(curl -sS -i "${endpoint}" | sed -n '1,20p')"
--  echo "${headers}"
--  printf '%s\n' "${headers}" | grep -q "200" || {
--    echo "[error] expected 200 from ${endpoint}"
--    exit 1
--  }
--done
--
--echo "[check] grafana provisioned dashboards"
--dashboard_count="$(
--  curl -sS -u "${GRAFANA_ADMIN_AUTH}" "http://localhost:${GRAFANA_PORT}/api/search?query=TraderX" \
--  | jq 'length'
--)"
--if [[ "${dashboard_count}" -lt 1 ]]; then
--  echo "[error] expected at least one provisioned Grafana dashboard, got ${dashboard_count}"
--  exit 1
--fi
--echo "[info] grafana dashboards=${dashboard_count}"
--
--echo "[check] grafana includes spring actuator dashboards"
--dashboard_uids_raw="$(
--  curl -sS -u "${GRAFANA_ADMIN_AUTH}" "http://localhost:${GRAFANA_PORT}/api/search?query=TraderX&type=dash-db" \
--  | jq -r '.[].uid'
--)"
--spring_dashboard_uid=""
--while IFS= read -r dashboard_uid; do
--  [[ -z "${dashboard_uid}" ]] && continue
--  dashboard_payload="$(curl -sS -u "${GRAFANA_ADMIN_AUTH}" "http://localhost:${GRAFANA_PORT}/api/dashboards/uid/${dashboard_uid}")"
--  dashboard_text="$(echo "${dashboard_payload}" | jq -r '.dashboard | tostring')"
--  if printf '%s\n' "${dashboard_text}" | rg -q 'http_server_requests_seconds_count|jvm_memory_used_bytes'; then
--    spring_dashboard_uid="${dashboard_uid}"
--    break
--  fi
--done <<< "${dashboard_uids_raw}"
--if [[ -z "${spring_dashboard_uid}" ]]; then
--  echo "[error] no provisioned TraderX dashboard includes expected Spring actuator metric queries"
--  exit 1
--fi
--echo "[info] grafana dashboard uid=${spring_dashboard_uid} includes Spring actuator metric queries"
--
--echo "[check] prometheus traderx probe targets discovered"
--target_count="$(
--  curl -sS "http://localhost:9090/api/v1/targets" \
--  | jq '[.data.activeTargets[] | select(.labels.job=="traderx-http-probe")] | length'
--)"
--if [[ "${target_count}" -lt 8 ]]; then
--  echo "[error] expected 8+ active probe targets, got ${target_count}"
--  exit 1
--fi
--echo "[info] active traderx probe targets=${target_count}"
--
--echo "[check] prometheus spring actuator scrape targets discovered"
--actuator_target_count="$(
--  curl -sS "http://localhost:9090/api/v1/targets" \
--  | jq '[.data.activeTargets[] | select(.labels.job=="traderx-spring-boot-actuator")] | length'
--)"
--if [[ "${actuator_target_count}" -lt 4 ]]; then
--  echo "[error] expected 4+ active Spring actuator targets, got ${actuator_target_count}"
--  exit 1
--fi
--echo "[info] active spring actuator targets=${actuator_target_count}"
--
--echo "[check] spring actuator targets are healthy (up)"
--actuator_target_up_count="$(
--  curl -sS "http://localhost:9090/api/v1/targets" \
--  | jq '[.data.activeTargets[] | select(.labels.job=="traderx-spring-boot-actuator" and .health=="up")] | length'
--)"
--if [[ "${actuator_target_up_count}" -lt 4 ]]; then
--  echo "[error] expected 4+ healthy Spring actuator targets, got ${actuator_target_up_count}"
--  curl -sS "http://localhost:9090/api/v1/targets" \
--    | jq -r '.data.activeTargets[] | select(.labels.job=="traderx-spring-boot-actuator") | "\(.labels.instance) health=\(.health) error=\(.lastError // "")"'
--  exit 1
--fi
--echo "[info] healthy spring actuator targets=${actuator_target_up_count}"
--
--echo "[check] spring services expose /actuator/prometheus"
--for endpoint in \
--  "http://localhost:18088/actuator/prometheus" \
--  "http://localhost:18090/actuator/prometheus" \
--  "http://localhost:18091/actuator/prometheus" \
--  "http://localhost:18092/actuator/prometheus"; do
--  headers="$(curl -sS -i "${endpoint}" | sed -n '1,20p')"
--  echo "${headers}"
--  printf '%s\n' "${headers}" | grep -Eq "HTTP/1\\.[01] 200" || {
--    echo "[error] expected 200 from ${endpoint}"
--    exit 1
--  }
--done
--
--echo "[check] warm representative business endpoints so http_server metrics are non-empty"
--curl -sS "${INGRESS_URL}/account-service/account/22214" >/dev/null
--curl -sS "${INGRESS_URL}/position-service/positions/22214" >/dev/null
--curl -sS "${INGRESS_URL}/trade-service/v3/api-docs" >/dev/null
--curl -sS "${INGRESS_URL}/trade-processor/health" >/dev/null
--
--echo "[check] prometheus spring actuator metric families are queryable"
--actuator_metric_samples="$(
--  curl -sS --get "http://localhost:9090/api/v1/query" \
--    --data-urlencode 'query=count(http_server_requests_seconds_count{job="traderx-spring-boot-actuator"})' \
--  | jq -r '.data.result[0].value[1] // "0"'
--)"
--if ! awk "BEGIN {exit !(${actuator_metric_samples} > 0)}"; then
--  echo "[error] expected Spring actuator metric samples in Prometheus query results, got ${actuator_metric_samples}"
--  exit 1
--fi
--echo "[info] spring actuator metric sample count=${actuator_metric_samples}"
--
--echo "[check] grafana loki datasource has non-empty log streams"
--now_ms=$(($(date +%s) * 1000))
--from_ms=$((now_ms - 15 * 60 * 1000))
--loki_total_query_result="$(
--  curl -sS -u "${GRAFANA_ADMIN_AUTH}" -H 'Content-Type: application/json' -X POST "http://localhost:${GRAFANA_PORT}/api/ds/query" \
--    -d "{\"from\":\"${from_ms}\",\"to\":\"${now_ms}\",\"queries\":[{\"refId\":\"A\",\"datasource\":{\"uid\":\"loki\",\"type\":\"loki\"},\"expr\":\"sum(count_over_time({compose_project=\\\"${COMPOSE_PROJECT_NAME}\\\"}[5m]))\",\"queryType\":\"range\",\"intervalMs\":1000,\"maxDataPoints\":500}]}"
--)"
--loki_total_query_error="$(echo "${loki_total_query_result}" | jq -r '.results.A.error // empty')"
--loki_total_last="$(echo "${loki_total_query_result}" | jq -r '.results.A.frames[0].data.values[1][-1] // "0"')"
--if [[ -n "${loki_total_query_error}" ]]; then
--  echo "[error] grafana loki query failed: ${loki_total_query_error}"
--  exit 1
--fi
--if ! awk "BEGIN {exit !(${loki_total_last} > 0)}"; then
--  echo "[error] expected non-empty Loki ingestion in last 5m, got ${loki_total_last}"
--  exit 1
--fi
--
--echo "[check] dashboard service-filtered logs are present (runtime + messaging + control-plane)"
--loki_service_query_result="$(
--  curl -sS -u "${GRAFANA_ADMIN_AUTH}" -H 'Content-Type: application/json' -X POST "http://localhost:${GRAFANA_PORT}/api/ds/query" \
--    -d "{\"from\":\"${from_ms}\",\"to\":\"${now_ms}\",\"queries\":[{\"refId\":\"A\",\"datasource\":{\"uid\":\"loki\",\"type\":\"loki\"},\"expr\":\"sum(count_over_time({compose_project=\\\"${COMPOSE_PROJECT_NAME}\\\",service=~\\\"nats-broker|trade-service|trade-processor|web-front-end-angular|ingress|grafana|loki|tempo|otel-collector|prometheus|promtail\\\"}[10m]))\",\"queryType\":\"range\",\"intervalMs\":1000,\"maxDataPoints\":500}]}"
--)"
--loki_service_query_error="$(echo "${loki_service_query_result}" | jq -r '.results.A.error // empty')"
--loki_service_last="$(echo "${loki_service_query_result}" | jq -r '.results.A.frames[0].data.values[1][-1] // "0"')"
--if [[ -n "${loki_service_query_error}" ]]; then
--  echo "[error] grafana loki service-filter query failed: ${loki_service_query_error}"
--  exit 1
--fi
--if ! awk "BEGIN {exit !(${loki_service_last} > 0)}"; then
--  echo "[error] expected non-empty service-filtered Loki logs for dashboard panels, got ${loki_service_last}"
--  exit 1
--fi
--
--echo "[check] baseline behavior under observability runtime"
--TRADERX_COMPOSE_FILE="${COMPOSE_FILE}" COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}" \
--  "${REPO_ROOT}/scripts/test-state-006-messaging-nats-replacement.sh" "${INGRESS_URL}" "${ORIGIN}"
--
--echo "[done] state 007 observability runtime smoke tests passed"
-diff --git a/scripts/test-state-008-pricing-awareness-market-data.sh b/scripts/test-state-008-pricing-awareness-market-data.sh
-deleted file mode 100755
-index f784755..0000000
---- a/scripts/test-state-008-pricing-awareness-market-data.sh
-+++ /dev/null
-@@ -1,314 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--INGRESS_URL="http://localhost:8080"
--ORIGIN="http://localhost:8080"
--COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-008}"
--GRAFANA_PORT="${GRAFANA_PORT:-3001}"
--GRAFANA_ADMIN_USER="${TRADERX_GRAFANA_ADMIN_USER:-traderx-admin}"
--GRAFANA_ADMIN_PASSWORD="${TRADERX_GRAFANA_ADMIN_PASSWORD:-traderx-state-008}"
--GRAFANA_ADMIN_AUTH="${GRAFANA_ADMIN_USER}:${GRAFANA_ADMIN_PASSWORD}"
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--SKIP_MESSAGING=0
--
--while (( "$#" )); do
--  case "$1" in
--    --skip-messaging)
--      SKIP_MESSAGING=1
--      ;;
--    *)
--      if [[ "${INGRESS_URL}" == "http://localhost:8080" ]]; then
--        INGRESS_URL="$1"
--      elif [[ "${ORIGIN}" == "http://localhost:8080" ]]; then
--        ORIGIN="$1"
--      else
--        echo "[error] unknown argument: $1"
--        echo "[hint] usage: $0 [INGRESS_URL] [ORIGIN] [--skip-messaging]"
--        exit 1
--      fi
--      ;;
--  esac
--  shift
--done
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    args=("${INGRESS_URL}" "${ORIGIN}")
--    if [[ "${SKIP_MESSAGING}" -eq 1 ]]; then
--      args+=("--skip-messaging")
--    fi
--    exec "${LOCAL_RUNTIME_SCRIPT}" "${args[@]}"
--  fi
--fi
--COMPOSE_FILE="${GENERATED_ROOT}/code/target-generated/pricing-awareness-market-data/docker-compose.yml"
--
--if ! command -v docker >/dev/null 2>&1; then
--  echo "[error] docker command not found"
--  exit 1
--fi
--
--if [[ ! -f "${COMPOSE_FILE}" ]]; then
--  echo "[error] compose file not found: ${COMPOSE_FILE}"
--  echo "[hint] run: bash pipeline/generate-state.sh 008-pricing-awareness-market-data"
--  exit 1
--fi
--
--check_message_bus_health_endpoint() {
--  local endpoint="$1"
--  local component="$2"
--  local payload
--  payload="$(curl -fsS "${endpoint}")"
--
--  local top_status
--  top_status="$(echo "${payload}" | jq -r '.status // empty')"
--  if [[ "${top_status}" != "ok" ]]; then
--    echo "[error] ${component} system health is not ok at ${endpoint}: status=${top_status}"
--    echo "${payload}"
--    exit 1
--  fi
--
--  local statuses
--  statuses="$(echo "${payload}" | jq -r '
--    if (.messageBus | type) != "object" then
--      empty
--    elif ((.messageBus | has("publisher")) or (.messageBus | has("subscriber"))) then
--      [.messageBus.publisher.status?, .messageBus.subscriber.status?] | .[]
--    else
--      .messageBus.status // empty
--    end
--  ')"
--
--  if [[ -z "${statuses//[$'\n\r\t ']}" ]]; then
--    echo "[error] ${component} system health missing messageBus status payload at ${endpoint}"
--    echo "${payload}"
--    exit 1
--  fi
--
--  while IFS= read -r bus_status; do
--    [[ -z "${bus_status}" ]] && continue
--    if [[ "${bus_status}" != "connected" ]]; then
--      echo "[error] ${component} message bus is not connected at ${endpoint}: status=${bus_status}"
--      echo "${payload}"
--      exit 1
--    fi
--  done <<< "${statuses}"
--}
--
--echo "[check] compose services running"
--docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps
--running_services="$(docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps --status running --services | wc -l | tr -d ' ')"
--if [[ "${running_services}" -lt 11 ]]; then
--  echo "[error] expected 11+ running services, got ${running_services}"
--  exit 1
--fi
--
--if docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps --services | grep -q '^trade-feed$'; then
--  echo "[error] state 008 runtime must not contain trade-feed service"
--  exit 1
--fi
--
--echo "[check] postgres readiness"
--docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" exec -T database \
--  pg_isready -U traderx -d traderx
--
--echo "[check] postgres baseline data loaded"
--accounts_count="$(docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" exec -T database \
--  psql -U traderx -d traderx -tAc "select count(*) from accounts;" | tr -d '[:space:]')"
--if [[ -z "${accounts_count}" || "${accounts_count}" -lt 7 ]]; then
--  echo "[error] expected baseline accounts in postgres, got count=${accounts_count:-0}"
--  exit 1
--fi
--
--echo "[check] price-publisher quote endpoint"
--price_headers="$(curl -sS -i "http://localhost:18100/prices/IBM" | sed -n '1,30p')"
--echo "${price_headers}"
--printf '%s\n' "${price_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from price-publisher /prices/IBM"
--  exit 1
--}
--curl -sS "http://localhost:18100/prices/IBM" | jq -e '.ticker == "IBM" and (.price|type=="number")' >/dev/null || {
--  echo "[error] price-publisher quote payload missing expected fields"
--  exit 1
--}
--
--echo "[check] nginx ingress health endpoint"
--health_headers="$(curl -sS -i "${INGRESS_URL}/health" | sed -n '1,20p')"
--echo "${health_headers}"
--printf '%s\n' "${health_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress /health"
--  exit 1
--}
--
--echo "[check] ingress UI root"
--ui_headers="$(curl -sS -i "${INGRESS_URL}/" | sed -n '1,20p')"
--echo "${ui_headers}"
--printf '%s\n' "${ui_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from ingress UI root"
--  exit 1
--}
--
--echo "[check] api explorer pubsub inspector contract"
--bash "${REPO_ROOT}/scripts/test-api-explorer-pubsub-inspector.sh" \
--  "${INGRESS_URL}" \
--  "specs/008-pricing-awareness-market-data/system/messaging-subject-map.md"
--
--echo "[check] NATS broker monitor endpoint"
--nats_varz_headers="$(curl -sS -i "http://localhost:8222/varz" | sed -n '1,30p')"
--echo "${nats_varz_headers}"
--printf '%s\n' "${nats_varz_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected 200 from NATS monitor endpoint"
--  exit 1
--}
--curl -sS "http://localhost:8222/varz" | jq -e '.server_id and .max_payload and .proto' >/dev/null || {
--  echo "[error] NATS /varz payload missing required keys"
--  exit 1
--}
--
--echo "[check] ingress websocket upgrade route to NATS"
--ws_headers="$(
--  curl -sS -i --max-time 5 \
--    -H "Connection: Upgrade" \
--    -H "Upgrade: websocket" \
--    -H "Sec-WebSocket-Version: 13" \
--    -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
--    "${INGRESS_URL}/nats-ws" 2>/dev/null | sed -n '1,30p' || true
--)"
--echo "${ws_headers}"
--printf '%s\n' "${ws_headers}" | grep -Eq "HTTP/1\\.[01] 101|HTTP/2 101" || {
--  echo "[error] expected websocket 101 response from ${INGRESS_URL}/nats-ws"
--  exit 1
--}
--
--echo "[check] message bus connectivity pre-check via /system/health"
--check_message_bus_health_endpoint "${INGRESS_URL}/trade-service/system/health" "trade-service"
--check_message_bus_health_endpoint "${INGRESS_URL}/trade-processor/system/health" "trade-processor"
--
--if docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps --status running --services | grep -q '^prometheus$'; then
--  echo "[check] prometheus message bus connectivity metric is queryable"
--  message_bus_sample_count="$(
--    curl -sS --get "http://localhost:9090/api/v1/query" \
--      --data-urlencode 'query=traderx_messagebus_connected' \
--    | jq -r '.data.result | length'
--  )"
--  if [[ "${message_bus_sample_count}" -lt 3 ]]; then
--    echo "[error] expected 3+ traderx_messagebus_connected samples in Prometheus, got ${message_bus_sample_count}"
--    exit 1
--  fi
--  echo "[info] traderx_messagebus_connected series=${message_bus_sample_count}"
--else
--  echo "[info] prometheus service is not part of state 008 compose; skipping Prometheus metric assertions"
--fi
--
--if docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps --status running --services | grep -q '^grafana$'; then
--  echo "[check] grafana includes message bus connectivity dashboard/panel query"
--  dashboard_uids_raw="$(
--    curl -sS -u "${GRAFANA_ADMIN_AUTH}" "http://localhost:${GRAFANA_PORT}/api/search?query=TraderX&type=dash-db" \
--    | jq -r '.[].uid'
--  )"
--  message_bus_dashboard_uid=""
--  while IFS= read -r dashboard_uid; do
--    [[ -z "${dashboard_uid}" ]] && continue
--    dashboard_payload="$(curl -sS -u "${GRAFANA_ADMIN_AUTH}" "http://localhost:${GRAFANA_PORT}/api/dashboards/uid/${dashboard_uid}")"
--    dashboard_text="$(echo "${dashboard_payload}" | jq -r '.dashboard | tostring')"
--    if printf '%s\n' "${dashboard_text}" | rg -q 'traderx_messagebus_connected'; then
--      message_bus_dashboard_uid="${dashboard_uid}"
--      break
--    fi
--  done <<< "${dashboard_uids_raw}"
--  if [[ -z "${message_bus_dashboard_uid}" ]]; then
--    echo "[error] no provisioned TraderX dashboard includes traderx_messagebus_connected query"
--    exit 1
--  fi
--  echo "[info] grafana dashboard uid=${message_bus_dashboard_uid} includes message bus connectivity query"
--else
--  echo "[info] grafana service is not part of state 008 compose; skipping dashboard assertions"
--fi
--
--if docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps --status running --services | grep -q '^grafana$'; then
--  echo "[check] grafana loki datasource has non-empty pricing/runtime log streams"
--  now_ms=$(($(date +%s) * 1000))
--  from_ms=$((now_ms - 15 * 60 * 1000))
--  loki_total_query_result="$(
--    curl -sS -u "${GRAFANA_ADMIN_AUTH}" -H 'Content-Type: application/json' -X POST "http://localhost:${GRAFANA_PORT}/api/ds/query" \
--      -d "{\"from\":\"${from_ms}\",\"to\":\"${now_ms}\",\"queries\":[{\"refId\":\"A\",\"datasource\":{\"uid\":\"loki\",\"type\":\"loki\"},\"expr\":\"sum(count_over_time({compose_project=\\\"${COMPOSE_PROJECT_NAME}\\\"}[5m]))\",\"queryType\":\"range\",\"intervalMs\":1000,\"maxDataPoints\":500}]}"
--  )"
--  loki_total_query_error="$(echo "${loki_total_query_result}" | jq -r '.results.A.error // empty')"
--  loki_total_last="$(echo "${loki_total_query_result}" | jq -r '.results.A.frames[0].data.values[1][-1] // "0"')"
--  if [[ -n "${loki_total_query_error}" ]]; then
--    echo "[error] grafana loki query failed: ${loki_total_query_error}"
--    exit 1
--  fi
--  if ! awk "BEGIN {exit !(${loki_total_last} > 0)}"; then
--    echo "[error] expected non-empty Loki ingestion in last 5m, got ${loki_total_last}"
--    exit 1
--  fi
--
--  echo "[check] dashboard service-filtered pricing pipeline logs are present"
--  loki_service_query_result="$(
--    curl -sS -u "${GRAFANA_ADMIN_AUTH}" -H 'Content-Type: application/json' -X POST "http://localhost:${GRAFANA_PORT}/api/ds/query" \
--      -d "{\"from\":\"${from_ms}\",\"to\":\"${now_ms}\",\"queries\":[{\"refId\":\"A\",\"datasource\":{\"uid\":\"loki\",\"type\":\"loki\"},\"expr\":\"sum(count_over_time({compose_project=\\\"${COMPOSE_PROJECT_NAME}\\\",service=~\\\"price-publisher|trade-service|trade-processor|position-service|nats-broker|web-front-end-angular\\\"}[10m]))\",\"queryType\":\"range\",\"intervalMs\":1000,\"maxDataPoints\":500}]}"
--  )"
--  loki_service_query_error="$(echo "${loki_service_query_result}" | jq -r '.results.A.error // empty')"
--  loki_service_last="$(echo "${loki_service_query_result}" | jq -r '.results.A.frames[0].data.values[1][-1] // "0"')"
--  if [[ -n "${loki_service_query_error}" ]]; then
--    echo "[error] grafana loki service-filter query failed: ${loki_service_query_error}"
--    exit 1
--  fi
--  if ! awk "BEGIN {exit !(${loki_service_last} > 0)}"; then
--    echo "[error] expected non-empty service-filtered Loki logs for pricing dashboards, got ${loki_service_last}"
--    exit 1
--  fi
--else
--  echo "[info] grafana service is not part of state 008 compose; skipping Loki datasource assertions"
--fi
--
--echo "[check] ingress trade-service unknown ticker validation"
--status_code="$(curl -sS -o /tmp/traderx-state-008-trade.out -w "%{http_code}" \
--  -H "Content-Type: application/json" \
--  -d '{"security":"NOTREAL","quantity":1,"accountId":22214,"side":"Buy"}' \
--  "${INGRESS_URL}/trade-service/trade")"
--cat /tmp/traderx-state-008-trade.out
--echo
--rm -f /tmp/traderx-state-008-trade.out
--if [[ "${status_code}" != "404" ]]; then
--  echo "[error] expected 404 for unknown ticker through ingress, got ${status_code}"
--  exit 1
--fi
--
--echo "[check] persisted trade/position include price and average cost basis"
--curl -sS "http://localhost:18090/trades/22214" | jq -e 'length > 0 and (.[0].price != null)' >/dev/null || {
--  echo "[error] expected persisted trades to include price"
--  exit 1
--}
--curl -sS "http://localhost:18090/positions/22214" | jq -e 'length > 0 and (.[0].averageCostBasis != null)' >/dev/null || {
--  echo "[error] expected persisted positions to include averageCostBasis"
--  exit 1
--}
--
--echo "[check] baseline component smoke suite in state 008 runtime"
--TRADERX_LOCAL_RUNTIME_SCRIPT=1 "${REPO_ROOT}/scripts/test-reference-data-overlay.sh" "${ORIGIN}" "http://localhost:18085" "20"
--TRADERX_LOCAL_RUNTIME_SCRIPT=1 "${REPO_ROOT}/scripts/test-people-service-overlay.sh" "${ORIGIN}" "http://localhost:18089" "http://localhost:18088/accountuser/"
--TRADERX_LOCAL_RUNTIME_SCRIPT=1 "${REPO_ROOT}/scripts/test-account-service-overlay.sh" "${ORIGIN}" "http://localhost:18088"
--TRADERX_LOCAL_RUNTIME_SCRIPT=1 "${REPO_ROOT}/scripts/test-position-service-overlay.sh" "${ORIGIN}" "http://localhost:18090"
--TRADERX_LOCAL_RUNTIME_SCRIPT=1 "${REPO_ROOT}/scripts/test-trade-service-overlay.sh" "${ORIGIN}" "http://localhost:18092" "http://localhost:18090"
--TRADERX_LOCAL_RUNTIME_SCRIPT=1 "${REPO_ROOT}/scripts/test-web-angular-overlay.sh" "${INGRESS_URL}"
--echo "[check] web-front-end state-aware UX contract"
--TRADERX_LOCAL_RUNTIME_SCRIPT=1 "${REPO_ROOT}/scripts/test-web-angular-baseline-ux-contract.sh" "${GENERATED_ROOT}/code/target-generated/web-front-end/angular"
--
--if [[ "${SKIP_MESSAGING}" -eq 1 ]]; then
--  echo "[info] skipping messaging smoke step (--skip-messaging)"
--else
--  echo "[check] messaging smoke step (post-functional): state 008"
--  TRADERX_LOCAL_RUNTIME_SCRIPT=1 "${REPO_ROOT}/scripts/test-messaging-008-pricing-awareness-market-data.sh" "${INGRESS_URL}" "http://localhost:18092" "22214"
--fi
--
--echo "[done] state 008 pricing-awareness runtime smoke tests passed"
-diff --git a/scripts/test-state-009-order-management-matcher.sh b/scripts/test-state-009-order-management-matcher.sh
-deleted file mode 100755
-index 9ea3c78..0000000
---- a/scripts/test-state-009-order-management-matcher.sh
-+++ /dev/null
-@@ -1,580 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--INGRESS_URL="http://localhost:8080"
--ORDER_MATCHER_PORT="${ORDER_MATCHER_PORT:-18110}"
--COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-009}"
--GRAFANA_PORT="${GRAFANA_PORT:-3001}"
--GRAFANA_ADMIN_USER="${TRADERX_GRAFANA_ADMIN_USER:-traderx-admin}"
--GRAFANA_ADMIN_PASSWORD="${TRADERX_GRAFANA_ADMIN_PASSWORD:-traderx-state-009}"
--GRAFANA_ADMIN_AUTH="${GRAFANA_ADMIN_USER}:${GRAFANA_ADMIN_PASSWORD}"
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--SKIP_MESSAGING=0
--
--while (( "$#" )); do
--  case "$1" in
--    --skip-messaging)
--      SKIP_MESSAGING=1
--      ;;
--    *)
--      if [[ "${INGRESS_URL}" == "http://localhost:8080" ]]; then
--        INGRESS_URL="$1"
--      else
--        echo "[error] unknown argument: $1"
--        echo "[hint] usage: $0 [INGRESS_URL] [--skip-messaging]"
--        exit 1
--      fi
--      ;;
--  esac
--  shift
--done
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    args=("${INGRESS_URL}")
--    if [[ "${SKIP_MESSAGING}" -eq 1 ]]; then
--      args+=("--skip-messaging")
--    fi
--    exec "${LOCAL_RUNTIME_SCRIPT}" "${args[@]}"
--  fi
--fi
--COMPOSE_FILE="${GENERATED_ROOT}/code/target-generated/order-management-matcher/docker-compose.yml"
--
--if ! command -v docker >/dev/null 2>&1; then
--  echo "[error] docker command not found"
--  exit 1
--fi
--
--if [[ ! -f "${COMPOSE_FILE}" ]]; then
--  echo "[error] compose file not found: ${COMPOSE_FILE}"
--  echo "[hint] run: bash pipeline/generate-state.sh 009-order-management-matcher"
--  exit 1
--fi
--
--check_message_bus_health_endpoint() {
--  local endpoint="$1"
--  local component="$2"
--  local payload
--  payload="$(curl -fsS "${endpoint}")"
--
--  local top_status
--  top_status="$(echo "${payload}" | jq -r '.status // empty')"
--  if [[ "${top_status}" != "ok" ]]; then
--    echo "[error] ${component} system health is not ok at ${endpoint}: status=${top_status}"
--    echo "${payload}"
--    exit 1
--  fi
--
--  local statuses
--  statuses="$(echo "${payload}" | jq -r '
--    if (.messageBus | type) != "object" then
--      empty
--    elif ((.messageBus | has("publisher")) or (.messageBus | has("subscriber"))) then
--      [.messageBus.publisher.status?, .messageBus.subscriber.status?] | .[]
--    else
--      .messageBus.status // empty
--    end
--  ')"
--
--  if [[ -z "${statuses//[$'\n\r\t ']}" ]]; then
--    echo "[error] ${component} system health missing messageBus status payload at ${endpoint}"
--    echo "${payload}"
--    exit 1
--  fi
--
--  while IFS= read -r bus_status; do
--    [[ -z "${bus_status}" ]] && continue
--    if [[ "${bus_status}" != "connected" ]]; then
--      echo "[error] ${component} message bus is not connected at ${endpoint}: status=${bus_status}"
--      echo "${payload}"
--      exit 1
--    fi
--  done <<< "${statuses}"
--}
--
--echo "[check] compose services running"
--docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps
--running_services="$(docker compose -f "${COMPOSE_FILE}" --project-name "${COMPOSE_PROJECT_NAME}" ps --status running --services | wc -l | tr -d ' ')"
--if [[ "${running_services}" -lt 19 ]]; then
--  echo "[error] expected 19+ running services, got ${running_services}"
--  exit 1
--fi
--
--echo "[check] observability control-plane endpoints"
--for endpoint in \
--  "http://localhost:${GRAFANA_PORT}/api/health" \
--  "http://localhost:9090/-/ready" \
--  "http://localhost:3100/ready" \
--  "http://localhost:3200/ready"; do
--  headers="$(curl -sS -i "${endpoint}" | sed -n '1,20p')"
--  echo "${headers}"
--  printf '%s\n' "${headers}" | grep -q "200" || {
--    echo "[error] expected 200 from ${endpoint}"
--    exit 1
--  }
--done
--
--echo "[check] message bus connectivity pre-check via /system/health"
--check_message_bus_health_endpoint "${INGRESS_URL}/trade-service/system/health" "trade-service"
--check_message_bus_health_endpoint "${INGRESS_URL}/trade-processor/system/health" "trade-processor"
--check_message_bus_health_endpoint "${INGRESS_URL}/order-matcher/system/health" "order-matcher"
--
--echo "[check] prometheus message bus connectivity metric is queryable"
--message_bus_sample_count="$(
--  curl -sS --get "http://localhost:9090/api/v1/query" \
--    --data-urlencode 'query=traderx_messagebus_connected' \
--  | jq -r '.data.result | length'
--)"
--if [[ "${message_bus_sample_count}" -lt 4 ]]; then
--  echo "[error] expected 4+ traderx_messagebus_connected samples in Prometheus, got ${message_bus_sample_count}"
--  exit 1
--fi
--echo "[info] traderx_messagebus_connected series=${message_bus_sample_count}"
--
--echo "[check] order matcher health and metrics endpoints"
--health_headers="$(curl -sS -i "http://localhost:${ORDER_MATCHER_PORT}/health" | sed -n '1,20p')"
--echo "${health_headers}"
--printf '%s\n' "${health_headers}" | grep -q "200" || {
--  echo "[error] expected 200 from order matcher health endpoint"
--  exit 1
--}
--
--metrics_body="$(curl -fsS "http://localhost:${ORDER_MATCHER_PORT}/metrics")"
--printf '%s\n' "${metrics_body}" | rg -q '^traderx_orders_open_total' || {
--  echo "[error] missing metric traderx_orders_open_total"
--  exit 1
--}
--printf '%s\n' "${metrics_body}" | rg -q '^traderx_orders_unfilled_total' || {
--  echo "[error] missing metric traderx_orders_unfilled_total"
--  exit 1
--}
--printf '%s\n' "${metrics_body}" | rg -q '^traderx_order_events_total' || {
--  echo "[error] missing metric traderx_order_events_total"
--  exit 1
--}
--printf '%s\n' "${metrics_body}" | rg -q '^traderx_order_match_latency_seconds_bucket' || {
--  echo "[error] missing metric traderx_order_match_latency_seconds histogram"
--  exit 1
--}
--echo "[info] required order metrics detected"
--
--echo "[check] grafana order dashboards provisioned"
--dashboard_uids_raw="$(
--  curl -sS -u "${GRAFANA_ADMIN_AUTH}" "http://localhost:${GRAFANA_PORT}/api/search?query=TraderX&type=dash-db" \
--  | jq -r '.[].uid'
--)"
--if [[ -z "${dashboard_uids_raw}" ]]; then
--  echo "[error] expected at least one provisioned TraderX dashboard in Grafana (type=dash-db)"
--  exit 1
--fi
--order_metrics_dashboard_uid=""
--while IFS= read -r dashboard_uid; do
--  [[ -z "${dashboard_uid}" ]] && continue
--  dashboard_payload="$(curl -sS -u "${GRAFANA_ADMIN_AUTH}" "http://localhost:${GRAFANA_PORT}/api/dashboards/uid/${dashboard_uid}")"
--  dashboard_text="$(echo "${dashboard_payload}" | jq -r '.dashboard | tostring')"
--  if printf '%s\n' "${dashboard_text}" | rg -q 'traderx_orders_open_total|traderx_order_events_total'; then
--    order_metrics_dashboard_uid="${dashboard_uid}"
--    break
--  fi
--done <<< "${dashboard_uids_raw}"
--if [[ -z "${order_metrics_dashboard_uid}" ]]; then
--  echo "[error] no provisioned TraderX dashboard includes order observability metric queries"
--  exit 1
--fi
--echo "[info] grafana dashboard uid=${order_metrics_dashboard_uid} includes order observability metrics"
--
--echo "[check] grafana includes order + spring actuator SLI dashboard coverage"
--order_sli_dashboard_uid=""
--while IFS= read -r dashboard_uid; do
--  [[ -z "${dashboard_uid}" ]] && continue
--  dashboard_payload="$(curl -sS -u "${GRAFANA_ADMIN_AUTH}" "http://localhost:${GRAFANA_PORT}/api/dashboards/uid/${dashboard_uid}")"
--  dashboard_text="$(echo "${dashboard_payload}" | jq -r '.dashboard | tostring')"
--  if printf '%s\n' "${dashboard_text}" | rg -q 'traderx_order_match_latency_seconds_bucket|http_server_requests_seconds_count'; then
--    order_sli_dashboard_uid="${dashboard_uid}"
--    break
--  fi
--done <<< "${dashboard_uids_raw}"
--if [[ -z "${order_sli_dashboard_uid}" ]]; then
--  echo "[error] no provisioned TraderX dashboard includes combined order matcher + Spring actuator SLI queries"
--  exit 1
--fi
--echo "[info] grafana dashboard uid=${order_sli_dashboard_uid} includes order matcher + actuator SLI queries"
--
--echo "[check] grafana includes message bus connectivity panel query"
--message_bus_dashboard_uid=""
--while IFS= read -r dashboard_uid; do
--  [[ -z "${dashboard_uid}" ]] && continue
--  dashboard_payload="$(curl -sS -u "${GRAFANA_ADMIN_AUTH}" "http://localhost:${GRAFANA_PORT}/api/dashboards/uid/${dashboard_uid}")"
--  dashboard_text="$(echo "${dashboard_payload}" | jq -r '.dashboard | tostring')"
--  if printf '%s\n' "${dashboard_text}" | rg -q 'traderx_messagebus_connected'; then
--    message_bus_dashboard_uid="${dashboard_uid}"
--    break
--  fi
--done <<< "${dashboard_uids_raw}"
--if [[ -z "${message_bus_dashboard_uid}" ]]; then
--  echo "[error] no provisioned TraderX dashboard includes traderx_messagebus_connected query"
--  exit 1
--fi
--echo "[info] grafana dashboard uid=${message_bus_dashboard_uid} includes message bus connectivity query"
--
--echo "[check] prometheus discovered order-matcher scrape target"
--target_count="$(
--  curl -sS "http://localhost:9090/api/v1/targets" \
--  | jq '[.data.activeTargets[] | select(((.labels.instance // "") | test("order-matcher")) or ((.discoveredLabels.__address__ // "") | test("order-matcher")))] | length'
--)"
--if [[ "${target_count}" -lt 1 ]]; then
--  echo "[error] expected at least one active order-matcher target in Prometheus"
--  exit 1
--fi
--echo "[info] prometheus order-matcher targets=${target_count}"
--
--echo "[check] prometheus spring actuator scrape targets discovered"
--actuator_target_count="$(
--  curl -sS "http://localhost:9090/api/v1/targets" \
--  | jq '[.data.activeTargets[] | select(.labels.job=="traderx-spring-boot-actuator")] | length'
--)"
--if [[ "${actuator_target_count}" -lt 5 ]]; then
--  echo "[error] expected 5+ active Spring actuator targets, got ${actuator_target_count}"
--  exit 1
--fi
--echo "[info] active spring actuator targets=${actuator_target_count}"
--
--echo "[check] prometheus order-matcher actuator metrics are queryable"
--order_matcher_http_samples="$(
--  curl -sS --get "http://localhost:9090/api/v1/query" \
--    --data-urlencode 'query=count(http_server_requests_seconds_count{job="traderx-spring-boot-actuator",instance=~".*order-matcher.*"})' \
--  | jq -r '.data.result[0].value[1] // "0"'
--)"
--if ! awk "BEGIN {exit !(${order_matcher_http_samples} > 0)}"; then
--  echo "[error] expected order-matcher Spring actuator HTTP metrics in Prometheus query results, got ${order_matcher_http_samples}"
--  exit 1
--fi
--echo "[info] order-matcher actuator metric sample count=${order_matcher_http_samples}"
--
--echo "[check] ingress remains healthy"
--curl -fsS "${INGRESS_URL}/health" >/dev/null
--
--echo "[check] api explorer pubsub inspector contract"
--bash "${REPO_ROOT}/scripts/test-api-explorer-pubsub-inspector.sh" \
--  "${INGRESS_URL}" \
--  "specs/009-order-management-matcher/system/messaging-subject-map.md"
--
--echo "[check] frontend order views use push updates (no polling regressions)"
--ORDER_UI_ROOT="${GENERATED_ROOT}/code/target-generated/web-front-end/angular/main/app"
--ORDER_BLOTTER_FILE="${ORDER_UI_ROOT}/trade/order-blotter/order-blotter.component.ts"
--ORDER_ADMIN_FILE="${ORDER_UI_ROOT}/admin/order-admin.component.ts"
--ORDER_ADMIN_SERVICE_FILE="${ORDER_UI_ROOT}/service/order-admin.service.ts"
--for file in "${ORDER_BLOTTER_FILE}" "${ORDER_ADMIN_FILE}" "${ORDER_ADMIN_SERVICE_FILE}"; do
--  if [[ ! -f "${file}" ]]; then
--    echo "[error] expected order UI file not found: ${file}"
--    exit 1
--  fi
--done
--if rg -n 'interval\(|setInterval\(' "${ORDER_BLOTTER_FILE}" "${ORDER_ADMIN_FILE}" >/dev/null; then
--  echo "[error] polling detected in order UI components; expected websocket push subscriptions"
--  exit 1
--fi
--rg -Fq "/accounts/\${accountId}/orders" "${ORDER_BLOTTER_FILE}" || {
--  echo "[error] expected order-blotter to define account-scoped realtime topic template"
--  exit 1
--}
--rg -Fq "'/orders'" "${ORDER_BLOTTER_FILE}" || {
--  echo "[error] expected order-blotter to define all-accounts realtime topic"
--  exit 1
--}
--rg -Fq 'orderAdminService.subscribe(topic' "${ORDER_BLOTTER_FILE}" || {
--  echo "[error] expected order-blotter to subscribe via orderAdminService.subscribe(topic, callback)"
--  exit 1
--}
--rg -q '/orders' "${ORDER_ADMIN_FILE}" || {
--  echo "[error] expected order-admin to subscribe to /orders realtime topic"
--  exit 1
--}
--rg -q 'subscribe\(topic' "${ORDER_ADMIN_SERVICE_FILE}" || {
--  echo "[error] expected order-admin service to expose realtime subscribe(topic, callback)"
--  exit 1
--}
--
--echo "[check] order admin API through ingress"
--orders_payload="$(curl -fsS "${INGRESS_URL}/order-matcher/orders?status=open")"
--echo "${orders_payload}" | jq '.[0]' >/dev/null
--orders_count="$(echo "${orders_payload}" | jq 'length')"
--if [[ "${orders_count}" -lt 1 ]]; then
--  echo "[error] expected at least one open order from ingress order-matcher API"
--  exit 1
--fi
--echo "[info] open orders via ingress=${orders_count}"
--
--echo "[check] user journey: create order from ticket flow"
--pre_open_count="$(curl -fsS "${INGRESS_URL}/order-matcher/orders/open-count" | jq -r '.openOrders')"
--create_payload='{"accountId":22214,"security":"IBM","side":"Buy","quantity":77,"limitPrice":1.000}'
--create_response="$(
--  curl -sS -w '\n%{http_code}' \
--    -H "Content-Type: application/json" \
--    -X POST \
--    -d "${create_payload}" \
--    "${INGRESS_URL}/order-matcher/orders"
--)"
--create_http="$(echo "${create_response}" | tail -n1)"
--create_body="$(echo "${create_response}" | sed '$d')"
--if [[ "${create_http}" != "201" ]]; then
--  echo "[error] expected 201 from create order, got ${create_http}"
--  echo "${create_body}"
--  exit 1
--fi
--created_order_id="$(echo "${create_body}" | jq -r '.orderId // empty')"
--if [[ -z "${created_order_id}" ]]; then
--  echo "[error] create order response missing orderId"
--  echo "${create_body}"
--  exit 1
--fi
--echo "[info] created order=${created_order_id}"
--
--echo "[check] user journey: account-scoped open orders listing includes created order"
--account_open_orders="$(curl -fsS "${INGRESS_URL}/order-matcher/orders?status=open&accountId=22214")"
--listed_count="$(echo "${account_open_orders}" | jq --arg order_id "${created_order_id}" '[.[] | select(.orderId == $order_id)] | length')"
--if [[ "${listed_count}" -lt 1 ]]; then
--  echo "[error] expected created order ${created_order_id} in account open-orders listing"
--  exit 1
--fi
--
--echo "[check] user journey: cancel open order"
--cancel_response="$(
--  curl -sS -w '\n%{http_code}' \
--    -H "Content-Type: application/json" \
--    -X POST \
--    -d '{}' \
--    "${INGRESS_URL}/order-matcher/orders/${created_order_id}/cancel"
--)"
--cancel_http="$(echo "${cancel_response}" | tail -n1)"
--cancel_body="$(echo "${cancel_response}" | sed '$d')"
--if [[ "${cancel_http}" != "200" ]]; then
--  echo "[error] expected 200 from cancel order, got ${cancel_http}"
--  echo "${cancel_body}"
--  exit 1
--fi
--cancel_status="$(echo "${cancel_body}" | jq -r '.status // empty')"
--if [[ "${cancel_status}" != "CANCELED" ]]; then
--  echo "[error] expected canceled order status, got ${cancel_status}"
--  echo "${cancel_body}"
--  exit 1
--fi
--
--echo "[check] admin journey: force-fill an open order"
--pre_trade_count="$(curl -fsS "${INGRESS_URL}/position-service/trades/44044" | jq 'length')"
--pre_jpm_position_qty="$(curl -fsS "${INGRESS_URL}/position-service/positions/44044" | jq -r '[.[] | select(.security == "JPM")][0].quantity // 0')"
--admin_create_payload='{"accountId":44044,"security":"JPM","side":"Sell","quantity":55,"limitPrice":191.875}'
--admin_create_response="$(
--  curl -sS -w '\n%{http_code}' \
--    -H "Content-Type: application/json" \
--    -X POST \
--    -d "${admin_create_payload}" \
--    "${INGRESS_URL}/order-matcher/orders"
--)"
--admin_create_http="$(echo "${admin_create_response}" | tail -n1)"
--admin_create_body="$(echo "${admin_create_response}" | sed '$d')"
--if [[ "${admin_create_http}" != "201" ]]; then
--  echo "[error] expected 201 from admin setup create order, got ${admin_create_http}"
--  echo "${admin_create_body}"
--  exit 1
--fi
--admin_order_id="$(echo "${admin_create_body}" | jq -r '.orderId // empty')"
--if [[ -z "${admin_order_id}" ]]; then
--  echo "[error] admin setup create order missing orderId"
--  echo "${admin_create_body}"
--  exit 1
--fi
--force_fill_response="$(
--  curl -sS -w '\n%{http_code}' \
--    -H "Content-Type: application/json" \
--    -X POST \
--    -d '{}' \
--    "${INGRESS_URL}/order-matcher/orders/${admin_order_id}/force-fill"
--)"
--force_fill_http="$(echo "${force_fill_response}" | tail -n1)"
--force_fill_body="$(echo "${force_fill_response}" | sed '$d')"
--if [[ "${force_fill_http}" != "200" ]]; then
--  echo "[error] expected 200 from force-fill order, got ${force_fill_http}"
--  echo "${force_fill_body}"
--  exit 1
--fi
--force_fill_status="$(echo "${force_fill_body}" | jq -r '.status // empty')"
--if [[ "${force_fill_status}" != "FILLED" ]]; then
--  echo "[error] expected force-filled order status FILLED, got ${force_fill_status}"
--  echo "${force_fill_body}"
--  exit 1
--fi
--echo "[check] force-filled order created trade and changed position"
--trade_observed=0
--for _ in {1..30}; do
--  trades_after="$(curl -fsS "${INGRESS_URL}/position-service/trades/44044")"
--  trade_count_after="$(echo "${trades_after}" | jq 'length')"
--  matched_trade_count="$(echo "${trades_after}" | jq '[.[] | select(.security == "JPM" and .side == "Sell" and .quantity == 55)] | length')"
--  if [[ "${trade_count_after}" -gt "${pre_trade_count}" && "${matched_trade_count}" -ge 1 ]]; then
--    trade_observed=1
--    break
--  fi
--  sleep 2
--done
--if [[ "${trade_observed}" -ne 1 ]]; then
--  echo "[error] expected force-fill to produce persisted JPM sell trade for account 44044"
--  exit 1
--fi
--expected_jpm_position_qty="$((pre_jpm_position_qty - 55))"
--position_observed=0
--for _ in {1..30}; do
--  position_rows="$(curl -fsS "${INGRESS_URL}/position-service/positions/44044")"
--  current_jpm_qty="$(echo "${position_rows}" | jq -r '[.[] | select(.security == "JPM")][0].quantity // 0')"
--  if [[ "${current_jpm_qty}" == "${expected_jpm_position_qty}" ]]; then
--    position_observed=1
--    break
--  fi
--  sleep 2
--done
--if [[ "${position_observed}" -ne 1 ]]; then
--  echo "[error] expected JPM position quantity=${expected_jpm_position_qty} after force-fill"
--  exit 1
--fi
--
--echo "[check] matcher journey: in-the-money order auto-fills on tick policy"
--autofill_create_payload='{"accountId":22214,"security":"IBM","side":"Buy","quantity":5000,"limitPrice":99999.000}'
--autofill_create_response="$(
--  curl -sS -w '\n%{http_code}' \
--    -H "Content-Type: application/json" \
--    -X POST \
--    -d "${autofill_create_payload}" \
--    "${INGRESS_URL}/order-matcher/orders"
--)"
--autofill_create_http="$(echo "${autofill_create_response}" | tail -n1)"
--autofill_create_body="$(echo "${autofill_create_response}" | sed '$d')"
--if [[ "${autofill_create_http}" != "201" ]]; then
--  echo "[error] expected 201 from auto-fill setup create order, got ${autofill_create_http}"
--  echo "${autofill_create_body}"
--  exit 1
--fi
--autofill_order_id="$(echo "${autofill_create_body}" | jq -r '.orderId // empty')"
--if [[ -z "${autofill_order_id}" ]]; then
--  echo "[error] auto-fill setup create order missing orderId"
--  echo "${autofill_create_body}"
--  exit 1
--fi
--autofill_first_remaining=""
--for _ in {1..20}; do
--  autofill_order="$(curl -fsS "${INGRESS_URL}/order-matcher/orders/${autofill_order_id}")"
--  autofill_status="$(echo "${autofill_order}" | jq -r '.status // empty')"
--  autofill_remaining="$(echo "${autofill_order}" | jq -r '.remainingQuantity // -1')"
--  if [[ "${autofill_status}" != "NEW" ]]; then
--    autofill_first_remaining="${autofill_remaining}"
--    break
--  fi
--  sleep 1
--done
--if [[ -z "${autofill_first_remaining}" ]]; then
--  echo "[error] expected auto-fill order to progress from NEW on matcher ticks"
--  exit 1
--fi
--case "${autofill_first_remaining}" in
--  2500|1250|625|0) ;;
--  *)
--    echo "[error] auto-fill remaining quantity did not follow expected reduction policy, got ${autofill_first_remaining}"
--    exit 1
--    ;;
--esac
--autofill_terminal=0
--for _ in {1..40}; do
--  autofill_order="$(curl -fsS "${INGRESS_URL}/order-matcher/orders/${autofill_order_id}")"
--  autofill_status="$(echo "${autofill_order}" | jq -r '.status // empty')"
--  if [[ "${autofill_status}" == "FILLED" ]]; then
--    autofill_terminal=1
--    break
--  fi
--  sleep 1
--done
--if [[ "${autofill_terminal}" -ne 1 ]]; then
--  echo "[error] expected auto-fill order ${autofill_order_id} to reach FILLED"
--  exit 1
--fi
--
--echo "[check] lifecycle metrics include create/cancel/force_fill counters"
--metrics_after_lifecycle="$(curl -fsS "http://localhost:${ORDER_MATCHER_PORT}/metrics")"
--printf '%s\n' "${metrics_after_lifecycle}" | rg -q 'traderx_order_events_total\{event="create"\}' || {
--  echo "[error] missing create event counter after lifecycle actions"
--  exit 1
--}
--printf '%s\n' "${metrics_after_lifecycle}" | rg -q 'traderx_order_events_total\{event="cancel"\}' || {
--  echo "[error] missing cancel event counter after lifecycle actions"
--  exit 1
--}
--printf '%s\n' "${metrics_after_lifecycle}" | rg -q 'traderx_order_events_total\{event="force_fill"\}' || {
--  echo "[error] missing force_fill event counter after lifecycle actions"
--  exit 1
--}
--post_open_count="$(curl -fsS "${INGRESS_URL}/order-matcher/orders/open-count" | jq -r '.openOrders')"
--if (( post_open_count > pre_open_count + 1 )); then
--  echo "[error] open-order count increased unexpectedly (before=${pre_open_count}, after=${post_open_count})"
--  exit 1
--fi
--echo "[info] order lifecycle checks passed (open orders before=${pre_open_count}, after=${post_open_count})"
--
--echo "[check] admin route served by web UI"
--admin_headers="$(curl -sS -i "${INGRESS_URL}/admin" | sed -n '1,20p')"
--echo "${admin_headers}"
--printf '%s\n' "${admin_headers}" | grep -q "200" || {
--  echo "[error] expected admin route to return 200"
--  exit 1
--}
--
--echo "[check] grafana loki datasource has non-empty log streams in order-management runtime"
--now_ms=$(($(date +%s) * 1000))
--from_ms=$((now_ms - 15 * 60 * 1000))
--loki_total_query_result="$(
--  curl -sS -u "${GRAFANA_ADMIN_AUTH}" -H 'Content-Type: application/json' -X POST "http://localhost:${GRAFANA_PORT}/api/ds/query" \
--    -d "{\"from\":\"${from_ms}\",\"to\":\"${now_ms}\",\"queries\":[{\"refId\":\"A\",\"datasource\":{\"uid\":\"loki\",\"type\":\"loki\"},\"expr\":\"sum(count_over_time({compose_project=\\\"${COMPOSE_PROJECT_NAME}\\\"}[5m]))\",\"queryType\":\"range\",\"intervalMs\":1000,\"maxDataPoints\":500}]}"
--)"
--loki_total_query_error="$(echo "${loki_total_query_result}" | jq -r '.results.A.error // empty')"
--loki_total_last="$(echo "${loki_total_query_result}" | jq -r '.results.A.frames[0].data.values[1][-1] // "0"')"
--if [[ -n "${loki_total_query_error}" ]]; then
--  echo "[error] grafana loki query failed: ${loki_total_query_error}"
--  exit 1
--fi
--if ! awk "BEGIN {exit !(${loki_total_last} > 0)}"; then
--  echo "[error] expected non-empty Loki ingestion in last 5m, got ${loki_total_last}"
--  exit 1
--fi
--
--echo "[check] dashboard service-filtered logs are present (nats/pricing/control-plane/order)"
--loki_service_query_result="$(
--  curl -sS -u "${GRAFANA_ADMIN_AUTH}" -H 'Content-Type: application/json' -X POST "http://localhost:${GRAFANA_PORT}/api/ds/query" \
--    -d "{\"from\":\"${from_ms}\",\"to\":\"${now_ms}\",\"queries\":[{\"refId\":\"A\",\"datasource\":{\"uid\":\"loki\",\"type\":\"loki\"},\"expr\":\"sum(count_over_time({compose_project=\\\"${COMPOSE_PROJECT_NAME}\\\",service=~\\\"nats-broker|price-publisher|trade-service|trade-processor|position-service|order-matcher|web-front-end-angular|grafana|loki|tempo|otel-collector|prometheus|promtail\\\"}[10m]))\",\"queryType\":\"range\",\"intervalMs\":1000,\"maxDataPoints\":500}]}"
--)"
--loki_service_query_error="$(echo "${loki_service_query_result}" | jq -r '.results.A.error // empty')"
--loki_service_last="$(echo "${loki_service_query_result}" | jq -r '.results.A.frames[0].data.values[1][-1] // "0"')"
--if [[ -n "${loki_service_query_error}" ]]; then
--  echo "[error] grafana loki service-filter query failed: ${loki_service_query_error}"
--  exit 1
--fi
--if ! awk "BEGIN {exit !(${loki_service_last} > 0)}"; then
--  echo "[error] expected non-empty service-filtered Loki logs for dashboards, got ${loki_service_last}"
--  exit 1
--fi
--
--echo "[check] web-front-end state-aware UX contract"
--TRADERX_LOCAL_RUNTIME_SCRIPT=1 "${REPO_ROOT}/scripts/test-web-angular-baseline-ux-contract.sh" "${GENERATED_ROOT}/code/target-generated/web-front-end/angular"
--
--if [[ "${SKIP_MESSAGING}" -eq 1 ]]; then
--  echo "[info] skipping messaging smoke step (--skip-messaging)"
--else
--  echo "[check] messaging smoke step (post-functional): state 009"
--  TRADERX_LOCAL_RUNTIME_SCRIPT=1 "${REPO_ROOT}/scripts/test-messaging-009-order-management-matcher.sh" "${INGRESS_URL}" "http://localhost:18092" "22214"
--fi
--
--echo "[done] state 009 order-management observability smoke tests passed"
-diff --git a/scripts/test-state-010-kubernetes-runtime.sh b/scripts/test-state-010-kubernetes-runtime.sh
-deleted file mode 100755
-index ba36dbf..0000000
---- a/scripts/test-state-010-kubernetes-runtime.sh
-+++ /dev/null
-@@ -1,349 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--source "${REPO_ROOT}/scripts/lib/kubernetes-smoke-readiness.sh"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--
--INGRESS_URL="${1:-http://localhost:8080}"
--NAMESPACE="${2:-traderx}"
--K8S_PROVIDER="${3:-${K8S_PROVIDER:-kind}}"
--BUILD_PLAN="${GENERATED_ROOT}/code/target-generated/kubernetes-runtime/build-plan.json"
--DEFAULT_CLUSTER_NAME="traderx-state-010"
--
--if [[ -f "${BUILD_PLAN}" ]] && command -v jq >/dev/null 2>&1; then
--  parsed_cluster_name="$(jq -r '.kindClusterName // empty' "${BUILD_PLAN}" 2>/dev/null || true)"
--  if [[ -n "${parsed_cluster_name}" && "${parsed_cluster_name}" != "null" ]]; then
--    DEFAULT_CLUSTER_NAME="${parsed_cluster_name}"
--  fi
--fi
--
--MINIKUBE_PROFILE="${4:-${MINIKUBE_PROFILE:-${DEFAULT_CLUSTER_NAME}}}"
--
--if ! command -v kubectl >/dev/null 2>&1; then
--  echo "[error] kubectl command not found"
--  exit 1
--fi
--
--case "${K8S_PROVIDER}" in
--  kind)
--    if ! command -v kind >/dev/null 2>&1; then
--      echo "[error] kind command not found"
--      exit 1
--    fi
--    if ! kind get clusters | grep -Fx "${MINIKUBE_PROFILE}" >/dev/null 2>&1; then
--      echo "[error] expected kind cluster not found: ${MINIKUBE_PROFILE}"
--      exit 1
--    fi
--    kubectl config use-context "kind-${MINIKUBE_PROFILE}" >/dev/null
--    ;;
--  minikube)
--    if ! command -v minikube >/dev/null 2>&1; then
--      echo "[error] minikube command not found"
--      exit 1
--    fi
--    if ! minikube status -p "${MINIKUBE_PROFILE}" >/dev/null 2>&1; then
--      echo "[error] expected minikube profile not running: ${MINIKUBE_PROFILE}"
--      exit 1
--    fi
--    if ! kubectl config use-context "${MINIKUBE_PROFILE}" >/dev/null 2>&1; then
--      kubectl config use-context "minikube" >/dev/null
--    fi
--    ;;
--  *)
--    echo "[error] unsupported provider: ${K8S_PROVIDER}"
--    echo "[hint] supported providers: kind, minikube"
--    exit 1
--    ;;
--esac
--
--check_message_bus_health_endpoint() {
--  local endpoint="$1"
--  local component="$2"
--  local payload
--  payload="$(curl -fsS "${endpoint}")"
--
--  local top_status
--  top_status="$(echo "${payload}" | jq -r '.status // empty')"
--  if [[ "${top_status}" != "ok" ]]; then
--    echo "[error] ${component} system health is not ok at ${endpoint}: status=${top_status}"
--    echo "${payload}"
--    exit 1
--  fi
--
--  local statuses
--  statuses="$(echo "${payload}" | jq -r '
--    if (.messageBus | type) != "object" then
--      empty
--    elif ((.messageBus | has("publisher")) or (.messageBus | has("subscriber"))) then
--      [.messageBus.publisher.status?, .messageBus.subscriber.status?] | .[]
--    else
--      .messageBus.status // empty
--    end
--  ')"
--
--  if [[ -z "${statuses//[$'\n\r\t ']}" ]]; then
--    echo "[error] ${component} system health missing messageBus status payload at ${endpoint}"
--    echo "${payload}"
--    exit 1
--  fi
--
--  while IFS= read -r bus_status; do
--    [[ -z "${bus_status}" ]] && continue
--    if [[ "${bus_status}" != "connected" ]]; then
--      echo "[error] ${component} message bus is not connected at ${endpoint}: status=${bus_status}"
--      echo "${payload}"
--      exit 1
--    fi
--  done <<< "${statuses}"
--}
--
--echo "[check] kubernetes deployments available in namespace ${NAMESPACE}"
--kubectl get deployments -n "${NAMESPACE}"
--kubectl wait --for=condition=Available deployment --all -n "${NAMESPACE}" --timeout="${TRADERX_K8S_DEPLOYMENT_WAIT_TIMEOUT:-300s}" >/dev/null
--traderx_k8s_rollout_status_all "${NAMESPACE}" "${BUILD_PLAN}" "${TRADERX_K8S_ROLLOUT_TIMEOUT:-300s}"
--
--echo "[check] application readiness through ingress"
--traderx_wait_for_traderx_ingress_readiness \
--  "${INGRESS_URL}" \
--  "$(traderx_k8s_smoke_ready_timeout)"
--
--echo "[check] edge health endpoint"
--health_headers="$(curl -sS -i "${INGRESS_URL}/health" | sed -n '1,20p')"
--echo "${health_headers}"
--printf '%s\n' "${health_headers}" | grep -q "HTTP/1.1 200" || {
--  echo "[error] expected HTTP 200 from ${INGRESS_URL}/health"
--  exit 1
--}
--
--echo "[check] deployed UI dev-only paths are rejected"
--for dev_only_path in "/@vite/client" "/@fs/package.json"; do
--  dev_only_status="$(curl -sS -o /dev/null -w "%{http_code}" "${INGRESS_URL}${dev_only_path}")"
--  if [[ "${dev_only_status}" == "200" ]]; then
--    echo "[error] expected non-200 for deployed dev-only path ${INGRESS_URL}${dev_only_path}"
--    exit 1
--  fi
--done
--
--echo "[check] edge account-service path"
--account_headers="$(curl -sS -i "${INGRESS_URL}/account-service/account/22214" | sed -n '1,25p')"
--echo "${account_headers}"
--printf '%s\n' "${account_headers}" | grep -Eq "HTTP/1\\.[01] 200" || {
--  echo "[error] expected HTTP 200 from ${INGRESS_URL}/account-service/account/22214"
--  exit 1
--}
--
--echo "[check] order matcher ingress health and listing endpoints"
--order_health_headers="$(curl -sS -i "${INGRESS_URL}/order-matcher/health" | sed -n '1,25p')"
--echo "${order_health_headers}"
--printf '%s\n' "${order_health_headers}" | grep -Eq "HTTP/1\\.[01] 200" || {
--  echo "[error] expected HTTP 200 from ${INGRESS_URL}/order-matcher/health"
--  exit 1
--}
--
--order_listing_payload="$(curl -sS -w '\n%{http_code}' "${INGRESS_URL}/order-matcher/orders?status=open")"
--order_listing_http="$(echo "${order_listing_payload}" | tail -n1)"
--order_listing_body="$(echo "${order_listing_payload}" | sed '$d')"
--if [[ "${order_listing_http}" != "200" ]]; then
--  echo "[error] expected HTTP 200 from ${INGRESS_URL}/order-matcher/orders?status=open, got ${order_listing_http}"
--  echo "${order_listing_body}"
--  exit 1
--fi
--echo "${order_listing_body}" | jq -e 'if type=="array" then . else empty end' >/dev/null || {
--  echo "[error] expected order-matcher list response to be a JSON array"
--  echo "${order_listing_body}"
--  exit 1
--}
--
--echo "[check] message bus connectivity pre-check via /system/health"
--check_message_bus_health_endpoint "${INGRESS_URL}/trade-service/system/health" "trade-service"
--check_message_bus_health_endpoint "${INGRESS_URL}/trade-processor/system/health" "trade-processor"
--check_message_bus_health_endpoint "${INGRESS_URL}/order-matcher/system/health" "order-matcher"
--
--echo "[check] observability ingress routes"
--grafana_headers="$(curl -sS -i "${INGRESS_URL}/grafana/api/health" | sed -n '1,25p')"
--echo "${grafana_headers}"
--printf '%s\n' "${grafana_headers}" | grep -Eq "HTTP/1\\.[01] 200" || {
--  echo "[error] expected HTTP 200 from ${INGRESS_URL}/grafana/api/health"
--  exit 1
--}
--
--prometheus_headers="$(curl -sS -i "${INGRESS_URL}/prometheus/-/ready" | sed -n '1,25p')"
--echo "${prometheus_headers}"
--printf '%s\n' "${prometheus_headers}" | grep -Eq "HTTP/1\\.[01] 200" || {
--  echo "[error] expected HTTP 200 from ${INGRESS_URL}/prometheus/-/ready"
--  exit 1
--}
--
--echo "[check] prometheus query API responds"
--prometheus_query_payload="$(curl -sS "${INGRESS_URL}/prometheus/api/v1/query?query=up" | tr -d '\n')"
--printf '%s\n' "${prometheus_query_payload}" | grep -q '"status":"success"' || {
--  echo "[error] expected Prometheus API query to return status=success"
--  exit 1
--}
--
--echo "[check] prometheus message bus connectivity metric is queryable"
--message_bus_sample_count="$(
--  curl -sS --get "${INGRESS_URL}/prometheus/api/v1/query" \
--    --data-urlencode 'query=traderx_messagebus_connected' \
--  | jq -r '.data.result | length'
--)"
--if [[ "${message_bus_sample_count}" -lt 4 ]]; then
--  echo "[error] expected 4+ traderx_messagebus_connected samples in Prometheus, got ${message_bus_sample_count}"
--  exit 1
--fi
--echo "[info] traderx_messagebus_connected series=${message_bus_sample_count}"
--
--echo "[check] grafana datasource can query prometheus"
--now_ms=$(($(date +%s) * 1000))
--from_ms=$((now_ms - 10 * 60 * 1000))
--grafana_query_result="$(
--  curl -sS -u admin:admin -H 'Content-Type: application/json' -X POST "${INGRESS_URL}/grafana/api/ds/query" \
--    -d "{\"from\":\"${from_ms}\",\"to\":\"${now_ms}\",\"queries\":[{\"refId\":\"A\",\"datasource\":{\"uid\":\"prometheus\",\"type\":\"prometheus\"},\"expr\":\"probe_success{job=\\\"traderx-http-probe\\\"}\",\"instant\":true,\"range\":false,\"intervalMs\":1000,\"maxDataPoints\":500}]}"
--)"
--grafana_query_error="$(echo "${grafana_query_result}" | jq -r '.results.A.error // empty')"
--grafana_query_frames="$(echo "${grafana_query_result}" | jq -r '.results.A.frames | length')"
--if [[ -n "${grafana_query_error}" ]]; then
--  echo "[error] grafana datasource query failed: ${grafana_query_error}"
--  exit 1
--fi
--if [[ "${grafana_query_frames}" -lt 1 ]]; then
--  echo "[error] expected at least one Grafana data frame from Prometheus query"
--  exit 1
--fi
--
--echo "[check] grafana includes message bus connectivity panel query"
--dashboard_uids_raw="$(
--  curl -sS -u admin:admin "${INGRESS_URL}/grafana/api/search?query=TraderX&type=dash-db" \
--  | jq -r '.[].uid'
--)"
--message_bus_dashboard_uid=""
--while IFS= read -r dashboard_uid; do
--  [[ -z "${dashboard_uid}" ]] && continue
--  dashboard_payload="$(curl -sS -u admin:admin "${INGRESS_URL}/grafana/api/dashboards/uid/${dashboard_uid}")"
--  dashboard_text="$(echo "${dashboard_payload}" | jq -r '.dashboard | tostring')"
--  if printf '%s\n' "${dashboard_text}" | rg -q 'traderx_messagebus_connected'; then
--    message_bus_dashboard_uid="${dashboard_uid}"
--    break
--  fi
--done <<< "${dashboard_uids_raw}"
--if [[ -z "${message_bus_dashboard_uid}" ]]; then
--  echo "[error] no provisioned TraderX dashboard includes traderx_messagebus_connected query"
--  exit 1
--fi
--echo "[info] grafana dashboard uid=${message_bus_dashboard_uid} includes message bus connectivity query"
--
--echo "[check] spring actuator scrape targets healthy in prometheus"
--actuator_up_count=0
--for _ in {1..30}; do
--  actuator_up_count="$(
--    curl -sS "${INGRESS_URL}/prometheus/api/v1/targets" \
--    | jq '[.data.activeTargets[] | select(.labels.job=="traderx-spring-boot-actuator" and .health=="up")] | length'
--  )"
--  if [[ "${actuator_up_count}" -ge 5 ]]; then
--    break
--  fi
--  sleep 2
--done
--if [[ "${actuator_up_count}" -lt 5 ]]; then
--  echo "[error] expected 5 healthy Spring actuator scrape targets, got ${actuator_up_count}"
--  curl -sS "${INGRESS_URL}/prometheus/api/v1/targets" \
--    | jq -r '.data.activeTargets[] | select(.labels.job=="traderx-spring-boot-actuator") | "\(.labels.instance) health=\(.health) error=\(.lastError // "")"'
--  exit 1
--fi
--
--echo "[check] spring actuator endpoints reachable through ingress"
--for endpoint in \
--  "${INGRESS_URL}/account-service/actuator/prometheus" \
--  "${INGRESS_URL}/position-service/actuator/prometheus" \
--  "${INGRESS_URL}/trade-processor/actuator/prometheus" \
--  "${INGRESS_URL}/trade-service/actuator/prometheus" \
--  "${INGRESS_URL}/order-matcher/actuator/prometheus"; do
--  headers="$(curl -sS -i "${endpoint}" | sed -n '1,20p')"
--  echo "${headers}"
--  printf '%s\n' "${headers}" | grep -Eq "HTTP/1\\.[01] 200" || {
--    echo "[error] expected HTTP 200 from ${endpoint}"
--    exit 1
--  }
--done
--
--echo "[check] warm traffic for spring http_server metrics"
--curl -sS "${INGRESS_URL}/account-service/account/22214" >/dev/null
--curl -sS "${INGRESS_URL}/position-service/positions/22214" >/dev/null
--curl -sS "${INGRESS_URL}/trade-service/v3/api-docs" >/dev/null
--curl -sS "${INGRESS_URL}/trade-processor/health" >/dev/null
--curl -sS "${INGRESS_URL}/order-matcher/orders/open-count" >/dev/null
--
--echo "[check] spring http_server metrics are queryable in prometheus"
--spring_metric_sample_count="$(
--  curl -sS --get "${INGRESS_URL}/prometheus/api/v1/query" \
--    --data-urlencode 'query=count(http_server_requests_seconds_count{job="traderx-spring-boot-actuator"})' \
--  | jq -r '.data.result[0].value[1] // "0"'
--)"
--if ! awk "BEGIN {exit !(${spring_metric_sample_count} > 0)}"; then
--  echo "[error] expected spring http_server metric samples, got ${spring_metric_sample_count}"
--  exit 1
--fi
--
--echo "[check] promtail daemonset is available"
--kubectl rollout status daemonset/promtail -n "${NAMESPACE}" --timeout=180s >/dev/null
--
--echo "[check] grafana loki datasource has ingesting log streams"
--now_ms=$(($(date +%s) * 1000))
--from_ms=$((now_ms - 15 * 60 * 1000))
--loki_total_query_result="$(
--  curl -sS -u admin:admin -H 'Content-Type: application/json' -X POST "${INGRESS_URL}/grafana/api/ds/query" \
--    -d "{\"from\":\"${from_ms}\",\"to\":\"${now_ms}\",\"queries\":[{\"refId\":\"A\",\"datasource\":{\"uid\":\"loki\",\"type\":\"loki\"},\"expr\":\"sum(count_over_time({compose_project=\\\"traderx-state-009\\\"}[5m]))\",\"queryType\":\"range\",\"intervalMs\":1000,\"maxDataPoints\":500}]}"
--)"
--loki_total_query_error="$(echo "${loki_total_query_result}" | jq -r '.results.A.error // empty')"
--loki_total_last="$(echo "${loki_total_query_result}" | jq -r '.results.A.frames[0].data.values[1][-1] // "0"')"
--if [[ -n "${loki_total_query_error}" ]]; then
--  echo "[error] grafana loki query failed: ${loki_total_query_error}"
--  exit 1
--fi
--if ! awk "BEGIN {exit !(${loki_total_last} > 0)}"; then
--  echo "[error] expected non-empty Loki ingestion in last 5m, got ${loki_total_last}"
--  exit 1
--fi
--
--echo "[check] dashboard service filters have log content (nats/pipeline/control-plane)"
--loki_service_query_result="$(
--  curl -sS -u admin:admin -H 'Content-Type: application/json' -X POST "${INGRESS_URL}/grafana/api/ds/query" \
--    -d "{\"from\":\"${from_ms}\",\"to\":\"${now_ms}\",\"queries\":[{\"refId\":\"A\",\"datasource\":{\"uid\":\"loki\",\"type\":\"loki\"},\"expr\":\"sum(count_over_time({compose_project=\\\"traderx-state-009\\\",service=~\\\"nats-broker|trade-service|trade-processor|price-publisher|position-service|grafana|loki|tempo|otel-collector|prometheus|edge-proxy\\\"}[10m]))\",\"queryType\":\"range\",\"intervalMs\":1000,\"maxDataPoints\":500}]}"
--)"
--loki_service_query_error="$(echo "${loki_service_query_result}" | jq -r '.results.A.error // empty')"
--loki_service_last="$(echo "${loki_service_query_result}" | jq -r '.results.A.frames[0].data.values[1][-1] // "0"')"
--if [[ -n "${loki_service_query_error}" ]]; then
--  echo "[error] grafana loki service-filter query failed: ${loki_service_query_error}"
--  exit 1
--fi
--if ! awk "BEGIN {exit !(${loki_service_last} > 0)}"; then
--  echo "[error] expected non-empty service-filtered Loki logs for dashboard panels, got ${loki_service_last}"
--  exit 1
--fi
--
--echo "[check] state 010 ingress-routed service smoke suite"
--"${REPO_ROOT}/scripts/test-reference-data-overlay.sh" "${INGRESS_URL}" "${INGRESS_URL}/reference-data"
--"${REPO_ROOT}/scripts/test-account-service-overlay.sh" "${INGRESS_URL}" "${INGRESS_URL}/account-service"
--"${REPO_ROOT}/scripts/test-people-service-overlay.sh" "${INGRESS_URL}" "${INGRESS_URL}/people-service" "${INGRESS_URL}/account-service/accountuser/"
--"${REPO_ROOT}/scripts/test-position-service-overlay.sh" "${INGRESS_URL}" "${INGRESS_URL}/position-service"
--"${REPO_ROOT}/scripts/test-trade-service-overlay.sh" "${INGRESS_URL}" "${INGRESS_URL}/trade-service" "${INGRESS_URL}/position-service"
--"${REPO_ROOT}/scripts/test-web-angular-overlay.sh" "${INGRESS_URL}"
--echo "[check] web-front-end state-aware UX contract"
--"${REPO_ROOT}/scripts/test-web-angular-baseline-ux-contract.sh" "${GENERATED_ROOT}/code/target-generated/web-front-end/angular"
--
--echo "[done] state 010 kubernetes runtime smoke tests passed"
-diff --git a/scripts/test-state-011-tilt-kubernetes-dev-loop.sh b/scripts/test-state-011-tilt-kubernetes-dev-loop.sh
-deleted file mode 100755
-index 6d12ce4..0000000
---- a/scripts/test-state-011-tilt-kubernetes-dev-loop.sh
-+++ /dev/null
-@@ -1,80 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--INGRESS_URL="${1:-http://localhost:8080}"
--NAMESPACE="${2:-traderx}"
--K8S_PROVIDER="${3:-${K8S_PROVIDER:-kind}}"
--DEFAULT_CLUSTER_NAME="traderx-state-011"
--CLUSTER_OR_PROFILE="${4:-${MINIKUBE_PROFILE:-${DEFAULT_CLUSTER_NAME}}}"
--STATE_DIR="${GENERATED_ROOT}/code/target-generated/tilt-kubernetes-dev-loop"
--TILT_DIR="${STATE_DIR}/tilt"
--UPSTREAM_BUILD_PLAN="${STATE_DIR}/upstream-build-plan.json"
--TILTFILE="${TILT_DIR}/Tiltfile"
--
--echo "[check] state 010 baseline compatibility for state 011"
--"${REPO_ROOT}/scripts/test-state-010-kubernetes-runtime.sh" "${INGRESS_URL}" "${NAMESPACE}" "${K8S_PROVIDER}" "${CLUSTER_OR_PROFILE}"
--
--echo "[check] state 011 tilt artifact pack exists"
--for required in \
--  "${STATE_DIR}/README.md" \
--  "${UPSTREAM_BUILD_PLAN}" \
--  "${TILTFILE}" \
--  "${TILT_DIR}/tilt-settings.json" \
--  "${TILT_DIR}/README.md"; do
--  [[ -f "${required}" ]] || {
--    echo "[error] missing expected state 011 artifact: ${required}"
--    exit 1
--  }
--done
--
--echo "[check] tiltfile structure"
--grep -q "allow_k8s_contexts" "${TILTFILE}" || {
--  echo "[error] Tiltfile missing allow_k8s_contexts"
--  exit 1
--}
--grep -q "k8s_yaml" "${TILTFILE}" || {
--  echo "[error] Tiltfile missing k8s_yaml declaration"
--  exit 1
--}
--grep -q "k8s_resource('edge-proxy'" "${TILTFILE}" || {
--  echo "[error] Tiltfile missing edge-proxy resource declaration"
--  exit 1
--}
--
--while IFS= read -r item; do
--  image="$(jq -r '.image' <<<"${item}")"
--  grep -q "${image}" "${TILTFILE}" || {
--    echo "[error] Tiltfile missing docker_build mapping for image ${image}"
--    exit 1
--  }
--done < <(jq -c '.images[]' "${UPSTREAM_BUILD_PLAN}")
--
--if grep -q "radius" "${TILTFILE}"; then
--  echo "[error] Tiltfile should not include radius artifacts in state 011"
--  exit 1
--fi
--
--if command -v tilt >/dev/null 2>&1; then
--  echo "[check] tilt CLI available"
--  tilt version | head -n 1
--else
--  echo "[info] tilt CLI not installed; skipping optional tilt command checks"
--fi
--
--echo "[done] state 011 tilt-kubernetes dev-loop smoke tests passed"
-diff --git a/scripts/test-state-012-platform-convergence-c3.sh b/scripts/test-state-012-platform-convergence-c3.sh
-deleted file mode 100755
-index 658a5e3..0000000
---- a/scripts/test-state-012-platform-convergence-c3.sh
-+++ /dev/null
-@@ -1,80 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--INGRESS_URL="${1:-http://localhost:8080}"
--NAMESPACE="${2:-traderx}"
--K8S_PROVIDER="${3:-${K8S_PROVIDER:-kind}}"
--DEFAULT_CLUSTER_NAME="traderx-state-012"
--CLUSTER_OR_PROFILE="${4:-${MINIKUBE_PROFILE:-${DEFAULT_CLUSTER_NAME}}}"
--STATE_DIR="${GENERATED_ROOT}/code/target-generated/tilt-kubernetes-dev-loop"
--TILT_DIR="${STATE_DIR}/tilt"
--UPSTREAM_BUILD_PLAN="${STATE_DIR}/upstream-build-plan.json"
--TILTFILE="${TILT_DIR}/Tiltfile"
--
--echo "[check] state 011 baseline compatibility for state 012"
--"${REPO_ROOT}/scripts/test-state-011-tilt-kubernetes-dev-loop.sh" "${INGRESS_URL}" "${NAMESPACE}" "${K8S_PROVIDER}" "${CLUSTER_OR_PROFILE}"
--
--echo "[check] state 012 convergence artifact pack exists"
--for required in \
--  "${STATE_DIR}/README.md" \
--  "${UPSTREAM_BUILD_PLAN}" \
--  "${TILTFILE}" \
--  "${TILT_DIR}/tilt-settings.json" \
--  "${TILT_DIR}/README.md"; do
--  [[ -f "${required}" ]] || {
--    echo "[error] missing expected state 012 artifact: ${required}"
--    exit 1
--  }
--done
--
--echo "[check] tiltfile structure"
--grep -q "allow_k8s_contexts" "${TILTFILE}" || {
--  echo "[error] Tiltfile missing allow_k8s_contexts"
--  exit 1
--}
--grep -q "k8s_yaml" "${TILTFILE}" || {
--  echo "[error] Tiltfile missing k8s_yaml declaration"
--  exit 1
--}
--grep -q "k8s_resource('edge-proxy'" "${TILTFILE}" || {
--  echo "[error] Tiltfile missing edge-proxy resource declaration"
--  exit 1
--}
--
--while IFS= read -r item; do
--  image="$(jq -r '.image' <<<"${item}")"
--  grep -q "${image}" "${TILTFILE}" || {
--    echo "[error] Tiltfile missing docker_build mapping for image ${image}"
--    exit 1
--  }
--done < <(jq -c '.images[]' "${UPSTREAM_BUILD_PLAN}")
--
--if grep -q "radius" "${TILTFILE}"; then
--  echo "[error] Tiltfile should not include radius artifacts in state 012"
--  exit 1
--fi
--
--if command -v tilt >/dev/null 2>&1; then
--  echo "[check] tilt CLI available"
--  tilt version | head -n 1
--else
--  echo "[info] tilt CLI not installed; skipping optional tilt command checks"
--fi
--
--echo "[done] state 012 platform convergence smoke tests passed"
-diff --git a/scripts/test-state-013-radius-kubernetes-platform.sh b/scripts/test-state-013-radius-kubernetes-platform.sh
-deleted file mode 100755
-index 4c2055a..0000000
---- a/scripts/test-state-013-radius-kubernetes-platform.sh
-+++ /dev/null
-@@ -1,64 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--INGRESS_URL="${1:-http://localhost:8080}"
--NAMESPACE="${2:-traderx}"
--K8S_PROVIDER="${3:-${K8S_PROVIDER:-kind}}"
--CLUSTER_OR_PROFILE="${4:-${MINIKUBE_PROFILE:-traderx-state-013}}"
--STATE_DIR="${GENERATED_ROOT}/code/target-generated/radius-kubernetes-platform"
--RADIUS_DIR="${STATE_DIR}/radius"
--UPSTREAM_BUILD_PLAN="${STATE_DIR}/upstream-build-plan.json"
--UPSTREAM_SPEC="${GENERATED_ROOT}/code/target-generated/kubernetes-runtime/spec-source/kubernetes-runtime.spec.json"
--
--echo "[check] state 010 baseline compatibility for state 013"
--"${REPO_ROOT}/scripts/test-state-010-kubernetes-runtime.sh" "${INGRESS_URL}" "${NAMESPACE}" "${K8S_PROVIDER}" "${CLUSTER_OR_PROFILE}"
--
--echo "[check] state 013 radius artifact pack exists"
--for required in \
--  "${STATE_DIR}/README.md" \
--  "${UPSTREAM_BUILD_PLAN}" \
--  "${RADIUS_DIR}/app.bicep" \
--  "${RADIUS_DIR}/bicepconfig.json" \
--  "${RADIUS_DIR}/.rad/rad.yaml"; do
--  [[ -f "${required}" ]] || {
--    echo "[error] missing expected state 013 artifact: ${required}"
--    exit 1
--  }
--done
--
--echo "[check] radius app model has expected declarations"
--grep -q '^extension radius' "${RADIUS_DIR}/app.bicep" || {
--  echo "[error] app.bicep is missing 'extension radius'"
--  exit 1
--}
--while IFS= read -r resource_name; do
--  grep -q "name: '${resource_name}'" "${RADIUS_DIR}/app.bicep" || {
--    echo "[error] app.bicep is missing resource declaration for ${resource_name}"
--    exit 1
--  }
--done < <(jq -r '.components[].name, .runtime.edge.serviceName' "${UPSTREAM_SPEC}")
--
--if command -v rad >/dev/null 2>&1; then
--  echo "[check] radius CLI available"
--  rad version | head -n 1
--else
--  echo "[info] radius CLI not installed; skipping optional rad command checks"
--fi
--
--echo "[done] state 013 radius-kubernetes platform smoke tests passed"
-diff --git a/scripts/test-trade-feed-overlay.sh b/scripts/test-trade-feed-overlay.sh
-deleted file mode 100755
-index 98d13d5..0000000
---- a/scripts/test-trade-feed-overlay.sh
-+++ /dev/null
-@@ -1,120 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--BASE_URL="${1:-http://localhost:18086}"
--
--echo "[check] trade-feed root endpoint"
--curl -sS -i "${BASE_URL}/" | sed -n '1,20p'
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--DEFAULT_SOCKET_IO_CLIENT_PATH="$("${REPO_ROOT}/scripts/lib/resolve-socketio-client-path.sh")"
--
--echo "[check] publish/subscribe compatibility including legacy unsubscribe command"
--BASE_URL="${BASE_URL}" SOCKET_IO_CLIENT_PATH="${SOCKET_IO_CLIENT_PATH:-${DEFAULT_SOCKET_IO_CLIENT_PATH}}" node <<'NODE'
--const baseUrl = process.env.BASE_URL || 'http://localhost:18086';
--const clientModulePath = process.env.SOCKET_IO_CLIENT_PATH;
--
--let createClient;
--try {
--  createClient = require(clientModulePath).io;
--} catch (err) {
--  createClient = require('socket.io-client').io;
--}
--
--function wait(ms) {
--  return new Promise((resolve) => setTimeout(resolve, ms));
--}
--
--function withTimeout(promise, ms, label) {
--  return Promise.race([
--    promise,
--    new Promise((_, reject) => setTimeout(() => reject(new Error(`timeout: ${label}`)), ms))
--  ]);
--}
--
--function waitForConnect(client, label) {
--  return withTimeout(new Promise((resolve, reject) => {
--    client.on('connect', resolve);
--    client.on('connect_error', (err) => reject(new Error(`${label} connect_error: ${err.message}`)));
--  }), 8000, `${label} connect`);
--}
--
--async function main() {
--  const topic = '/traderspec/smoke';
--  const smokeId = `smoke-${Date.now()}`;
--  let receivedCount = 0;
--
--  const subscriber = createClient(baseUrl, { transports: ['websocket'] });
--  const publisher = createClient(baseUrl, { transports: ['websocket'] });
--
--  try {
--    await Promise.all([
--      waitForConnect(subscriber, 'subscriber'),
--      waitForConnect(publisher, 'publisher')
--    ]);
--
--    subscriber.on('publish', (message) => {
--      if (message && message.topic === topic && message.payload && message.payload.smokeId === smokeId) {
--        receivedCount += 1;
--      }
--    });
--
--    subscriber.emit('subscribe', topic);
--    await wait(250);
--
--    publisher.emit('publish', {
--      topic,
--      type: 'message',
--      payload: {
--        smokeId,
--        phase: 1
--      }
--    });
--
--    await withTimeout(new Promise((resolve) => {
--      const poll = setInterval(() => {
--        if (receivedCount >= 1) {
--          clearInterval(poll);
--          resolve();
--        }
--      }, 50);
--    }), 6000, 'first publish delivery');
--
--    subscriber.emit('unusbscribe', topic);
--    await wait(250);
--
--    publisher.emit('publish', {
--      topic,
--      type: 'message',
--      payload: {
--        smokeId,
--        phase: 2
--      }
--    });
--
--    await wait(900);
--    if (receivedCount !== 1) {
--      throw new Error(`expected exactly 1 received message after legacy unsubscribe, got ${receivedCount}`);
--    }
--
--    console.log('[info] socket publish/subscribe checks passed');
--  } finally {
--    subscriber.disconnect();
--    publisher.disconnect();
--  }
--}
--
--main().catch((err) => {
--  console.error(`[error] ${err.message}`);
--  process.exit(1);
--});
--NODE
--
--echo "[done] trade-feed overlay smoke tests passed"
-diff --git a/scripts/test-trade-processor-overlay.sh b/scripts/test-trade-processor-overlay.sh
-deleted file mode 100755
-index 441764a..0000000
---- a/scripts/test-trade-processor-overlay.sh
-+++ /dev/null
-@@ -1,196 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--ORIGIN="${1:-http://localhost:18093}"
--PROCESSOR_URL="${2:-http://localhost:18091}"
--POSITION_URL="${3:-http://localhost:18090}"
--TRADE_FEED_URL="${4:-http://localhost:18086}"
--WAIT_ATTEMPTS="${WAIT_ATTEMPTS:-60}"
--WAIT_SLEEP_SECONDS="${WAIT_SLEEP_SECONDS:-1}"
--
--ACCOUNT_ID=22214
--QTY=7
--SECURITY="TS$((RANDOM % 9000 + 1000))$(date +%s)"
--SECURITY="${SECURITY:0:15}"
--SMOKE_ID="tp-$(date +%s)-$RANDOM"
--
--echo "[check] trade-processor docs endpoint"
--curl -sS -i "${PROCESSOR_URL}/" | sed -n '1,20p'
--
--echo "[check] CORS preflight for trade-processor order endpoint"
--headers="$(
--  curl -sS -i -X OPTIONS \
--    -H "Origin: ${ORIGIN}" \
--    -H "Access-Control-Request-Method: POST" \
--    "${PROCESSOR_URL}/tradeservice/order" | sed -n '1,30p'
--)"
--echo "${headers}"
--
--cors_header="$(printf '%s\n' "${headers}" | awk -F': ' 'tolower($1)=="access-control-allow-origin" {print $2}' | tr -d '\r' || true)"
--if [[ -z "${cors_header}" ]]; then
--  echo "[error] missing Access-Control-Allow-Origin header on trade-processor"
--  exit 1
--fi
--
--if [[ "${cors_header}" != "*" && "${cors_header}" != "${ORIGIN}" ]]; then
--  echo "[error] unexpected Access-Control-Allow-Origin value: ${cors_header}"
--  exit 1
--fi
--
--echo "[check] publish TradeOrder through trade-feed and verify account topic updates"
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--DEFAULT_SOCKET_IO_CLIENT_PATH="$("${REPO_ROOT}/scripts/lib/resolve-socketio-client-path.sh")"
--
--TRADE_FEED_URL="${TRADE_FEED_URL}" \
--ACCOUNT_ID="${ACCOUNT_ID}" \
--SECURITY="${SECURITY}" \
--QTY="${QTY}" \
--SMOKE_ID="${SMOKE_ID}" \
--SOCKET_IO_CLIENT_PATH="${SOCKET_IO_CLIENT_PATH:-${DEFAULT_SOCKET_IO_CLIENT_PATH}}" node <<'NODE'
--const baseUrl = process.env.TRADE_FEED_URL || 'http://localhost:18086';
--const accountId = Number(process.env.ACCOUNT_ID || '22214');
--const security = process.env.SECURITY;
--const qty = Number(process.env.QTY || '7');
--const smokeId = process.env.SMOKE_ID;
--const clientModulePath = process.env.SOCKET_IO_CLIENT_PATH;
--
--let createClient;
--try {
--  createClient = require(clientModulePath).io;
--} catch (err) {
--  createClient = require('socket.io-client').io;
--}
--
--function wait(ms) {
--  return new Promise((resolve) => setTimeout(resolve, ms));
--}
--
--function withTimeout(promise, ms, label) {
--  return Promise.race([
--    promise,
--    new Promise((_, reject) => setTimeout(() => reject(new Error(`timeout: ${label}`)), ms))
--  ]);
--}
--
--function waitForConnect(client, label) {
--  return withTimeout(new Promise((resolve, reject) => {
--    client.on('connect', resolve);
--    client.on('connect_error', (err) => reject(new Error(`${label} connect_error: ${err.message}`)));
--  }), 8000, `${label} connect`);
--}
--
--async function main() {
--  const inboundTopic = '/trades';
--  const tradeTopic = `/accounts/${accountId}/trades`;
--  const positionTopic = `/accounts/${accountId}/positions`;
--
--  let sawTradeUpdate = false;
--  let sawPositionUpdate = false;
--
--  const subscriber = createClient(baseUrl, { transports: ['websocket'] });
--  const publisher = createClient(baseUrl, { transports: ['websocket'] });
--
--  try {
--    await Promise.all([
--      waitForConnect(subscriber, 'subscriber'),
--      waitForConnect(publisher, 'publisher')
--    ]);
--
--    subscriber.on('publish', (message) => {
--      if (!message || !message.topic || !message.payload) {
--        return;
--      }
--
--      if (
--        message.topic === tradeTopic &&
--        message.payload.security === security &&
--        Number(message.payload.quantity) === qty &&
--        message.payload.state === 'Settled'
--      ) {
--        sawTradeUpdate = true;
--      }
--
--      if (
--        message.topic === positionTopic &&
--        message.payload.security === security &&
--        Number(message.payload.quantity) === qty
--      ) {
--        sawPositionUpdate = true;
--      }
--    });
--
--    subscriber.emit('subscribe', tradeTopic);
--    subscriber.emit('subscribe', positionTopic);
--    await wait(250);
--
--    publisher.emit('publish', {
--      topic: inboundTopic,
--      type: 'TradeOrder',
--      payload: {
--        id: smokeId,
--        accountId,
--        security,
--        side: 'Buy',
--        quantity: qty
--      }
--    });
--
--    await withTimeout(new Promise((resolve) => {
--      const poll = setInterval(() => {
--        if (sawTradeUpdate && sawPositionUpdate) {
--          clearInterval(poll);
--          resolve();
--        }
--      }, 100);
--    }), 12000, 'trade-processor publish flow');
--
--    console.log('[info] trade-feed publish -> trade-processor -> account topics flow passed');
--  } finally {
--    subscriber.disconnect();
--    publisher.disconnect();
--  }
--}
--
--main().catch((err) => {
--  console.error(`[error] ${err.message}`);
--  process.exit(1);
--});
--NODE
--
--echo "[check] processed trade persisted and visible via position-service"
--found_trade=0
--for _ in $(seq 1 "${WAIT_ATTEMPTS}"); do
--  trades_json="$(curl -sS "${POSITION_URL}/trades/${ACCOUNT_ID}")"
--  if echo "${trades_json}" | jq -e --arg sec "${SECURITY}" --argjson qty "${QTY}" 'map(select(.security == $sec and .quantity == $qty and .state == "Settled")) | length > 0' >/dev/null; then
--    found_trade=1
--    break
--  fi
--  sleep "${WAIT_SLEEP_SECONDS}"
--done
--if [[ "${found_trade}" != "1" ]]; then
--  echo "[error] expected settled trade for security ${SECURITY} via position-service"
--  exit 1
--fi
--
--found_position=0
--for _ in $(seq 1 "${WAIT_ATTEMPTS}"); do
--  positions_json="$(curl -sS "${POSITION_URL}/positions/${ACCOUNT_ID}")"
--  if echo "${positions_json}" | jq -e --arg sec "${SECURITY}" --argjson qty "${QTY}" 'map(select(.security == $sec and .quantity == $qty)) | length > 0' >/dev/null; then
--    found_position=1
--    break
--  fi
--  sleep "${WAIT_SLEEP_SECONDS}"
--done
--if [[ "${found_position}" != "1" ]]; then
--  echo "[error] expected position update for security ${SECURITY} via position-service"
--  exit 1
--fi
--
--echo "[done] trade-processor overlay smoke tests passed"
-diff --git a/scripts/test-trade-service-overlay.sh b/scripts/test-trade-service-overlay.sh
-deleted file mode 100755
-index 05f3516..0000000
---- a/scripts/test-trade-service-overlay.sh
-+++ /dev/null
-@@ -1,111 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--ORIGIN="${1:-http://localhost:18093}"
--TRADE_SERVICE_URL="${2:-http://localhost:18092}"
--POSITION_SERVICE_URL="${3:-http://localhost:18090}"
--REQUEST_ORIGIN="$(echo "${TRADE_SERVICE_URL}" | sed -E 's#^(https?://[^/]+).*$#\1#')"
--NORMALIZED_ORIGIN="${ORIGIN%/}"
--NORMALIZED_REQUEST_ORIGIN="${REQUEST_ORIGIN%/}"
--
--ACCOUNT_ID=22214
--QTY=$((4300 + RANDOM % 700))
--SECURITY="IBM"
--UNKNOWN_TICKER="NO_SUCH_TICKER_123"
--UNKNOWN_ACCOUNT=99999999
--
--echo "[check] CORS header from ${TRADE_SERVICE_URL}/trade/ for origin ${ORIGIN}"
--headers="$(
--  curl -sS -i -X OPTIONS \
--    -H "Origin: ${ORIGIN}" \
--    -H "Access-Control-Request-Method: POST" \
--    "${TRADE_SERVICE_URL}/trade/" | sed -n '1,30p'
--)"
--echo "${headers}"
--
--cors_header="$(printf '%s\n' "${headers}" | awk -F': ' 'tolower($1)=="access-control-allow-origin" {print $2}' | tr -d '\r' || true)"
--if [[ -z "${cors_header}" ]]; then
--  if [[ "${NORMALIZED_ORIGIN}" == "${NORMALIZED_REQUEST_ORIGIN}" ]]; then
--    echo "[info] Access-Control-Allow-Origin header omitted for same-origin request (${NORMALIZED_ORIGIN}); continuing"
--  else
--    echo "[error] missing Access-Control-Allow-Origin header"
--    exit 1
--  fi
--fi
--
--if [[ -n "${cors_header}" && "${cors_header}" != "*" && "${cors_header}" != "${ORIGIN}" ]]; then
--  echo "[error] unexpected Access-Control-Allow-Origin value: ${cors_header}"
--  exit 1
--fi
--
--echo "[check] valid trade submission is accepted"
--valid_http_code="$(
--  curl -sS -o /tmp/trade-service-valid.out -w "%{http_code}" \
--    -X POST "${TRADE_SERVICE_URL}/trade/" \
--    -H "Content-Type: application/json" \
--    -d "{\"security\":\"${SECURITY}\",\"quantity\":${QTY},\"accountId\":${ACCOUNT_ID},\"side\":\"Buy\"}"
--)"
--if [[ "${valid_http_code}" != "200" ]]; then
--  echo "[error] expected 200 for valid trade submit, got ${valid_http_code}"
--  cat /tmp/trade-service-valid.out
--  exit 1
--fi
--
--cat /tmp/trade-service-valid.out | jq
--returned_account_id="$(jq -r '.accountId // .accountID // empty' /tmp/trade-service-valid.out)"
--returned_security="$(jq -r '.security // empty' /tmp/trade-service-valid.out)"
--returned_qty="$(jq -r '.quantity // empty' /tmp/trade-service-valid.out)"
--if [[ "${returned_account_id}" != "${ACCOUNT_ID}" || "${returned_security}" != "${SECURITY}" || "${returned_qty}" != "${QTY}" ]]; then
--  echo "[error] response payload mismatch from valid submit"
--  exit 1
--fi
--
--echo "[check] processed trade appears in position-service trades view"
--found_trade=0
--for _ in $(seq 1 25); do
--  trades_json="$(curl -sS "${POSITION_SERVICE_URL}/trades/${ACCOUNT_ID}")"
--  if echo "${trades_json}" | jq -e --arg sec "${SECURITY}" --argjson qty "${QTY}" 'map(select(.security == $sec and .quantity == $qty and .state == "Settled")) | length > 0' >/dev/null; then
--    found_trade=1
--    break
--  fi
--  sleep 1
--done
--if [[ "${found_trade}" != "1" ]]; then
--  echo "[error] expected settled downstream trade from trade-service submit (security=${SECURITY}, quantity=${QTY})"
--  exit 1
--fi
--
--echo "[check] unknown ticker returns 404"
--unknown_ticker_http_code="$(
--  curl -sS -o /tmp/trade-service-unknown-ticker.out -w "%{http_code}" \
--    -X POST "${TRADE_SERVICE_URL}/trade/" \
--    -H "Content-Type: application/json" \
--    -d "{\"security\":\"${UNKNOWN_TICKER}\",\"quantity\":100,\"accountId\":${ACCOUNT_ID},\"side\":\"Buy\"}"
--)"
--if [[ "${unknown_ticker_http_code}" != "404" ]]; then
--  echo "[error] expected 404 for unknown ticker, got ${unknown_ticker_http_code}"
--  cat /tmp/trade-service-unknown-ticker.out
--  exit 1
--fi
--
--echo "[check] unknown account returns 404"
--unknown_account_http_code="$(
--  curl -sS -o /tmp/trade-service-unknown-account.out -w "%{http_code}" \
--    -X POST "${TRADE_SERVICE_URL}/trade/" \
--    -H "Content-Type: application/json" \
--    -d "{\"security\":\"${SECURITY}\",\"quantity\":100,\"accountId\":${UNKNOWN_ACCOUNT},\"side\":\"Buy\"}"
--)"
--if [[ "${unknown_account_http_code}" != "404" ]]; then
--  echo "[error] expected 404 for unknown account, got ${unknown_account_http_code}"
--  cat /tmp/trade-service-unknown-account.out
--  exit 1
--fi
--
--echo "[done] trade-service overlay smoke tests passed"
-diff --git a/scripts/test-web-angular-baseline-ux-contract.ps1 b/scripts/test-web-angular-baseline-ux-contract.ps1
-deleted file mode 100644
-index 6edd3ea..0000000
---- a/scripts/test-web-angular-baseline-ux-contract.ps1
-+++ /dev/null
-@@ -1,141 +0,0 @@
--#!/usr/bin/env pwsh
--Set-StrictMode -Version Latest
--$ErrorActionPreference = 'Stop'
--
--$env:TRADERX_LOCAL_RUNTIME_SCRIPT = '1'
--$env:TRADERX_SKIP_GENERATE = '1'
--if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable('TRADERX_GENERATED_ROOT'))) {
--  $env:TRADERX_GENERATED_ROOT = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
--}
--
--param([string]$WebRoot)
--
--. "$PSScriptRoot/lib/runtime-common.ps1"
--
--$repoRoot = Get-TraderxRepoRoot -ScriptPath $PSCommandPath
--$generatedRoot = Get-TraderxGeneratedRoot -RepoRoot $repoRoot
--Use-GeneratedRuntimeScript -ScriptPath $PSCommandPath -GeneratedRoot $generatedRoot -RepoRoot $repoRoot -ScriptArgs $args
--
--if ([string]::IsNullOrWhiteSpace($WebRoot)) {
--  $WebRoot = Join-Path $generatedRoot 'code/target-generated/web-front-end/angular'
--}
--
--if (-not (Test-Path -LiteralPath $WebRoot -PathType Container)) {
--  $altWebRoot = Join-Path $generatedRoot 'code/components/web-front-end-angular-specfirst'
--  if (Test-Path -LiteralPath $altWebRoot -PathType Container) {
--    $WebRoot = $altWebRoot
--  }
--}
--
--$altWebRoot = Join-Path $generatedRoot 'code/components/web-front-end-angular-specfirst'
--if (Test-Path -LiteralPath $altWebRoot -PathType Container) {
--  $aboutTs = Join-Path $WebRoot 'main/app/about/about.component.ts'
--  $statusTs = Join-Path $WebRoot 'main/app/status/status.component.ts'
--  if (-not (Test-Path -LiteralPath $aboutTs) -or -not (Test-Path -LiteralPath $statusTs)) {
--    $WebRoot = $altWebRoot
--  }
--}
--
--$tradeTs = Join-Path $WebRoot 'main/app/trade/trade.component.ts'
--$tradeHtml = Join-Path $WebRoot 'main/app/trade/trade.component.html'
--$tradeScss = Join-Path $WebRoot 'main/app/trade/trade.component.scss'
--$tradeTicketTs = Join-Path $WebRoot 'main/app/trade/trade-ticket/trade-ticket.component.ts'
--$tradeTicketHtml = Join-Path $WebRoot 'main/app/trade/trade-ticket/trade-ticket.component.html'
--$tradeBlotterTs = Join-Path $WebRoot 'main/app/trade/trade-blotter/trade-blotter.component.ts'
--$positionBlotterTs = Join-Path $WebRoot 'main/app/trade/position-blotter/position-blotter.component.ts'
--$accountTs = Join-Path $WebRoot 'main/app/accounts/account.component.ts'
--$routingTs = Join-Path $WebRoot 'main/app/routing.ts'
--$headerTs = Join-Path $WebRoot 'main/app/header/header.component.ts'
--$headerHtml = Join-Path $WebRoot 'main/app/header/header.component.html'
--$aboutHtml = Join-Path $WebRoot 'main/app/about/about.component.html'
--$statusTs = Join-Path $WebRoot 'main/app/status/status.component.ts'
--$statusHtml = Join-Path $WebRoot 'main/app/status/status.component.html'
--$stateUiJson = Join-Path $WebRoot 'main/assets/state-ui.json'
--
--function Require-Pattern {
--  param(
--    [Parameter(Mandatory = $true)][string]$File,
--    [Parameter(Mandatory = $true)][string]$Pattern,
--    [Parameter(Mandatory = $true)][string]$Message
--  )
--
--  if (-not (Test-Path -LiteralPath $File -PathType Leaf)) {
--    throw "[error] missing expected source file: $File"
--  }
--
--  if (-not (Select-String -LiteralPath $File -Pattern $Pattern -Quiet)) {
--    throw "[error] $Message`n        file=$File"
--  }
--}
--
--Write-Host '[check] all-accounts mode contract in trade page'
--Require-Pattern -File $tradeTs -Pattern "displayName: 'All Accounts'" -Message 'expected explicit All Accounts option'
--Require-Pattern -File $tradeTs -Pattern 'id: 0' -Message 'expected All Accounts sentinel id=0'
--Require-Pattern -File $tradeHtml -Pattern '\[disabled\]="isAllAccountsSelected"' -Message 'expected trade ticket button disabled in all-accounts mode'
--Require-Pattern -File $tradeHtml -Pattern 'disabled in <strong>All Accounts</strong> mode\.' -Message 'expected all-accounts explanatory message'
--Require-Pattern -File $tradeHtml -Pattern '\[allAccountsMode\]="isAllAccountsSelected"' -Message 'expected allAccountsMode input binding for blotters'
--Require-Pattern -File $tradeHtml -Pattern '\[accountIds\]="accountIds"' -Message 'expected accountIds input binding for blotters'
--
--Write-Host '[check] all-accounts aggregation contract in blotters'
--Require-Pattern -File $tradeBlotterTs -Pattern '@Input\(\) allAccountsMode = false;' -Message 'expected trade blotter all-accounts input'
--Require-Pattern -File $tradeBlotterTs -Pattern 'getAllTrades\(' -Message 'expected trade blotter all-accounts data fetch'
--Require-Pattern -File $tradeBlotterTs -Pattern "headerName: 'ACCOUNT'" -Message 'expected account column in all-accounts trade blotter mode'
--Require-Pattern -File $positionBlotterTs -Pattern '@Input\(\) allAccountsMode = false;' -Message 'expected position blotter all-accounts input'
--Require-Pattern -File $positionBlotterTs -Pattern 'getAllPositions\(' -Message 'expected position blotter all-accounts data fetch'
--Require-Pattern -File $positionBlotterTs -Pattern 'mergePositionsBySecurity\(' -Message 'expected cross-account position merge'
--
--Write-Host '[check] security typeahead contract'
--Require-Pattern -File $tradeTicketTs -Pattern 'matchLabel' -Message 'expected synthesized ticker-company match label'
--Require-Pattern -File $tradeTicketTs -Pattern 'return `\$\{stock\.ticker\} - \$\{stock\.companyName\}`;' -Message 'expected ticker-company combined match label'
--Require-Pattern -File $tradeTicketHtml -Pattern 'typeaheadOptionField="matchLabel"' -Message 'expected typeahead to use match label'
--Require-Pattern -File $tradeTicketHtml -Pattern 'autocomplete="off"' -Message 'expected browser autocomplete disabled on security input'
--
--Write-Host '[check] account user full-name enrichment contract'
--Require-Pattern -File $accountTs -Pattern "field: 'fullName'" -Message 'expected account users grid to display full name'
--Require-Pattern -File $accountTs -Pattern 'this\.userService\.getUser\(accountUser\.username\)' -Message 'expected people-service lookup for account-user display'
--
--Write-Host '[check] responsive blotter layout contract'
--Require-Pattern -File $tradeScss -Pattern 'flex-wrap: wrap;' -Message 'expected wrapping blotter layout'
--Require-Pattern -File $tradeScss -Pattern 'min-width: 700px;' -Message 'expected minimum blotter width guardrail'
--
--Write-Host '[check] state-aware header + about/status routing contract'
--Require-Pattern -File $headerTs -Pattern 'TraderX Sample Trading App' -Message 'expected state-aware title formatter in header component'
--Require-Pattern -File $headerHtml -Pattern 'class="system-group"' -Message 'expected right-aligned system group in top bar'
--Require-Pattern -File $headerTs -Pattern 'isSystemMenuOpen' -Message 'expected internal System dropdown state in header component'
--Require-Pattern -File $headerHtml -Pattern '\(click\)="toggleSystemMenu\(\$event\)"' -Message 'expected Angular-driven System dropdown toggle'
--Require-Pattern -File $headerHtml -Pattern '\[href\]="metadata\.apiExplorerUrl"' -Message 'expected API explorer link in System dropdown'
--Require-Pattern -File $headerHtml -Pattern '\[href\]="metadata\.pubSubInspectorUrl"' -Message 'expected Pub/Sub inspector link in System dropdown'
--Require-Pattern -File $headerHtml -Pattern 'routerLink="/about"' -Message 'expected About link in System dropdown'
--Require-Pattern -File $headerHtml -Pattern 'routerLink="/status"' -Message 'expected Status link in System dropdown'
--Require-Pattern -File $headerHtml -Pattern 'class="finos-logo"' -Message 'expected FINOS logo anchored at right side'
--Require-Pattern -File $headerHtml -Pattern 'class="[^"]*nav[^"]*nav-tabs[^"]*functional-tabs[^"]*"' -Message 'expected separate functional tab row'
--Require-Pattern -File $routingTs -Pattern "path: 'about'" -Message 'expected about route registration'
--Require-Pattern -File $routingTs -Pattern "path: 'status'" -Message 'expected status route registration'
--Require-Pattern -File $aboutHtml -Pattern 'Open lineage map' -Message 'expected lineage link in about page'
--Require-Pattern -File $aboutHtml -Pattern 'Open API explorer|Open API Explorer|Open API explorer' -Message 'expected API explorer link in about page'
--Require-Pattern -File $aboutHtml -Pattern 'Open Pub/Sub inspector|Open Pub/Sub Inspector|Open Pub/Sub inspector' -Message 'expected Pub/Sub inspector link in about page'
--Require-Pattern -File $statusTs -Pattern 'statusChecks' -Message 'expected status checks metadata wiring'
--Require-Pattern -File $statusHtml -Pattern 'Service Status' -Message 'expected status page heading'
--
--Write-Host '[check] generated UI metadata contract'
--if (-not (Test-Path -LiteralPath $stateUiJson -PathType Leaf)) {
--  throw "[error] missing generated UI metadata file: $stateUiJson"
--}
--
--try {
--  $metadata = Get-Content -LiteralPath $stateUiJson -Raw | ConvertFrom-Json -ErrorAction Stop
--  foreach ($field in @('stateId', 'generatedAtUtc', 'sourceBranch', 'apiExplorerUrl', 'pubSubInspectorUrl')) {
--    if ([string]::IsNullOrWhiteSpace([string]$metadata.$field)) {
--      throw "[error] UI metadata missing required field: $field"
--    }
--  }
--}
--catch {
--  Require-Pattern -File $stateUiJson -Pattern '"stateId"' -Message 'expected stateId in ui metadata'
--  Require-Pattern -File $stateUiJson -Pattern '"generatedAtUtc"' -Message 'expected generatedAtUtc in ui metadata'
--  Require-Pattern -File $stateUiJson -Pattern '"sourceBranch"' -Message 'expected sourceBranch in ui metadata'
--  Require-Pattern -File $stateUiJson -Pattern '"apiExplorerUrl"' -Message 'expected apiExplorerUrl in ui metadata'
--  Require-Pattern -File $stateUiJson -Pattern '"pubSubInspectorUrl"' -Message 'expected pubSubInspectorUrl in ui metadata'
--}
--
--Write-Host '[done] web-front-end-angular baseline UX contract checks passed'
-diff --git a/scripts/test-web-angular-baseline-ux-contract.sh b/scripts/test-web-angular-baseline-ux-contract.sh
-deleted file mode 100755
-index 53eb734..0000000
---- a/scripts/test-web-angular-baseline-ux-contract.sh
-+++ /dev/null
-@@ -1,137 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
--GENERATED_ROOT="${TRADERX_GENERATED_ROOT:-${REPO_ROOT}/generated}"
--
--if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
--  LOCAL_RUNTIME_SCRIPT="${GENERATED_ROOT}/code/target-generated/scripts/$(basename "${BASH_SOURCE[0]}")"
--  if [[ -x "${LOCAL_RUNTIME_SCRIPT}" ]]; then
--    exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
--  fi
--fi
--WEB_ROOT="${1:-${GENERATED_ROOT}/code/target-generated/web-front-end/angular}"
--if [[ ! -d "${WEB_ROOT}" ]]; then
--  ALT_WEB_ROOT="${GENERATED_ROOT}/code/components/web-front-end-angular-specfirst"
--  if [[ -d "${ALT_WEB_ROOT}" ]]; then
--    WEB_ROOT="${ALT_WEB_ROOT}"
--  fi
--fi
--ALT_WEB_ROOT="${GENERATED_ROOT}/code/components/web-front-end-angular-specfirst"
--if [[ -d "${ALT_WEB_ROOT}" ]]; then
--  if [[ ! -f "${WEB_ROOT}/main/app/about/about.component.ts" || ! -f "${WEB_ROOT}/main/app/status/status.component.ts" ]]; then
--    WEB_ROOT="${ALT_WEB_ROOT}"
--  fi
--fi
--TRADE_TS="${WEB_ROOT}/main/app/trade/trade.component.ts"
--TRADE_HTML="${WEB_ROOT}/main/app/trade/trade.component.html"
--TRADE_SCSS="${WEB_ROOT}/main/app/trade/trade.component.scss"
--TRADE_TICKET_TS="${WEB_ROOT}/main/app/trade/trade-ticket/trade-ticket.component.ts"
--TRADE_TICKET_HTML="${WEB_ROOT}/main/app/trade/trade-ticket/trade-ticket.component.html"
--TRADE_BLOTTER_TS="${WEB_ROOT}/main/app/trade/trade-blotter/trade-blotter.component.ts"
--POSITION_BLOTTER_TS="${WEB_ROOT}/main/app/trade/position-blotter/position-blotter.component.ts"
--ACCOUNT_TS="${WEB_ROOT}/main/app/accounts/account.component.ts"
--ROUTING_TS="${WEB_ROOT}/main/app/routing.ts"
--HEADER_TS="${WEB_ROOT}/main/app/header/header.component.ts"
--HEADER_HTML="${WEB_ROOT}/main/app/header/header.component.html"
--ABOUT_TS="${WEB_ROOT}/main/app/about/about.component.ts"
--ABOUT_HTML="${WEB_ROOT}/main/app/about/about.component.html"
--STATUS_TS="${WEB_ROOT}/main/app/status/status.component.ts"
--STATUS_HTML="${WEB_ROOT}/main/app/status/status.component.html"
--STATE_UI_JSON="${WEB_ROOT}/main/assets/state-ui.json"
--
--require_pattern() {
--  local file="$1"
--  local pattern="$2"
--  local message="$3"
--  if [[ ! -f "${file}" ]]; then
--    echo "[error] missing expected source file: ${file}"
--    exit 1
--  fi
--  if ! grep -Eq "${pattern}" "${file}"; then
--    echo "[error] ${message}"
--    echo "        file=${file}"
--    exit 1
--  fi
--}
--
--echo "[check] all-accounts mode contract in trade page"
--require_pattern "${TRADE_TS}" "displayName: 'All Accounts'" "expected explicit All Accounts option"
--require_pattern "${TRADE_TS}" "id: 0" "expected All Accounts sentinel id=0"
--require_pattern "${TRADE_HTML}" "\\[disabled\\]=\"isAllAccountsSelected\"" "expected trade ticket button disabled in all-accounts mode"
--require_pattern "${TRADE_HTML}" "disabled in <strong>All Accounts</strong> mode\\." "expected all-accounts explanatory message"
--require_pattern "${TRADE_HTML}" "\\[allAccountsMode\\]=\"isAllAccountsSelected\"" "expected allAccountsMode input binding for blotters"
--require_pattern "${TRADE_HTML}" "\\[accountIds\\]=\"accountIds\"" "expected accountIds input binding for blotters"
--
--echo "[check] all-accounts aggregation contract in blotters"
--require_pattern "${TRADE_BLOTTER_TS}" "@Input\\(\\) allAccountsMode = false;" "expected trade blotter all-accounts input"
--require_pattern "${TRADE_BLOTTER_TS}" "getAllTrades\\(" "expected trade blotter all-accounts data fetch"
--require_pattern "${TRADE_BLOTTER_TS}" "headerName: 'ACCOUNT'" "expected account column in all-accounts trade blotter mode"
--require_pattern "${POSITION_BLOTTER_TS}" "@Input\\(\\) allAccountsMode = false;" "expected position blotter all-accounts input"
--require_pattern "${POSITION_BLOTTER_TS}" "getAllPositions\\(" "expected position blotter all-accounts data fetch"
--require_pattern "${POSITION_BLOTTER_TS}" "mergePositionsBySecurity\\(" "expected cross-account position merge"
--
--echo "[check] security typeahead contract"
--require_pattern "${TRADE_TICKET_TS}" "matchLabel" "expected synthesized ticker-company match label"
--require_pattern "${TRADE_TICKET_TS}" 'return `\$\{stock\.ticker\} - \$\{stock\.companyName\}`;' "expected ticker-company combined match label"
--require_pattern "${TRADE_TICKET_HTML}" "typeaheadOptionField=\"matchLabel\"" "expected typeahead to use match label"
--require_pattern "${TRADE_TICKET_HTML}" "autocomplete=\"off\"" "expected browser autocomplete disabled on security input"
--
--echo "[check] account user full-name enrichment contract"
--require_pattern "${ACCOUNT_TS}" "field: 'fullName'" "expected account users grid to display full name"
--require_pattern "${ACCOUNT_TS}" "this\\.userService\\.getUser\\(accountUser\\.username\\)" "expected people-service lookup for account-user display"
--
--echo "[check] responsive blotter layout contract"
--require_pattern "${TRADE_SCSS}" "flex-wrap: wrap;" "expected wrapping blotter layout"
--require_pattern "${TRADE_SCSS}" "min-width: 700px;" "expected minimum blotter width guardrail"
--
--echo "[check] state-aware header + about/status routing contract"
--require_pattern "${HEADER_TS}" "TraderX Sample Trading App" "expected state-aware title formatter in header component"
--require_pattern "${HEADER_HTML}" "class=\"system-group\"" "expected right-aligned system group in top bar"
--require_pattern "${HEADER_TS}" "isSystemMenuOpen" "expected internal System dropdown state in header component"
--require_pattern "${HEADER_HTML}" '\(click\)="toggleSystemMenu\(\$event\)"' "expected Angular-driven System dropdown toggle"
--require_pattern "${HEADER_HTML}" "\\[href\\]=\"metadata\\.apiExplorerUrl\"" "expected API explorer link in System dropdown"
--require_pattern "${HEADER_HTML}" "\\[href\\]=\"metadata\\.pubSubInspectorUrl\"" "expected Pub/Sub inspector link in System dropdown"
--require_pattern "${HEADER_HTML}" "routerLink=\"/about\"" "expected About link in System dropdown"
--require_pattern "${HEADER_HTML}" "routerLink=\"/status\"" "expected Status link in System dropdown"
--require_pattern "${HEADER_HTML}" "class=\"finos-logo\"" "expected FINOS logo anchored at right side"
--require_pattern "${HEADER_HTML}" "class=\"[^\"]*nav[^\"]*nav-tabs[^\"]*functional-tabs[^\"]*\"" "expected separate functional tab row"
--require_pattern "${ROUTING_TS}" "path: 'about'" "expected about route registration"
--require_pattern "${ROUTING_TS}" "path: 'status'" "expected status route registration"
--require_pattern "${ABOUT_HTML}" "Open lineage map" "expected lineage link in about page"
--require_pattern "${ABOUT_HTML}" "Open API explorer|Open API Explorer|Open API explorer" "expected API explorer link in about page"
--require_pattern "${ABOUT_HTML}" "Open Pub/Sub inspector|Open Pub/Sub Inspector|Open Pub/Sub inspector" "expected Pub/Sub inspector link in about page"
--require_pattern "${STATUS_TS}" "statusChecks" "expected status checks metadata wiring"
--require_pattern "${STATUS_HTML}" "Service Status" "expected status page heading"
--
--echo "[check] generated UI metadata contract"
--if [[ ! -f "${STATE_UI_JSON}" ]]; then
--  echo "[error] missing generated UI metadata file: ${STATE_UI_JSON}"
--  exit 1
--fi
--if command -v jq >/dev/null 2>&1; then
--  state_id="$(jq -r '.stateId // empty' "${STATE_UI_JSON}")"
--  generated_at="$(jq -r '.generatedAtUtc // empty' "${STATE_UI_JSON}")"
--  source_branch="$(jq -r '.sourceBranch // empty' "${STATE_UI_JSON}")"
--  api_explorer_url="$(jq -r '.apiExplorerUrl // empty' "${STATE_UI_JSON}")"
--  pubsub_inspector_url="$(jq -r '.pubSubInspectorUrl // empty' "${STATE_UI_JSON}")"
--  if [[ -z "${state_id}" || -z "${generated_at}" || -z "${source_branch}" || -z "${api_explorer_url}" || -z "${pubsub_inspector_url}" ]]; then
--    echo "[error] UI metadata missing required fields (stateId/generatedAtUtc/sourceBranch/apiExplorerUrl/pubSubInspectorUrl)"
--    exit 1
--  fi
--else
--  require_pattern "${STATE_UI_JSON}" "\"stateId\"" "expected stateId in ui metadata"
--  require_pattern "${STATE_UI_JSON}" "\"generatedAtUtc\"" "expected generatedAtUtc in ui metadata"
--  require_pattern "${STATE_UI_JSON}" "\"sourceBranch\"" "expected sourceBranch in ui metadata"
--  require_pattern "${STATE_UI_JSON}" "\"apiExplorerUrl\"" "expected apiExplorerUrl in ui metadata"
--  require_pattern "${STATE_UI_JSON}" "\"pubSubInspectorUrl\"" "expected pubSubInspectorUrl in ui metadata"
--fi
--
--echo "[done] web-front-end-angular baseline UX contract checks passed"
-diff --git a/scripts/test-web-angular-overlay.sh b/scripts/test-web-angular-overlay.sh
-deleted file mode 100755
-index a4153a5..0000000
---- a/scripts/test-web-angular-overlay.sh
-+++ /dev/null
-@@ -1,53 +0,0 @@
--#!/usr/bin/env bash
--set -euo pipefail
--
--export TRADERX_LOCAL_RUNTIME_SCRIPT=1
--export TRADERX_SKIP_GENERATE=1
--if [[ -z "${TRADERX_GENERATED_ROOT:-}" ]]; then
--  TRADERX_GENERATED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
--  export TRADERX_GENERATED_ROOT
--fi
--
--BASE_URL="${1:-http://localhost:18093}"
--
--echo "[check] angular UI root endpoint"
--root_headers="$(curl -sS -i "${BASE_URL}/" | sed -n '1,25p')"
--echo "${root_headers}"
--
--if ! printf '%s\n' "${root_headers}" | head -n 1 | grep -Eq 'HTTP/1\.[01] 200'; then
--  echo "[error] expected HTTP 200 from ${BASE_URL}/"
--  exit 1
--fi
--
--root_body="$(curl -sS "${BASE_URL}/")"
--if ! printf '%s\n' "${root_body}" | grep -qi "<app-root"; then
--  echo "[error] expected Angular app shell (<app-root>) in root response"
--  exit 1
--fi
--
--echo "[check] angular route fallback for /trade"
--trade_headers="$(curl -sS -i "${BASE_URL}/trade" | sed -n '1,25p')"
--echo "${trade_headers}"
--if ! printf '%s\n' "${trade_headers}" | head -n 1 | grep -Eq 'HTTP/1\.[01] 200'; then
--  echo "[error] expected HTTP 200 from ${BASE_URL}/trade"
--  exit 1
--fi
--
--echo "[check] branding assets are served"
--for asset in \
--  "/assets/img/traderx-apple-touch-icon.png" \
--  "/assets/img/traderx-icon.png" \
--  "/assets/img/FINOS_Icon_White.png"; do
--  asset_headers="$(curl -sS -i "${BASE_URL}${asset}" | sed -n '1,15p')"
--  echo "${asset_headers}"
--  if ! printf '%s\n' "${asset_headers}" | head -n 1 | grep -Eq 'HTTP/1\.[01] 200'; then
--    echo "[error] expected HTTP 200 for branding asset ${asset}"
--    exit 1
--  fi
--done
--
--SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
--TRADERX_LOCAL_RUNTIME_SCRIPT=1 "${SCRIPT_DIR}/test-position-blotter-upsert-contract.sh"
--TRADERX_LOCAL_RUNTIME_SCRIPT=1 "${SCRIPT_DIR}/test-web-angular-baseline-ux-contract.sh"
--
--echo "[done] web-front-end-angular overlay smoke tests passed"
+ INGRESS_URL="${1:-http://localhost:8080}"
+ ORIGIN="${2:-http://localhost:8080}"
+ COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-traderx-state-004}"
 diff --git a/start-env.sh b/start-env.sh
 new file mode 100755
 index 0000000..e057a15
@@ -17464,13 +13927,13 @@ index 0000000..187e687
 +- Commands: `subscribe`, `unsubscribe`, `unusbscribe` (legacy compatibility), `publish`
 diff --git a/trade-feed/SPEC.manifest.json b/trade-feed/SPEC.manifest.json
 new file mode 100644
-index 0000000..b0ff5e7
+index 0000000..4fa2a49
 --- /dev/null
 +++ b/trade-feed/SPEC.manifest.json
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,33 @@
 +{
 +  "schemaVersion": "1.0.0",
-+  "generatedAtUtc": "2026-03-31T12:59:32Z",
++  "generatedAtUtc": "2026-07-22T12:27:30Z",
 +  "component": {
 +    "id": "trade-feed",
 +    "kind": "service",
@@ -17484,7 +13947,8 @@ index 0000000..b0ff5e7
 +  "runtime": {
 +    "defaultPort": 18086,
 +    "dependsOn": [],
-+    "requiredEnv": ["TRADE_FEED_PORT","CORS_ALLOWED_ORIGINS"]
++    "requiredEnv": ["TRADE_FEED_PORT","CORS_ALLOWED_ORIGINS"],
++    "healthHint": "tcp://<host>:18086 (TCP reachability)"
 +  },
 +  "contracts": {
 +    "primary": null
@@ -17677,7 +14141,7 @@ index 0000000..ea23c90
 +});
 diff --git a/trade-feed/package-lock.json b/trade-feed/package-lock.json
 new file mode 100644
-index 0000000..33e775c
+index 0000000..0d65dc8
 --- /dev/null
 +++ b/trade-feed/package-lock.json
 @@ -0,0 +1,1387 @@
@@ -17686,6 +14150,7 @@ index 0000000..33e775c
 +  "version": "0.1.0",
 +  "lockfileVersion": 3,
 +  "requires": true,
++  "traderxPackageJsonSha256": "cc3a567c65940b267ee692065053d41c21d68a351d03923a059e2e38405841bd",
 +  "packages": {
 +    "": {
 +      "name": "@traderspec/trade-feed-specfirst",
@@ -18022,9 +14487,9 @@ index 0000000..33e775c
 +      }
 +    },
 +    "node_modules/engine.io": {
-+      "version": "6.6.6",
-+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
-+      "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
++      "version": "6.6.9",
++      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
++      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
 +      "license": "MIT",
 +      "dependencies": {
 +        "@types/cors": "^2.8.12",
@@ -18036,7 +14501,7 @@ index 0000000..33e775c
 +        "cors": "~2.8.5",
 +        "debug": "~4.4.1",
 +        "engine.io-parser": "~5.2.1",
-+        "ws": "8.21.0"
++        "ws": "~8.21.0"
 +      },
 +      "engines": {
 +        "node": ">=10.2.0"
@@ -18051,7 +14516,7 @@ index 0000000..33e775c
 +        "@socket.io/component-emitter": "~3.1.0",
 +        "debug": "~4.4.1",
 +        "engine.io-parser": "~5.2.1",
-+        "ws": "8.21.0",
++        "ws": "~8.18.3",
 +        "xmlhttprequest-ssl": "~2.1.1"
 +      }
 +    },
@@ -18825,7 +15290,7 @@ index 0000000..33e775c
 +      "license": "MIT",
 +      "dependencies": {
 +        "debug": "~4.4.1",
-+        "ws": "8.21.0"
++        "ws": "~8.18.3"
 +      }
 +    },
 +    "node_modules/socket.io-client": {
@@ -19039,7 +15504,7 @@ index 0000000..33e775c
 +    "node_modules/ws": {
 +      "version": "8.21.0",
 +      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
++      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 +      "license": "MIT",
 +      "engines": {
 +        "node": ">=10.0.0"
@@ -19065,15 +15530,14 @@ index 0000000..33e775c
 +        "node": ">=0.4.0"
 +      }
 +    }
-+  },
-+  "traderxPackageJsonSha256": "39fc4e0ac495da280f556f73c2994cb933384da19c272c01d289ab11319b15d5"
++  }
 +}
 diff --git a/trade-feed/package.json b/trade-feed/package.json
 new file mode 100644
-index 0000000..d9ef000
+index 0000000..136e009
 --- /dev/null
 +++ b/trade-feed/package.json
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,20 @@
 +{
 +  "name": "@traderspec/trade-feed-specfirst",
 +  "version": "0.1.0",
@@ -19089,6 +15553,8 @@ index 0000000..d9ef000
 +    "winston": "^3.17.0"
 +  },
 +  "overrides": {
++    "engine.io": "6.6.9",
++    "qs": "6.15.2",
 +    "ws": "8.21.0"
 +  }
 +}
@@ -19148,13 +15614,13 @@ index 0000000..e70a138
 +- CORS allowlist: `CORS_ALLOWED_ORIGINS` (default `*`)
 diff --git a/trade-processor/SPEC.manifest.json b/trade-processor/SPEC.manifest.json
 new file mode 100644
-index 0000000..54d8fe2
+index 0000000..c9e24d0
 --- /dev/null
 +++ b/trade-processor/SPEC.manifest.json
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,33 @@
 +{
 +  "schemaVersion": "1.0.0",
-+  "generatedAtUtc": "2026-03-31T12:59:32Z",
++  "generatedAtUtc": "2026-07-22T12:27:30Z",
 +  "component": {
 +    "id": "trade-processor",
 +    "kind": "service",
@@ -19163,12 +15629,13 @@ index 0000000..54d8fe2
 +    "buildTool": "Gradle",
 +    "sourcePath": "generated/code/components/trade-processor-specfirst",
 +    "targetPath": "apps/trade-processor",
-+    "notes": "Consumes /trades topic, persists trades/positions, and publishes account trade/position updates."
++    "notes": "\"Consumes /trades topic"
 +  },
 +  "runtime": {
 +    "defaultPort": 18091,
 +    "dependsOn": ["database","trade-feed"],
-+    "requiredEnv": ["TRADE_PROCESSOR_SERVICE_PORT","DATABASE_TCP_HOST","DATABASE_TCP_PORT","DATABASE_NAME","DATABASE_DBUSER","DATABASE_DBPASS","TRADE_FEED_ADDRESS","TRADE_FEED_HOST","CORS_ALLOWED_ORIGINS"]
++    "requiredEnv": ["TRADE_PROCESSOR_SERVICE_PORT","DATABASE_TCP_HOST","DATABASE_TCP_PORT","DATABASE_NAME","DATABASE_DBUSER","DATABASE_DBPASS","TRADE_FEED_ADDRESS","TRADE_FEED_HOST","CORS_ALLOWED_ORIGINS"],
++    "healthHint": "persists trades/positions, and publishes account trade/position updates.\",\"http://<host>:18091/v3/api-docs\""
 +  },
 +  "contracts": {
 +    "primary": "specs/001-baseline-uncontainerized-parity/contracts/trade-processor/openapi.yaml"
@@ -19186,17 +15653,18 @@ index 0000000..54d8fe2
 +}
 diff --git a/trade-processor/build.gradle b/trade-processor/build.gradle
 new file mode 100644
-index 0000000..83ce3bb
+index 0000000..3b645d6
 --- /dev/null
 +++ b/trade-processor/build.gradle
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,53 @@
 +plugins {
 +  id 'java'
-+  id 'org.springframework.boot' version '3.5.15'
++  id 'org.springframework.boot' version '3.5.16'
 +  id 'io.spring.dependency-management' version '1.1.7'
 +}
 +
-+ext['tomcat.version'] = '10.1.55'
++ext['jackson-bom.version'] = '2.22.1'
++ext['tomcat.version'] = '10.1.57'
 +
 +group = 'finos.traderx.trade-processor-specfirst'
 +version = '0.1.0'
@@ -19214,21 +15682,21 @@ index 0000000..83ce3bb
 +  implementation 'org.springframework.boot:spring-boot-starter-web'
 +  implementation 'com.h2database:h2:2.4.240'
 +  implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.17'
++  implementation 'org.apache.logging.log4j:log4j-api:2.26.1'
++  implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.26.1'
 +
 +  implementation('org.json:json:20240303') {
 +    because 'previous versions are affected by multiple CVE'
 +  }
-+  implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.3.20'
++  implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.4.10'
 +  implementation('io.socket:socket.io-client:2.1.2') {
 +    exclude group: 'org.json', module: 'json'
 +  }
 +  implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 +  implementation ('ch.qos.logback:logback-core:1.5.34') {
-+    because 'version brought in by spring boot 3.5.15 affected by CVE-2024-12798'
++    because 'version brought in by spring boot affected by CVE-2024-12798'
 +  }
 +  implementation 'ch.qos.logback:logback-classic:1.5.34'
-+  implementation 'org.apache.logging.log4j:log4j-api:2.26.0'
-+  implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.26.0'
 +  implementation 'org.apache.commons:commons-lang3:3.20.0'
 +
 +  testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -19242,6 +15710,1141 @@ index 0000000..83ce3bb
 +  exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk7'
 +  exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
 +}
+diff --git a/trade-processor/gradle/wrapper/gradle-wrapper.jar b/trade-processor/gradle/wrapper/gradle-wrapper.jar
+new file mode 100644
+index 0000000000000000000000000000000000000000..9bbc975c742b298b441bfb90dbc124400a3751b9
+GIT binary patch
+literal 43705
+zcma&Obx`DOvL%eWOXJW;<L>V64viP??$)@wHcsJ<yG!Hl?(U7dFYnCW{r1k?dA}jz
+z`Gcs6s9#i`JSR_PKBXuF4uJsz0|NsB0z&+G{=YvI5Lgg7F;yWtDS2@QSt$`Qc@;4=
+zRY(xfzuvO0rR}uJ{>68)>bJS6*&iHnskXE8MjvIPVl|FrmV}Npeql07fCw6`pw`0s
+zGauF(<*@v{3t!qoUU*=j)6;|-(yg@jvDx&fV^trtZt27?4Tkn729qrItVh@PMwG5$
+z+oXHSPM??iHZ!cVP~gYact-CwV`}~Q+R}PPNRy+T-geK+>fHrijpllon_F4N{@b-}
+z1M0=a!VbVmJM8Xk@NRv)m&aRYN}FSJ{LS;}2ArQ5baSjfy40l@T5)1r-^0fAU6f_}
+zzScst%$Nd-^ElV~H0TetQhMc%S{}Q4lssln=|;LG?Ulo}*mhg8YvBAUY7YFdXs~vv
+zv~{duzVw%C#GxkBwX=TYp1Dh*Uaum2?RmsvPaLlzO^fIJ`L?&OV?Y&kKj~^kWC`Ly
+zfL-}J^4a0Ojuz9O{jUbIS;^JatJ5+YNNHe}6nG9Yd6P-lJiK2ms)A^xq^H2fKrTF)
+zp!6=`Ece~57>^9(RA4OB9;f1FAhV%zVss%#rDq$9ZW3N2cXC7dMz;|UcRFecBm`DA
+z1pCO!#6zKp#@mx{2>Qcme8y$Qg_gnA%(`Vtg3ccwgb~D(&@y8#Jg8nNYW*-P{_M#E
+zZ|wCsQoO1(iIKd-2B9xzI}?l#Q@G5d$m1Lfh0q;iS5FDQ&9_2X-H)VDKA*fa{b(sV
+zL--krNCXibi1+*C2;4qVjb0KWUVGjjRT{A}Q*!cFmj0tRip2ra>WYJ>ZK4C|V~RYs
+z6;~+*)5F^x^aQqk9tjh)L;DOLlD8j+0<>kHc8<MT8<q;@cs^TP%TBGLJb3?hF`f1u
+zr^#HdaN9hgmYP%3&4eX^>MN|68PxQV`tJFbgxSfq-}b(_h`luA0&<H)Ks&ZC5avn$
+zblv>;Vk<@5<kF$(jU%Y1<)oJ9n#F!_Nzr$1q5g8vk%4E5n+!%&?C??!2P`6+_1%cB
+zz~CmX+0avvVR!Fm9DBz=5OYDMzyT5o=mbbC1@y!;y!`Xf(U~IBp=}v8UBCUG8>1i0
+z_cu6{_*=vlvYbKjDawLw+t^H?OV00_73Cn3goU<yjj&HS+sgjt5ulpVMAFPV!h#%(
+z;O+R^(R7duR?KDiP~~*Sz}yNf2S{i|h1xTKnI_B>5?})UYFuoSX6Xqw;TKcrsc|r#
+z$sMWYl@cs#SVopO$hpHZ)cdU-+Ui%z&Sa#lMI~zWW@vE%QDh@bTe0&V9nL>4Et9`N
+zGT8(X{l@A~loDx}BDz`m6@tLv@$mTlVJ;4MGuj!;9Y=%;;_kj#o8n5tX%@M)2I@}u
+z_{I!^7N1BxW9`g&Z+K#lZ@7_dXdsqp{W9_`)zgZ=sD~%WS5s$`7z#XR!Lfy(4se(m
+zR@a3twgMs19!-c4jh`PfpJOSU;vShBKD|I0@rmv_x|+ogqslnLLOepJpPMOxhRb*i
+zGHkw<C6i>f#?ylQ@k9QJL?!}MY4i7joSzMcEhrDKJH&?2v{-tgCqJe+Y0njl7HYff
+z{&~M;JUXVR$qM1FPucIEY(IBAuCHC@^~QG6O!dAjzQBxDOR~lJEr4KS9R*idQ^p{D
+zS#%NQADGbAH~6wAt}(1=Uff-1O#ITe)31zCL$e9~{w)gx)g>?zFE{Bc9nJT6xR!i8
+z)l)~9&~zSZTH<f>k{?iQL^MQo$wLi}`B*qnvUy+Y*jEraZMnEhuj`Fu+>b5xD1_Tp
+z)8|wedv42#3AZUL7x&G@p@&zcUvPkv<gOT$sg9nDsP`h2d9g#)Sfr@kmW^OuGVzBe
+z-mcj_6tCQbJjPpCR0_6&eS`PLDmBn1jc_}#l=&oN(1kZX%4pnohcH*OTaAUFUQR9I
+zJsE{W;L}Y`SMW2`Yxlamz6R=sERGI$HJ&wT!!xuJCXi~%#!zT5#JMaroI8+$NZU!j
+zFFo1(OoSgnZ`tOBNEeS}AJTa*w)!5g*s2NJdIyH_O<3^t7uCBd5c|%jlVJAD=GPv6
+zGy{$r4IuY4V;#IhoM9(k9N?|GBT!0wNQtL*(Wla6D)K3^HTQh9<!?y8pnvCIy%Of4
+zum(WCu{ljigy+8e*vg{OEP4h-N6?BPRwPrLau9K*^W?WW;LAPzYRy1|S<{}2ayMO6
+z8Gk5*s)+cT;R6e$f61Q!-QhR7$s`=CY0vN!#Gm}?vOh0St8%mcv%@1{x_S+@@wk7+
+zFHA$hX%gbrT2VQ8hV%{#=997-Aa7v_qGy2j`{6(KD}jjYS=X4TTgcc_#&`99oP{`1
+z+?qRA0-j~Bi$<R4kd7i0PY(>g=YJS6?1B7ZEXr4b>M+9Gli$gK-Sgh{O@>q7TUg+H
+zNJj`6q#O@>4HpPJEHvNij`sYW&u%#=215HKNg;C!0#hH1vlO<x`KH1(L52Jfzqckp
+zK+CZ7Ysjx9Ry1%Exbc$7q$%?P{F`qK)zp<pKl6?{P-tc#d(^voQM{*HzaqZ$MF6+j
+zS~SbNnOTb~v^`{pTqA`20=exoU<o^ZUk`ng!~@i!3dZcf;2^$k_C@g8WV8ec1R9H3
+z1`mCus@E!98f~!1rPz5UtUeu7G^^TU%W)2pTm^QP5I*2-sUu2=PL2Gs`-60K_$N2v
+zq}PJt3O#wc`jCA!5t<`h+K4FljR)C<HUy;}xwV&b`+VADm9(!vPCRX?^<oG+Vqeyc
+zzAmc*_iJ~=?~J-H*{$GHN4NIN0}j0yD3GR_r7^*==U{*u<)Ms-C|SiYB&zk-Wp@Y%
+zp&S*-{+zxwY`#DQ<w|BzbKuAp({yI0gR5k4q=KVfX|Z@&C2D=%htF<kWp>5+dFq9&
+zS)8{5_%hz?#D#wn&nm@aB?1_|@kpA<uzp&}l&AD1u)JhYR;ZXh9aBhZCzAtxS13Bp
+zA6Zy}vU8v^?dRy1PIC=7_PA-v<La!D;#*&-5%sU))yJ_yayZVijq+d8MU%ahLUSA$
+zb0EHFFV2D{O}X^o(5AJif==$^X=iGGhpJ4KYw@<T@0PxkDnjx1LyF6S1hcurMfQm5
+zJhtbDMr1*Q{|1EZ*mS}Qd33Qo7~2#jY)+05;Xfi)zKK9EDUF$=6E5F1W+xgADW`s2
+zH|$E3Fed+2a!z;4mZn&JN5DxUfPSaKxluwruV#d2eoAHtR&D=*wdN6FVZ6oI2g0Hw
+zOP;PSG}*`dJEr(*FvR10V<#_MSwpBkIpj_jL>@{%jYcs{K%$a4W{<UY0d}<G_tvcW
+zMNcwn<nVcftdCFzNuiwF_|8?DI$6#{zbc7GvkUvU3|!{Ax?HKf@j9mrId!xHE6!-2
+z{C)xYPtH9rOV?L9kcZN6$krD3qudB?$8^ttXzA!P2B|T6$sO-q_YsmhfI9ntr>k@F
+zPyTav?jb;F(|GaZhm6&M#g|`ckO+|mCtAU)5_(<C;Peqq9IE<_AsNiFs{{>hn&Ogd
+z9Ku}orOMu@K^Ac>eRh3+0-y^F`j^noa*OkS3p^tLV`TY$F$cPXZJ48!xz1d7%vfA(
+zUx2+sDPqHfiD-_wJDb38K^LtpN2B0w=$A10z%F9f_P2aDX63w7zDG5CekVQJGy18I
+zB!tI`6rZr7TK10L(8bpiaQ>S@b7r_u@lh^vakd0e6USWw7W%d_Ob%M!a`K>#I3r-w
+zo2^+9Y)Sb?P9)x0iA#^ns+Kp{JFF|$09jb6ZS2}_<-=$?^#IUo5;g`4ICZknr!_aJ
+zd73%QP^e-$%Xjt|28xM}ftD|V@76V_qvNu#?Mt*A-OV{E4_zC4Ymo|(cb+w^`Wv==
+z>)c%_U0w`d$^`lZQp@midD89ta_qTJW~5lRrIVwjRG_9aRiQGug%f3p@<N8PMQE{a
+zd_6w48$rsd^cXZQ7Dwk9nz}YC&*86L&Yst+a`$%*_e1yJh%kgNQXk4z5r6m?Y@2xN
+zly?J=iN07}T>;*%Y@J5uQ|#dJ+P{Omc`d2VR)DXM*=ukjVqIpkb<9gn9{*+&#p)Ek
+zN=4zwNWHF~=Gqc<UjtcOL9OLcIawlSDS7cyPainIsyG~{9o!H&xa9hYf#oyhSccci
+zt8ciEDfpw+|JDHKvIGdAID*M?Ww(Uo_>Lkd!q0p(S2_K=Q`$whZ}r@ec_cb9hhg9a
+z6CE=1n8Q;hC?;ujo0numJBSYY6)GTq^=kB~`-qE*h%*V6-ip=c4+Yqs*7C@@b4YAi
+zuLjsmD!5M7r7d5ZPe>4$;iv|zq=9=;B$lI|xuAJwi~j~^Wuv!Qj2iEPWjh<cjq`B2
+zQQyz_oTCXImfm@9L;Jg(EcYq6*mZ2Ar7Wg-A&#d%mn;}2vkz#+K|`?Os_iMQICL7M
+z%X3DlLx`B&@S70b+8_uUYlQ7Jjwqbip^{Sy&<=Xy_(h{9O0(ZA&bm55akipSI@h-P
+zouFPBu_Do|z_f_JGMu+d26M|qD0mf|&pPvU(0X6B(p676+94<iS<G;?SQn?!TsCT<
+zW`oSdht$$w66GB-l}L1v_Gel0yjn`(hShw}$Zca>9Z&#<HMI*Z2_1}T(Ag7?VQuOk
+z`{mYjKhEP<qwlCQ<3{~SgOxwbx2t!SbHzjBYU=s|B(D4sC75oIbo;F+(N+m9uUJay
+z3zRQ;6klQ`P7c#H*XA(0OTAp7rMZSXB;)Q$&ymhbN*ra}sd<0WM1I3@<CsDWXd;ki
+z&@?%;r2lEn-Rstvl;9}rizIur@q3(@kvLvHJ^t^eGQ9G#)J~{}lP*OWXqf7ze8OWy
+z5Rgs^5D>+G>lZQpZ@(xfBrhc{rlLwOC;opt<Bi<dsH_Yf{WPKs9reW6WSuhO9Lv`J
+z^%&id)VSO@jT9{?+)0RW%3gsMRWsJNqP+s@Agpg+Fbck0IbJz}ettAGj7<$cpWvte
+z6!<*<{!y4dAH~kmjKRziU~Fx|U}SB<AYx}@1F$ugwXii2ax`<XF|l<Pb2l=vceb#z
+zr8lw$I63{F=af?zmj-7-$zEDn&|(O{iskxs=4#PjtBP81^sD$wd-1XbZiaEHaTAOo
+zQD4&~nfoQEH>JZDj4Xfu3$u6rt_=YY0~lxoy~fq=*L_&RmD7dZWBUmY&12S;(Ui^y
+zBpHR0?Gk|`U&CooNm_(kkO~pK+cC%uVh^cnNn)MZjF@l{_bvn4`Jc}8QwC5_)k$zs
+zM2qW1Zda%bIgY^3NcfL)9ug`05r5c%8ck)J6{fluBQhVE>h+IA&Kb}~$55m-^c1S3
+zJMXGlOk+01qTQUFlh5Jc3xq|7McY$nCs$5=`8Y;|il#Ypb{O9}GJZD8!kYh{TKqs@
+z-mQn1K4q$yGeyMcryHQgD6Ra<6^5V(>6_qg`3uxbl|T&cJVA*M_+OC#>w(xL`RoPQ
+zf1ZCI3G%;<gu?&p>o-x>RzO!mc}K!XX{1rih0$~9XeczHgHdPfL}4IPi~5EV#ZcT9
+zdgkB3+NPbybS-d;{8%bZW^U+x@Ak+uw;a5JrZ<t9b~FAko|dNnqw@`fG4fl;gO}GN
+zja@xAhij0PWn_9yAtqa|Q~JyS@OCX>H!WbNvl<c^f{)!@kr}sV306x!m(JFK2Su#H
+zA{l>!b~r4*vs#he^bqz`W93PkZna2oYO9dBrKh2QCWt{dGOw)%Su%1bIjtp4dKjZ^
+zWfhb$M0MQiDa4)9rkip9DaH0_tv=XxNm>6MKeWv>`KNk@QVkp$Lhq_~>M6S$oliq2
+zU6i7bK;TY)m>-}X7hDTie>cc$J|`*}t=MAMfWIALRh2=O{L57{#fA_9LMnrV(HrN6
+zG0K_P5^#$eKt{J|#l~U0WN_3)p^LLY(XEqes0OvI?3)GTNY&S13X+9`6PLVFRf8K)
+z9x@c|2T72+-KOm|kZ@j4EDDec>03FdgQlJ!&FbUQQH+nU^=U3Jyrgu97&#-W4C*;_
+z(WacjhBDp@&Yon<9(BWPb;Q?Kc0gR5ZH~aRNkPAWbDY!FiYVSu!~Ss^9067|JCrZk
+z-{Rn2KEBR|Wti<xxNV#Db47^*a|{iSLoUSn+}XCk5${GR@Qb+|Eox;WbSB?b>_iy)
+zXnh2wiU5Yz2L!W{{_#LwNWXeNPHkF=jj<Oca}a<VYq$(Z)L~2{hsCZ>XmHC@n*oiz
+zIoM~Wvo^T@@t!QQW?Ujql-GBOlnB|HjN@x~K8z)c(X}%%5Zcux09vC8=@tvgY>czq
+z3D(U&FiETaN9aP}FDP3ZSIXIffq>M3{~eTB{uauL07oYiM=~K(XA{SN!rJLyXeC+Y
+zOdeebgHOc2aCIgC=8>-Q>zfuXV*=a&gp{l#E@K|{qft@YtO>xaF>O7sZz%8);e86?
+z+jJlFB{0fu6%8ew^_<+v>>%6eB8|t*_v7gb{x=vLLQYJKo;p7^o9!9A1)fZZ8i#ZU
+z<|E?bZakjkEV8xGi?n+{Xh3EgFKdM^;4D;5fHmc04PI>6oU>>WuLy6jgpPhf8$K4M
+zjJo*MbN0rZbZ!5DmoC^@hbqXiP^1l7I5;Wtp2i9Jkh+KtDJoXP0O8qmN;Sp(+%upX
+zAxXs*qlr(ck+-QG_mMx<HJPMiiyFhyvyc$BVLB{06!#fNnvcq+4(CeJ9NSp(yBP{p
+zz9+FDyloDA-5BFzU$X6O5`cUWFMHGQXtH9zX=W;Z0SMrXCMHY77EA&39fq<AIjYX_
+zL-)E@whkh@FYnG!*@-)hr`+%$^!mR-H_bvW274&&>?hQNXVV~LT{$Q$ShX+&x?Q7v
+z@8t|UDylH6@RZ?WsMVd3B0z5zf50BP6U<&X_}+y3uJ0c5OD}+J&2T8}A%2Hu#Nt_4
+zoOoTI$A!hQ<2pk5wfZDv+7Z{yo+Etqry=$!*pvYyS+kA4xnJ~3b~TBmA8Qd){w_bE
+zqDaLIjnU8m$wG#&T!}{e0qmHHipA{$j`%KN{&#_Kmjd&#X-hQN+ju$5Ms$iHj4r?)
+z&5m8tI}L$ih&95AjQ9EDfPKSmMj-@j?Q+h~C3<|Lg2zVtfKz=ft{YaQ1i6Om&EMll
+zzov%MsjSg=u^%EfnO+W}@)O<s4y0<!F*}jN{~^*=<<M!`pCE38_&X5u{wE+7HZiqx
+zG!eIObaGa4G5p`k`7da0P_t5)HNf!I6NGD^#Jcju!NjqqL7(FK$?;p8B-cTjS(f#p
+zHML@9bjCH8>6u0LwoX709h3Cxdc2Rwgjd%LLTChQvHZ+y<1q6kbJXj3_pq1&MBE{8
+zd;aFotyW>4WHB{JSD8Z9M@jBitC1RF;!B8;Rf-B4nOiVbGlh9w51(8WjL&e{_iXN(
+zAvuMDIm_>L?rJPxc>S`bqC|W$njA0MKWa?V$u6mN@PLKYqak!bR!b%c^ze(M`ec(x
+zv500337YCT4gO3+9>oVIJLv$pkf`01S(DUM+4u!HQob|IFHJHm#>eb#eB1X5;bMc|
+z>QA4Zv}$S?fWg~31?Lr(C>MKhZg>gplRm`2WZ--iw%&&YlneQYY|PXl;_4*>vkp;I
+z$VYTZq|B*(3(y17#@ud@o)XUZPYN*rStQg5U1Sm2gM}7hf_G<>*T%6ebK*tF(kbJc
+zNPH4*xMnJNgw!ff{YXrhL&V$6`ylY={qT_xg9z<NbPza#S5_;7-HDWW5RigZ=LV6*
+zC(tYTyWThzXHf4MXBa7hZbsubd?Ryu_#A)%-?VnWgzy8ET!tu|{8#c_&gaH`oCBdA
+zDZ_rb+3zi849gP{1S5P<jk#MGP++DGAy-3vwo{u^X(9-1cLI-eD^5-vRFWj~@&pA;
+zVHMOE7R0Uo3r+HxoApr;N3Ucb6+Fi&Rw>nQWw9>PlG~IbhnpsG_94Kk_(V-o&v7#F
+znra%uD-}KOX2dkak**hJnZZQyp#ERyyV^lNe!Qrg=VHiyr7*%j#PMvZMuYNE8o;JM
+zGrnDWmGGy)(UX{rLzJ*<yAEppP~EY>QEBd(VwMBXnJ@>*F8eOFy|FK*Vi0tYDw;#E
+zu#6eS;%Nm2KY+7dHGT3m{TM7sl=z8|V0e!DzEkY-RG8vTWDdSQFE|?+&FYA146@|y
+zV(JP>LWL;TSL6rao@W5fWqM1-xr$gRci#RQV2DX-x4@`w{uEUgoH4G|`J%H!N?*Qn
+zy~rjzuf(E7E!A9R2bSF|{{U(zO+;e29K_dGmC^p7MCP!=Bz<LU?&i-}KG6X?-t~{t
+z6;cwZkN#6(bfNz)LHYiZ1eLM1bF=-Y%KTGzRGb0MCjXM5S?b4b=q6Yne5@ub&Z1fi
+zwe1K(xpIl(UuqiL&9zbE3--S?_yjh~vM9{@56fnz)vH22_-yvCYe2Y7H${#(Jncbu
+zdEOFD?GkNqW$#j4@v}(bNmkD>q@}&AdF5=rt<!COJnb)nu<w2#Fc9&zR-N5X<)-uZ
+z$<fUbN+So80PB;-k3&vQQgFt#a4A~G5i7YfkwVod(g_caMdbNUgH}RSd$;2i>Cwka
+zTT1A?5o}i*sXCsRXBt)`?nOL$zxuP3i*rm<aImxvw^U@{B*fUS0^1}v7Fr7%=t{5R
+zr{ZxLLkwm{RxNy^ZS6xw>3Gmbmr6}9HCLvL*45d|(zP;q&(v%}S5yBmRVdYQQ24zh
+z6qL2<2>StU$_Ft29Iy<fP{_A}(TLFc`ulnZB85D4f`?3P{(NRH&`r%oRcE}aoRUTu
+zE?7Y|z|k@bRY%JdWY5F(IA^2{CsLJ|)7+Sk)-1LuGjdpW2<~xRpIawD7|b}pzW)Q9
+zAY5MSu{bw_VLh`wPo4Jb7n0QMsV))LK}%s$WqXQ<7NQ-5!+}@QkF+dLPzuz#x@W)<
+znhWO;3yF&C)0P|n)1lp<2aeQ_$@3&mI?kFLSzhC?s<NQdC{FP%I#bp;kORX{l<3x0
+zI8yQp7E^WBY)WEgiAkeUv{*@dstpdRH)q&jD@2v`EidG8QsD}**_mj0v08)ZlDq;v
+z=LqggR_Jz_t>F!6=!@;tW=o8vNzVy*hh}XhZhUbxa&;9~woye<_YmkUZ)S?PW{7t;
+zmr%({tBlRLx=ffLd60`e{PQR3NUniWN2W^~7Sy~MPJ>A#!6PLnlw7O0(`=PgA}JLZ
+ztqhiNcKvobCcB<yMplTfXcPqrYE+vVszVQmm@rg}2{rJGaO7?|y?`3a_S!XcQLG&V
+z?bgXaiD}w%%A$ShO3yHwQZ52?;xk}hq`az4Qz(&ZI4P8rn`^{UhqrR}d!P@Af>el2
+z-N82?4-()eGOisnWcQ9Wp23|ybG?*g!2j#>m3~0__IX1o%dG4b;VF@^B+mRgKx|ij
+zWr5G4jiRy}5n*(qu!W`y54Y*t8g`$YrjSunUmOsqykYB4-D(*(A~?QpuFWh;)A;5=
+zPl|=x+-w&H9B7EZGjUMqXT}MkcSfF}bHeRFLttu!vHD{Aq)3HVhvtZY^&-lxYb2%`
+zDXk7>V#WzPfJs6u{?ZhXpsMdm3kZscOc<^P&e&684Rc1-d=+=VOB)NR;{?0NjTl~D
+z1MXak$#X4{VNJyD$b;U~Q@;zlGoPc@ny!u7Pe;N2l4;i8Q=8>R3<TEv>H{>HU<axH
+zp`GSL-T`v+`h{A=aX;JW4CEU!(+?Uoa0aOL$De+GUOkWsAqa2ZK4FC`K3!1~Zy9HB
+zzvq?1%x_y$*Bv$0)GEimNLh#E5__f1Mpw)(hNBlqy(D20`q=1`jdMVFIk`mBE8>(z
+z%hV2?rSinAg6&wuv1DmXo<vm47<QjMysD@bzHIj93EKq|LsScFN}?1q^I)(oMd!rn
+zn|DubZt_^bCFb75g5Trh|4Qx?zo0F<A>k`5@a3@H0BrqsF~L$pRYHNEXXuRIWom0l
+zR9hrZpn1LoYc+G@q@VsFyMDNX;>_Vf%4>6$Y@j;KSK#g)TZRmjJxB!_NmUMTY(cAV
+zmew<J38CI3YanL~W|fbwxrqJqw<my@*XH*?z?)KSw#4MywnI6A#4U@pFSNEc`Lrv-
+z-S!+OS6bh_zm$&432UozL4&En7L86;ghp^8;$ppb%xO{FV^Pm{yQ`>n7H{z`M3^Z&
+z2O$pWlDuZHAQJ{xjA}B;fuojAj8WxhO}_9>qd0|p0nBXS6IIRMX|8Qa!YDD{9NYYK
+z%JZrk2!Ss(Ra@NRW<7U#%8SZdWMFDU@;q<}%F{|6n#Y|?FaBgV$7!@|=NSVox<B(`
+zIq)S_BbU4&5Y;#+zzGVxaXAWCz*U+(@Q+o!?%YbO5Lnd}NLZ#m2X87gxZsJLNwk+3
+z@~G>lJI4G-G(rn}bh|?m<PI-QoC(rF$EW8<oaZlKv17e{ZZEs5gI5rI>KkaBF$-Yr
+zA;t0r?^5Nz;u6gwxURapQ0$(-su(S+24Ffmx-aP(@8d>GhMtC5x*iEXIKthE*mk$`
+zOj!Uri|EAb4>03C1xaC#(q_I<;t}U7;1Jq<Pun#t0_d*_eJ@mw@913m0*PYiG@}tB
+ztP(s*U6EvObA-KfU!e+*)h*+A8wNY(z9PpR7|ng1RQ75YwD8Ip`2*1~IH(z=Ujxyl
+z<ntP1@(4b<498kKUoYg<(N=o2;8F4n|CejK@H@|3g8~6DMEW~D{f`P>ISVHz3tO{)
+zD(Yu@=>I9FDmDtUiWt81;BeaU{_=es^#QI7>uYl@e$$lGeZ~Q(f$?^3>$<<{n`Bn$
+zn8ba<y1J3mk7QrBkS`^06lBb%XobuZz0Uc3vJW$}oz5rqH-CVXbQ?TYcYWkt$y+%%
+zDGW6>mZlL@6r^RZHV_c5WV7m2(G6X|OI!+04eAnNA5=0v1Z3lxml2#p<Q2Hk_3rET
+z#;|JLdCr%w6PIsdU-R${5=&H%MpF|6*IQEs*~vt<`)osFM7~B}S2*^XM|R%(!bK5x
+z?B98-@YWD?D?WIa89ue2g+&}MCA&<zv{-XU9dkW^Z!-wg1^SV3v?-k+`&iNJ0Tmf1
+z6uA?;4A2J1dJC}17}snGhxuUKB>~Zo57ri;4>;#16sSXXEK#QlH>=b$inEH0`G#<_
+zvp;{+iY)BgX$R!`HmB{S&1TrS=V;*5SB$7*&%4rf_2wQS2ed2E%Wtz@y$4ecq4w<)
+z-?1vz_&u>s?BMrCQG6t9;t&gvYz;@K@$k!Zi=`tgpw*v-#U1Pxy%S9%52`uf$XMv~
+zU}7FR5L4F<#9i%$P=t29nX9VBVv)-y7S$ZW;gmMVBvT$BT8d}B#XV^@;wXErJ-W2A
+zA=Jft<sUW%eIzvD`%|;&1KUO!vBts9$jx)aLl#J~zQpxlFUxMboZ!i0c9Fc`OtVN_
+zc!Oz?NJ1z_+?YXWzG9yyn`e=Y8ro2cgXxj=V=SljU>QR<YtbUwpQ+@vL?uI{$gmcZ
+zYC3@UzzpYKLZewwpeTE~#NkBl55_$s{)OK@ziuA6Ps5h_w}$OMst5l!aNPioCjY)3
+z3|9SgY>L>vNO(!n4mcd3O27bHYZD!a0kI)6b4hzzL9)l-OqWn)a~{VP;=Uo|D~?AY
+z#8grAAASNOkFMbRDdlqVUfB;GIS-B-_YXNlT_8~a|LvRMVXf!<^uy;)d$^OR(u)!)
+zHHH=FqJF-*BXif9uP~`SXlt0pYx|W&7jQnCbjy|8b-i>NWb@!6bx;1L&$v&+!%9BZ
+z0nN-l`&}xvv|wwxmC-ZmoFT_B#BzgQZxtm|4N<cR35n#bARS74OQDTms<32~v8v=`
+z7-caF<C)1AG)W4zO)YE8SJ$Y@<CJ4$G=}`=!37S-py?UnU1Gh2h2n_6&p(Ao5Qqf6
+z=k(-OuAx!R!Y>+|;+(YW&Jtj^g!)iqPG++Z%x0LmqnF875%Ry&2QcCamx!T@FgE@H
+zN39P6e#I5y6Yl&K4eUP{^biV`u9{&CiCG#U6xgGR<Po=AznL^)f6o>Qr)zew;Z%x+
+z-gC>y%gvx<e=sLpgCWdgi6XpJK8=uXJkkm8YE@{r>|dM=OrO`N@P+h2klPtb<Ry(x
+zpu?Xm?4btAWLp$6D_`$o&fb}lDqgV$`64jZuZt*NMiKvp57y55K7Ikao<AXqBElPW
+zh~1j8oF$DxMm1(>YvjS!mNnk4yE0+I&YrSRi?F^plh}hIp_+OKd#o7ID;b;%*c0ES
+z!J))9D&YufGIvNVwT|qsGWiZAwFODugFQ$VsNS%gMi8OJ#i${a4!E3<-4Jj<9SdSY
+z<OXh$_?#e&cT#EB-U!=XwtowFV|9Uhv$sUK3q>&xe|D0V1c`dZv+$8>(}RE|zL{E3
+z-$5Anhp#7}oO(xm#}tF+W=K<zEDOn&&TBZukL{eI>E*3(xxKxhBt-uuJP}`_K#0A<
+zE%rhMg?=b$ot^i@BhE3&)bNBpt1V*O`g?8hhcsV-n#=|9wGCOYt8`^#T&H7{U`yt2
+z{l9Xl5CVsE=`)w4A^%PbIR6uG_5Ww9k`=q<@t9Bu662;o{8PTj<F}p=3(;yTV~Qyf
+zgQDdrLzMjDw7>DBzzbY#tL;$wrpjONqZ{^Ds4oanFm~uyPm#y1Ll3(H57YDWk9TlC
+zq;kebC!e=`FU&q2ojmz~GeLxaJHfs0#F%c(i+~gg$#$XOHIi@<TM;Hv2aC}$s8#Sv
+z+Dd3KT+?=#!iTV?Ms~47n*H>1mA72g2pFEdZSvp}m0zgQb5u2?tSRp#oo!bp`FP}<
+zaK4iuMpH+Jg{bb7n9N6e<k8B#=)v)d%-lnDQKtnG^2KYKtU2;<n>R*NZfgL7QiLxI
+zk6{uKr>xxJ42sR%bJ%m8QgrL|fzo9@?9eQiMW8O`j3teoO_R8cXPe_XiLnlYkE3U4
+zN!^F)Z4ZWcA8gekEPLtFqX-Q~)te`LZnJK_pgdKs)<s7#%|5P$s1t)kN+!Um>Dp50
+zdUq)JjlJeELskKg^6KY!sIou-HUnSFRsqG^lsHuRs`Z{f(Ti9eyd3cwu*Kxp?Ws7l
+z3cN>hGPXTnQK@qBgqz(n*qdJ2wbafELi?b90fK~+#XIkFGU4+Hihn<y_>Wq;{{)1J
+zv*Txl@GlnIMOjzjA1z%g?GsB2(6Zb-8fooT*8b0KF2CdsIw}~Hir$d3TdVHRx1m3c
+z4C3#h@1Xi@{t4zge-#B6jo*ChO%s-R%+9%-E|y<*4;L>$766RiygaLR?X%izyqMXA
+zb|<FVRVPIkP%(S)yIvuu+5z_83buf`qe#ezb);jn)u$oPrWvD(s&~KHbqKNL%cobC
+zN-|C-DK*$CAI~b2Ac6>N=Z-0PSFeH;W6aQ3(5VZWVC>5Ibgi&cj*c%_3=o#VyUJv*
+zM&bjyFOzlaFq;ZW(q?|yyi|_zS%oIuH^T*MZ6NNXBj;&yM3eQ7!CqXY?`7+*+GN47
+zNR#%*ZH<^x{(0@hS8l{seisY~IE*<IWx!UK-u2j(e2O!c*%v`vbRdmnwY3~F@WfqY
+z%qQlFf<s6fB4WlqklvTVl*JK;YI>)BD+R6^OJX}<2HRzo^fC$n>#yTOAZbk<pxtmH
+zJ~q1kaL=GoN56akk-6RD`q2mzV0mH8>4%=Bei=<kddu{Z(hj1<vW)@wW7M&+@6=2s
+zZD&Op_jWe#TTdH<JbSg3bLF85E$EBmVzcroiC)+RvF8h>JEe=o$jm`or0YDw*G?d>
+z=i$eEL7^}_?UI^9$;1Tn9b>$KOM@NAnvWrcru)r`?LodV%lz55O3y(%FqN;cKgj7t
+zlJ7BmLTQ*NDX#uel<G9Op(1@^PULS#3C#Zq5&eylEB%v#D2Qdisi+`5Pk=N?QpqNe
+zn3Q0BprVD+s9yvAi-Ka>GbCY>k+&H*iSK?x-{w;f5G%%!^e4QT9z<_0vHbXW^MLR}
+zeC*jezrU|{*_F`I0mi)9=sUj^G03i@MjXx@ePv@(Udt2CCXVOJhRh4yp~fpn>ssHZ
+z?k(C>2uOMWKW5FVsBo#Nk!oqYbL`?#i~#!{3w^qmCto05uS|hKkT+iPrC-}hU_nbL
+zO622#mJupB21nChpime}&M1+whF2XM?prT-Vv)|EjWYK(yGYwJLRRMCkx;nMSpu?0
+zNwa*<?h%^Uxlo#rhlXX^1ry~0-r)@+JQ4MlP_WRi_c8}Pe;l(#WnThfspZ$^3+`@%
+zmW}tS#o_f`H(V@)Qt__Qwx4kv+ooP8ZrPBV-j<==nbQ*DT}dlBw*|*N7vHSJyQH}0
+zm|S-J1_lheA!DE{g6^Xv;AA#SxCooopboet4w*f2U~sm_9-x1=xp|LI-xxj9006QY
+z1mgxK<wER;C#1B$%?%3n>{0n+Yg6=SR3-S&;<?krxZxGO!Tw^S=d_=26`yQ0@waRw
+z@SmVU&DQEaY5x6V*rbHQm)eLi0+(WkiJ>vq=-lRqN`s9~#)OOaIcy3GZ&~l4g@2h|
+zThAN#=dh{3U<aA#cPR4&ofsaO#bX_do9RRvi_^pV^V=?kpT`)pH$SJl(tC+UO9KU%
+zw*Fj&O-G3~P~VA<unl1F2&AK=52kP@qipFV?Oj1#&{KUN^>N7Xil;nb8@%)wx5t!l
+z0RSe_yJQ+_y#qEYy$B)m2yDlul^|m9V2Ia$1CKi6Q19~GTbzqk*{y4;ew=_B4V8zw
+zScDH&QedBl&M*-S+bH}@IZUSkUfleyM45G>CnYY{hx8J9q}ME?Iv%XK`#DJRNmAYt
+zk2uY?A*uyBA<BiMLU_*M#NCCxjGD{)FKf5%TR%^0(tj%ZEC|pB`lh!G8#P^_7rgl6
+zHD8H9#lPg#uyjB59dckNv=l!fBEB{M6vF+Eh;w^K5=@MUOHXMhDuV2p%rP)^5%vfh
+zn^LIqAcivg*z)=%xYv);q@8+WaMY5huI1GOD-9N$`j-dE7hH0tcwmf1#`ceO!mOHP
+zCyw-!`T<sF+;H*u*8-P5M#r^Q!nW)d+HW6<4*Bj<y{xwPJ5aVv2w6&T;_`2#jdBoY
+zJBy`lJrSwb+PH8(hrh;>=nlYjkcNPMGi*552=*Q>%l?gDK_XYh<zL<ke_eZ$ot|PF
+zZVgv}4Sq{EZ4ogcRofdp&JliroypZ_e}$4iKs?X|D!2Ac$5!nj(ZskdL0_wd=BN37
+zZG}#$eUO#D_A!-?os3(Syu!QKCTTw$pZe08wZZN8KnynfmowC;MZ_o?kig}nxLgNw
+zM?*Zz05oY7v>*Rya_c)ve{=ps`QYE0n!n!)_$TrGi_}J|>1v}(VE7I~aP-wns#?>Y
+zu+O7`5kq32zM4mAQpJ50vJsUDT_^s&^k-llQMy9!@wRnxw@~kXV6{;z_wLu3i=F3m
+z&eVsJmuauY)8(<=pNUM5!!fQ4uA6hBkJoElL1asWNkYE#qaP?a+biwWw~vB48PRS7
+zY;DSHvgbIB$)!uJU)xA!yLE*kP0owzYo`v@wfdux#~f!dv#u<u)VAl7h<(Ox?_8|-
+zieXQ0tIl#N(#Ubvm=#=RRW-l$qV+J9qkYE;+MW4sd~tDdcA{`>Nc_$SF@Qq9#3q5R
+zfuQnPPN_(z;#X#nRHTV>TWL_Q%}5N-a=PhkQ^GL+$=QYfoDr2JO-zo#j;mCsZVUQ)
+zJ96e^OqdLW6b-T@CW@eQg)EgIS9*k`xr$1yDa1NWqQ|gF^2pn#dP}3NjfRYx$pTrb
+zwGrf8=bQAjXx*8?du*?rlH2x~^pXjiEmj^XwQo{<CPx+@82|8@X@<D@6UUi%p$ehj
+zhXQlcfF2phkkCDxVFxfI?!~Bx<^Y(i{JB%4bav+Pbd2%<Y>`NMonBN=Q@Y21!H)D(
+zA~%|VhiTjaRQ%|#Q9d*K4j~JDXOa4wmHb0L)hn*;Eq#*GI}@#ux4}bt+olS(M4$>c
+z=v8x74V_5~xH$sP+LZCTrMxi)VC%(Dg!2)KvW|Wwj@pwmH6%8zd*x0rUUe$e(Z%AW
+z@Q{4LL9#(A-9QaY2*+q8Yq2P`pbk3!V3mJkh3uH~uN)+p?67d(r|Vo0CebgR#u}i?
+zBxa^w%U|7QytN%L9bKaeYhwdg7(z=AoMeP0)M3XZA)NnyqL%D_x-(jXp&tp*`%Qsx
+z6}=lGr;^m1<{;e=QQZ!FNxvLcvJVGPkJ63at5%*`W?46!6|5FHYV0qhizSMT>Zoe8
+zsJ48kb2@=*txGRe;?~KhZgr-ZZ&c0rNV7eK+h$I-UvQ=552@psVrvj#Ys@EU4p8`3
+zsNqJu-o=#@9N!Pq`}<=|((u)>^r0k^*%r<{YTMm+mOPL>EoSREuQc-e2~C#ZQ&Xve
+zZ}OUzmE4{N-7cqhJiUoO_V#(nHX11fdfVZJT>|6CJGX5RQ+Ng$Nq9xs-C86-)~`>p
+zW--X53<fjk))~(Y7xt;2-3Mp_sh^OGttxT8JXcE>J`O~vS{WWjsAuGq{K#8f#2iz`
+zzSSNIf6;?5sXrHig%X(}0q^Y=eYwvh{TWK-fT>($8Ex>!vo_oGFw#ncr{<A-F%$p&
+zc|DGKq;$_R8E0EodRv?$JW^Po<Ex>vmERi^m7lRi%8Imph})ZopLoIWt*eFWSPuBK
+zu>;Pu2B#+e_W|IZ0_Q9E9(s@0>C*1ft`V{*UWz^K<0Ispxi@4umgGXW!j%7n+NC~*
+zBDhZ~k6sS44(G}<L8r7U{uvHTXWzD_JuHzxZ-XY|N?p*qndC=U0c*Cl@BtNW7i{&R
+z-Me?NHPa(a(vIZUFSMee2{hPx14nk+e_C|^?Bd;r8#<I5LFO<RoqQ`w{VLAmJAmJ-
+zf-f}_R{!XhIih6nYvLOxM^4vM+l^NaQ|ty{<XIb6;HnNe&IB3k;~%;YB%OMx`D8+)
+z&)Zf1-i7=>*zg||X#9Weto;u*Ty;fP!+v*7be%cYG|yEOBomch#m8Np!Sw`L)q+T`
+zmrTMf2^}7j=RPwgpO9@eXfb{Q>GW#{X=+xt`AwTl!=TgYm)aS2x5*`FSUaaP_I{Xi
+zA#irF%G33Bw>t?^1YqX%czv|JF0+@Pzi%!KJ?z!u$A`Catug*tYPO`_Zho5iip0@!
+z;`rR0-|Ao!YUO3yaujlSQ+j-@*{m9dHLtve!sY1Xq_T2L3&=8N;n!!Eb8P0Z^p4PL
+zQDdZ?An2uzbIakOpC|d@=xEA}v-srucnX3Ym{~I#Ghl~JZU(a~Ppo9Gy1oZH&Wh%y
+zI=KH_s!Lm%lAY&`_KGm*Ht)j*C{-t}Nn71drvS!o|I|g>ZKjE3&Mq0TCs6}W;p>%M
+zQ(e!h*U~b;rsZ1OPigud>ej=&hRzs@b>>sq6@Yjhnw?M26YLnDH_Wt#*7S$-BtL08
+zVyIKBm$}^vp?ILpIJ<dp3ooa+cndqkSQ3UA!R3}}yC4bxfeA6S8LO9hE~vx|Yi68@
+zNr?jvc2@*eXxky?<YJ*9EIA;CdIbdqd2SQpx9uQtXD#8(J3Vt<5%NQ*o02|K+6bY0
+z;sT8vn@o8e%0|hi^#v|34DqvO58NzmQDAp!LXk*AcbC{I;vTjGcE|?=;e?ESe2XV{
+zRUgP)(rNkqS#Yhf8ziDbO6ep!K;GEwl%7iVkc_KR&%z8}O~7*V=?=DsoCZuiU?(w*
+zHV&rJy*1isBFt8he4l73U>etMkW1VtIc&7P3z0M|{y5gA!Yi5x4}UNz5C0Wdh02!h
+zNS>923}vrkzl07CX`hi)nj-B?#n?B<Q|A1|76WLZEE&m-hhR<X$5TK&X`9{ZnvFM%
+zu_h)S<XvC@S;kBiJJBt>J2Vk0zOGsF<~{Fo7OMCN_85daxhk*pO}x_8;<dX=<+?Qg
+z#r>-h>}pcw26V6CqR-=x2vRL?GB#y%tYqi;J}kvxaz}*iFO6YO0ha6!fHU9#UI2Nv
+z_(`F#QU1B+P;E!t#Lb)^KaQYYSewj4L!_w$RH%@IL-M($?DV<J?Z?(&T(jN~E*h4k
+zjT$bEE;1X$dKstuB%kL?N}i|18#(T<X%h{nQolXBTKBIbWb9u%<<*n%KAruYiv41M
+z(BV$!uq)MDNOGLcUNoFp1O|t~h!*SC05{|sLBD8s0{dGDvJFAn@fT!9#{nXqzUzhA
+ze1Wde$2)jpHttd7Vt%dJc<P1PQ_QtXhR)w~A<pGWwkJB}X>@lGj%3ZgVdHe^q>n(x
+zyd5PDpGbvR-&p*eU9$#e5#g3-W_Z@loCSz}f~{94>k6VRG`e5lI=SE0AJ7Z_+=nnE
+zTuHEW)W|a8{fJS>2<PuTj25j+DhXW(hd~r?Xh^MxKJCimxGsmwzKdi%?KCIX3{&)m
+zZ0nj+u3m}byL|gc@7el5sG0YZn703R7lHPF8j}A(O#keT{0lwVD2_|_3ZlF(l>TaX
+zuRoa=LCP~kP)kx4L+OqTjtJOtXiF=y;*eUFgCn^Y@`gtyp?n14PvWF=zhNGGsM{R-
+z^DsGx<p*94-ySu{F;3A%Gw(MuWcO5hc=1Fn6S6X-V`dR&jLKv;9Ov9;sNX7hCxxgJ
+z&)GGfI53?p5EUqj1kN{nL`cLj*Ny6Bb93QS#TWv+m?{)VTv#I?UM_EBDq&18Y1rBF
+zqj?j71ovsu1jc{FMqN`ZbtUe%y6G-sBQrAwb$+jv1%VjW_k<x<OD8=u&hN{;<-bn?
+z@rS2|Sdn<vp_N-gJ^Y{ISs}UnqwiH29Bq1>toDtx+g^hZi@E2Y(msb-hm{d<UuZ5B
+zF*RQXF90n8n5t!zMgUN!64)`l%MNqK%g0zqOLUu+a4FnHHt`Hf2k1Gsi_Mzb@Z^^=
+zxAOB&;5(e``nO6J%C~>WiHdoQvdX88EdM<JUQYg{sbyjNxshlKux2o|_*{in1UQ?k
+zIs#lx9Gw8xBIYJWRwj=B5<C|bZKqjrjCXeSc*C*6yaFuS2rWqx!(UR;j8e_%Q^I^0
+zj8p#CwJD3Wf>>^DS#f}&kCGpPFDu*KjEpv$FZtLpeT>@)mf|z#ZWEsueeW~hF78Hu
+zfY9a+Gp?<)s{Poh_qdcSATV2oZJo$OH<l8JXo;z<PcbGCYR0J9l8&nxRHHiz--^d2
+z8~J{Itr^Z$OtgTuQ6<JD;bmdLugNLaS^G}k$rEM-rW(6=U_mp(C><Q9gp1ZnUy!F0
+zwAdk5rFR<Ua`+2&K+(bk94CxMi5A;34dG4kTAucma$dNI_rA^e+RlExjm~4DcUPQV
+zUJ~3S<PG_W`@twX<bCoilw=BO0H-v<O^nbfi=xlVu&Cv1VWy=dd07F7ytH8mMU5a{
+zu#nKXVN5wbwo#QA!H4;0Ko9C5V@W}ba=cKzOSE;+-oDrv!(>~K@QzE2kCADZ@xX(;
+z)0i=kcAi%nvlsYagvUp(z0>3`39iKG9WBDu3z)h38p|hLGdD+Khk394PF3qkX!02H
+z#rNE`T~P9vwNQ_pNe0toMCRCBHuJUmNUl)KFn6Gu2je+p>{<9^oZ4Gfb!)rLZ3CR3
+z-<Jj6ofd&sk<LvELH)*PRT^`1cMjr9jc63Nl_{PuyZKn7*LCLu65p@97#0uR(E?9W
+zX`bZ}=9-Z$>o&b;Bh>51JOt=)$-9+Z!P}c@cKev_4F1ZZGs$I(A{*PoK!6j@ZJrAt
+zv2LxN#p1z2_0Ox|Q8PVblp9N${kXkpsNVa^tNWhof)8x8&VxywcJz#7&P&d8vvxn`
+zt75mu>yV=Dl#SuiV!^1BPh5R)`}k@Nr2+s8VGp?%Le>+fa{3&(XYi<NKc?C)>~{k{
+z-u4#CgYIdhp~GxLC+_wT%I*)tm4=w;ErgmAt<5i6c~)7JD2olIaK<AIVJAZuKkE<l
+z4Bm0%W2+6b=&ak;y7abRJFYhw&)H;bM_b*mAs4cDPr8CDbB=hVJk3YURR<;YVVe}i
+zH4VPi#sF`j{_5B)vN4u|e)jM(|JKI}{da==@2O^OXJqx+GG_R^W?=2&Wa0X`P-$%<
+zWMpLG<Rk~M1(^Mh#54JvEUXHm_-Lca3M)$jz5TrWVT^)HDZzq*6uqcRSEO&-H)J!v
+zox0RpNqqerD+o-nP(VP(;6Ij>8by{u-!tZWT#RQddptXRfEZxmfpt|@bs<*uh?Y_<
+zD>W09Iy4iM@@80&!e^~gj!N`3lZwosC!!ydvJtc0nH==K)v#ta_I}4Tar|;TLb|+)
+zSF(;=?$Z0?ZFdG6>Qz)6oPM}y1&zx_Mf`A&chb<i`Nr1_JKCJ^T_*s={KuqB@lhf>
+znSERvt9%wdPDBIU(07X+CY74u`J{@SSgesGy~)!Mqr#yV6$=w-dO;C`JDmv=YciTH
+zvcrN1kVvq|(3O)NNdth>X?ftc`W2X|FGnWV%s})+uV*bw>aoJ#0|$pIqK6K0Lw!@-
+z3pkPbzd`ljS=H2Bt0NYe)u+%kU%DWwWa>^vKo=lzDZHr>ruL5Ky&#q7davj-_$C6J
+z>V8D-XJ}0cL$8}Xud{T_{19#W5y}D9HT~$&YY-@=Th219U+#nT{tu=d|B)3K`pL53
+zf7`I*|L@^<akj8#_&*rXa0J-fn>dPEIDJkI3_oA9vsH7n7O}Ja<law4{uj~>R{G~8
+zfi$?kmKvu20(l`dV7=0S43VwVKvtF!7njv1Q{Ju#ysj=|dASq&iTE8ZTbd-iiu|2&
+zmll%Ee1|M?n9pf~?_tdQ<7%JA53!ulo1b^h#s|Su2S4r{TH7BRB3iIOiX5|vc^;5(
+zKfE1+ah18YA9o1EPT(AhBtve5(%GMbspXV)|1wf5VdvzeYt8GVGt0e*3|ELBhwRaO
+zE<IB-Cn|oj1SDl{xp8zad#YcCdtrs+9}i$s<*@)jbR<MzYyAq(U%KqfE2&l%Q`Tlq
+zFFOj{{w{t{I93tgk%#X+S#qY@HW9M}>|yMhl;Bm?8Ju3-;D<d0gaE$FN@5itD4g&V
+zgQbZVdU+i-wHuALtd^lmCPv@8>NnxM3Roelg`^!S%e({t)jvYtJCKPqN`LmMg^V&S
+z$9OIFLF$%Py~{l?#ReyMzpWixvm(n(Y^Am*#>atEZ8#YD&?>NUU=zLxOdSh0m6mL?
+z_twklB0SjM!3+7U^>-vV=KyQZI-6<(EZiwmNBzGy;Sjc#hQk%D;ba<AuKL_OVlNJ8
+zzJ~Op&$U`bGuaaEPGBR);C}uHL4psgioidnP6KL62R)y#$^To}F#LDexcw6-48nGH
+z&YxHT*vkPdY(F<p{z3^E)4$-vMrqU*T?nO|IF@Z74ohmQ)xMgvN&|_c7OfAIO#XAt
+zaL2E?e(>y$v#zczt%mFCHL*817X4R;E$~N5(N$1Tv{VZh7d4mhu?HgkE>O+^-C*R@
+zR0ima8PsEV*WFvz`NaB+lhX3&LUZcW<oTbF57ud5qxRCovnmT%0KJe~XJK}Gj*7_g
+z0&W(W*y&*@eIfyjN}|^Vg@Xk+l%k}&LK6+_!9US75W3aKwKA7N7eaP%(H`-gc7jx_
+zq4R52zNWM^&eZyQ!NoQEuNB3ura1z?O0n};Cx@E>WJJrG7ZjQrOWD%_jxv=)`cbCk
+zMgelcftZ%1-p9u!I-Zf_LLz{hcn5NRbxkWby@sj2XmYfAV?iw^0?hM<$&ZDctdC`;
+zsL|C-7d;w$z2Gt0@hsltNlytoPnK&$>ksr(=>!7}Vk#;)Hp)LuA7(2(Hh(y3LcxRY
+zim!`~j6`~<bW*$8$<<~?JS18Peo3DUOk=IRLX_ufFFmtupg*V26|}Y8;Di!sKr{px
+zU!wn|6erEM{4t*~C;Z!(|BF)mSIk8}_js-C0LEmZCZ+%vYv=#^U(wOd%<)qwWIx%%
+z#P)x%MYM{N-K;vs`}xdVg@cSV9;IsBd_FC#oCthSxj&+MND|t@FCnpb@*2FC0f*D2
+z?G^cWl=jPk-fVXO^6GAO{DQL0%m8{~;|J@R4tRbB$asqPCv~(P@*H}1{&>B+sRBv4
+z<mz=pCM?&uNVBoEf!$<Jl`Auv$WWg;Z6o}=Da&vNrmd(0r*Nq_WttlLt&FC;g7G}~
+zz%kSd_><#B{@38kH;sLB4eH2+8IPWklhd25r5j2VR}YK$lpZ%7eVF5CBr#~=kUp`i
+zlb+>Z%i%BJH}5dmfg1>h7U5Q(-F{1d=aHDbMv9TugohX5lq#szPAvPE|HaokMQIi_
+zTcTNsO53(oX=hg2w!XA&+qP}nwr$(C)pgG8emS@Mf7m0&*kiA!wPLS`88c=aD$niJ
+zp?3j%NI^uy|5*MzF`k4hFbsyQZ@wu!*IY+U&&9PwumdmyfL(S0#!2RFfmtzD3m9V7
+zsNOw9RQofl-XBfKBF^~~{oUVouka#r3EqRf=SnleD=r1Hm@<buigJ1Zgh}+47#N}=
+zA;FL!#2C23SP8!!apVBYzJ3fxxO$`OHLK}}G5fYfk`4&0f}B0=8mk!Hn*#TLB6~0w
+zVDX$-aLCK?dMa|C-1DpnLg1Y;dn>~`y8U7R)w16fgHvK-6?-TFth)f3WlklbZh+}0
+zx*}7oDF4U^1tX4^$qd%987I}g;+o0*$Gsd=J>~Uae~XY6UtbdF)J8TzJXoSrqHVC)
+zJ@pMgE#;zmuz?N2MIC+{&)tx=<l|D;tZlZQyALE=2ji-YLMO_Re>7A%$yq-{GAzyz
+zLzZLf=%2Jqy8wGHD;>^x57VG)sDZxU+EMfe0L{@1DtxrFOp)=zKY1i%HUf~Dro#8}
+zUw_Mj10K7iDsX}+fThqhb@&GI7PwONx!5z;`yLmB_92z0sBd#HiqTzDvAsTdx+%W{
+z2YL#U=9r!@3pNXMp_nvximh+@HV3psUaVa-lOB<kAlb5{e|+s3GRS<WGPVcKv}ufw
+zsm@L)j21fBT_PZS23MbS<jhcW_7ZmN8)9;FrTXBPApWUlG*$QXnli9;L`ce(&0uB<
+zK<7{*B6<8;LFx#98e~1Ipcz1=a?doj&-~;#cS-Pk$4@XT{MS|f&qHIFc^#?##d3%L
+zF_vTgzyFp0k4KXHb4gb>ekVuMf1RUd26~P*|MLouQrb}XM-bEw(UgQxMI6M&l3Nha
+z{MBcV=tl(b_4}oFdAo}<FNiIc;2!TENsPY_{u&vbEN_gH<2W2+zqz;HID|PS7~k-+
+z?orh+BjNq^{SNz=&lq$2>WX$~$Mj-z70FowdoB{TN|h<oa=NkAgwvViq7Zbbs20=(
+zjFf3J3IkKmvhA(1BFfTs0<}wn4tMNcYw*#d5+3#m^D7`Q>2BdYs?$imcj{IQpEf9q
+z)rzpttc0?iwop<FB}NoH|4vN8(!wS{7iPRZAtgAKfwm99$&fQSncFCAHTtkEGq%pm
+zWTY7<`y7xseX%vxnS$7Cg0<;j2&4>SmEoB&V!1aoZqEWEeO-MKMx(4iK7&Fhc(94c
+zdy}SOnSCOHX+A8q@i>gB@mQ~Anv|yiUsW!bO9hb&5JqTfDit9X6xDEz*mQEiNu$ay
+zwqkTV%WLat|Ar+xCOfYs0UQNM`sdsnn*zJr>5T=qOU4#Z(d90!IL76DaHIZeWKyE1
+zqwN%9+~lPf2d7)vN2*Q?En?DEPcM+GQwvA<#;X3v=fqsxmjYtLJpc3)A8~*g(KqFx
+zZEnqqruFDnEagXUM>TC7ngwKMjc2Gx%#Ll#=N4qkOuK|;>4%=0Xl7k`E69@QJ-*Vq
+zk9p5!+Ek#bjuPa<@Xv7ku4uiWo|_wy)6tIr`aO!)h>m5zaMS-@{HGIXJ0UilA7*I}
+z?|NZ!Tp8@o<g6{t!6GGpEZ3+xJO<~FK>-lnyde*H+@8IHME8VTQOGh96&XX3E+}OB
+zA>VLAGW+urF&J{H{9Gj3&u+Gyn?JAVW84_XBeGs1;mm?2SQm9^!3UE@(_FiMwgkJI
+zZ*caE={wMm`7>9R?z3Ewg!{PdFDrbzCmz=RF<@(yQJ<VyM+ly^hkKwrU?N(EcGTG)
+zusbNv5i$F3@Zf=?+&aeDOWDQ7$Qe9+B5{<3u0W4YeBR!LFJjuu&@SMl|F6jRfqiyz
+z{O`I${Euua!vE}0|0A#|Qib%yQO5k~F=XS~vL;+>_A6?PCd_MdUf5vv6G#9Mf)i#G
+z($OxDT~8RNZ>1R-vw|nN699a}MQN4gJE_9gA-0%>a?Q<9;f3ymgoi$O<?iymZH(Er
+zNGvX8A0}*i-nw7954=`Bwhd<ZUjO(yu}|0@?)GI5gP?*)IHp?Eg%^jP>I!=aE6Elw
+z2I`l!qe-1J$T$X&x9Zz#;3!P$I);jdOgYY1nqny-k=4|Q4F!mkqACSN`blRji>z1`
+zc8M57`~1lgL+Ha%@V9_G($HFBXH%k;Swyr>EsQvg%6rNi){Tr&+NAMga2;@85531V
+z_h+h{jdB&-l+%aY{$oy2hQfx`d{&?#psJ78iXrhrO)McOFt-o80(W^LKM{Zw93O}m
+z;}G!51qE?hi=Gk2VRUL2kYOBRuAzktql%_KYF4>944&lJKfbr+uo@)hklCHkC=i)E
+zE*%WbWr@9zoNjumq|kT<9Hm*%&ahcQ)|TCjp@uymEU!&mqqgS;d|v)QlBsE0Jw|+^
+zFi9xty2hOk?rlGYT3)Q7i4k65@$RJ-d<38o<`}3KsOR}t8sAShiVWevR8z^Si4>dS
+z)$&ILfZ9?H#H&l<RT2S~_Jj4$4(IRHJFV0?A!G0Qhg^SAVSGNU@RS<f${jo1F-$bS
+zyW`W1oDY=>umngpj7`|rKQQ`|tmMmFR+y-9PP`;-425w+#PRKKnx7o-Rw8;}*Ctyw
+zKh~1oJ5+0hNZ79!1fb(t7IqD8*O1I_hM;o*V~vd_LKqu7c_thyLalEF8Y3oAV=ODv
+z$F_m(Z>ucO(@?+g_vZ`S9+=~Msu6W-V5I-V6h7->50nQ@+TELlpl{SIfYYNvS6T6D
+z`9cq=at#zEZUmTfTiM3*vUamr!OB~g$#?9$&QiwDMbSaEmciWf3O2E<mlP_PonDwt
+zyitcRzTVrxyJMiqOZ6|7#G@nv5X=6&i;>8?oE0ApScg38hb&iN%K+kvRt#d))-tr^
+zD+%!d`<L4%gYWIkY!vD!A?&@isi9mjq}hc5uLusOi**W156CB;6jndj83!M&a=e4K
+zV{K2_%pB}vEiuAw60U0jUrMlCDCQLmYx75m`l(uEE8=2*7U?XVZesIds6ZgImrC6J
+zaSGNgykYte(u*RGC_Cdgw_=To1Sk<7c@waaCe^q4t!2!@1+<vcCZJJd`WP{XR`nxw
+zGu<m<ZH}qgdl57!HcrTLPnp>i!OOE3in0Q_HzNXE!JcZ<0;cu6P_@;_TIyMZ@Wv!J
+z)HSXAYKE%-oBk`Ye@W3S<fT|RJJ2x9j}N_gm*>hYu-bfC<JlS4ISeU0#72JEq&iV@
+z);;bzD{y$YwCJZhLJpC1#?j@p;n13~AR-U_7}H;)tO$ka&g;YU0hclMs2jggs@V)}
+z1ctUKqL*50yB=^24iD^`6e#NM3t6q_UJr0(0eheaY{0bzc8rmE8>AZ}1|J16hFnLy
+z?Bmg2_kLhlZ*?`5R8(1%Y?{O?xT)IMv{-)VWa9#<mvE`6Fsm;~;S~jwikf)Rjguu$
+z5vQddW;F{QVK_+$;)+G^5Vmb(r-Npc&G#KXM)uo^^@C#o|I{V8-x8LCrE4E&Qq(N-
+zMS66xhsVfaLJl|yc8xV__In+|p9mrG(%HWN_C^hqh)+P9$S6+nJmaAfIxP%v9WfYQ
+zL5;Uu-6T=cz->1pKH|oVRm4!lLmls=u}Lxs44@g^Zwa0Z_h>Rk<(_mHN47=Id4oba
+zQ-=qXGz^cNX(b*=NT0<^23+hpS&#OXzzVO@$Z2)D`@oS=#(s+eQ@+FSQcpXD@9npp
+zlxNC&q-PFU6|!;RiM`?o&Sj&)<4xG3#ozRyQxcW4=EE;E)wcZ&zUG*5elg;{9!j}I
+z9slay#_bb<)N!IKO16`n3^@w=Y%duKA-{8q``*!w9SW|SRbxcNl50{k&CsV@b`5Xg
+zWGZ1lX)zs_M65Yt&lO%mG0^IFxzE_CL_6$rDFc&#xX5EXEKbV8E2FOAt>Ka@e0aHQ
+zMBf>J$FLrCGL@$VgPKSbRkkqo>sOXmU!Yx+Dp7E3SRfT`v~!mjU3qj-*!!YjgI*^)
+z+*05x78FVnVwSGKr^A|FW*0B|HYgc{c;e3Ld}z4rMI7hVBKaiJRL_e$<k+t<^`D)J
+zEhcFT+>rxDW^8!nGLdJ<7ex9dFoyj|EkODflJ#Xl`j&bTO<I#P8edX2Zurtkc%j^@
+zNt6$0k5j7Tz*Hvqfi_&6#Q9+R)Fv6`GmW+`8bq@}anEonN&wkBMSbC3p65Q!BQJn9
+z($6ofVPsfai#?XWp7#{34OEeYG<ZeV`;e33{@dz|B}sgh&`J@Iq}UpnS6~gr0^_2`
+z<OPZ;lTV0rmf6o448!Uqt;aNgDOUMFk-WHp5yxc_@Pw(=_HnwV*fc`$ZOS^5Tv^Xj
+zs6|mx8FjhE6;^Q`ZD8?b*C=D)QP^dT)L|ZTke)O$7uVN>%=$v)c+gJsLK_%H3}A_}
+z6%rfG?a7+k7Bl(HW;wQ7BwY=YFMSR3J43?!;#~E&)-RV_L!|S%XEPYl&#`s!LcF>l
+zn&K8eemu&CJp2hOHJKaYU#hxEutr+O161ze&=j3w12)UKS%+LAwbjqR8sDoZH<g6`
+zeO;HbwrZ9reV{8OM|L-k?0OY=6?byB5<#Ri|6=ZM<cbTpfiMCe6D0+uuN~Snj^GI6
+zBGP94F2>nD<cul@`WjtmWkT9y3u`g7Ep4O>=m0(p62!zg<Af@s3vh7(o9SiY*ZKN>
+zxt!Sj65S<M*Zjht+%5QyX@dTS`ynS|*dw2j79o<R`%(HG^UA0FiEur$J4e>?6WPmm
+zL&U9c`6G}T`irf=NcOiZ!V)qhnvMNOPjVkyO2^CGJ+dKTnNAPa?!AxZEpO7yL_LkB
+zWpolpaDfSaO-&Uv=dj7`03^BT3_HJOAjn~X;wz-}03kNs@D^()_{*BD|0mII!J>5p
+z1h06PTyM#3BWzAz1FPewjtrQfvecWhkRR=^gKeFDe$rmaYAo!np6iuio3>$w?az$E
+zwGH|zy@OgvuXok}C)o1_&N6B3P7ZX&-yimXc1hAbXr!K&vclCL%hjVF$yHpK6i_Wa
+z*<Rda^MN8#r#%H(uhk!|+(Xdsw2E^5cUpnFp8p1^_KFVpjUj=6sF40s6^Zu$9=(bF
+zx1x^nKdB2b8!ICz8ygEJ+y4>CMg1RAH1(EuuA01@lA$sM<OVE;c)%cNQLi9uaS;hG
+z%fi;i)%@4^r8O+Wz2GPMFlZFnH;_-_U9)NAegHj_!}O-ZO`FT{#><S(uSx^)-K{gT
+zhG&r*35&meRW|1;vN}suvoTt-WY!oM-loV8;oR{IcSbtH!As;82qoT?HqV9V3*~qm
+z!SuufxJRefmX+!kF&rvO-e(?VCk%)$MRmimz$37siP-FuaN<K+5pNn#@=eC8%!@nb
+z2*5!qsZ<fp+A*NXf=8**@y(*g7NiBCiEV7bSE-BMr;5Zd;AV+}D!T7#a7AZhy$tZ}
+zBZj0LQc#mui!Lo2Q3KNe2agi@n?}tiW0Rj<VeQ<_*D6y|ViQ@=M%oDn5H>fe*s@9-
+z$jNWqM;a%d3?(>Hzp*MiOUM*?8eJ$=(0fYFis!YA;0m8s^Q=M0Hx4ai3eLn%CBm14
+zOb8lfI!^UAu_RkuHmKA-8gx8Z;##oCpZV{{NlNSe<<V1a7ju;v(TY8|0upX`)YP)i
+zhF9S0sKf|T)6o+<$QQ8snYX%z2pId%K2VdBjyrL|U&7n?j2gqBIlgc7sqRmR3rF|l
+zlUaMtZ*=q~vwXXK9=bFWx14^H@c)%dSINC6uKh#1>i;9!MfIN!&;JI-{|n{(A19|s
+z9oiGesEN<ynV})!iaH~auE<DSv%{<&k~X$kQz2b-qcNkA8P@0{SIU`uY<?@NmTQBx
+z)D?^>cLf@NN^9R0uIrgg(46r%kjR{0SbnjBqPq()wDJ@LC2{kUu_j$VR=l`#RdaRe
+zxx;b7bu+@I<Nh=^5@s63-0S!f#dfXn@}AC1>ntWaV$si1_nrQpo*IWGLBhhMS13qH
+zTy4NpK<-3aVc;M)5v(8JeksSAGQJ%6(PXGnQ-g^GQPh|xCop?zVXlFz>42%rbP@jg
+z)n<qUy~a=5h*jh6P7t^JBt^vIyENcV7ST}KUA-3{?3CB)-Fh4a#gMRWaLCBu<v>)%
+zM9anq5(R=uo4tq~W7wES$g|Ko<i2Il^N$GIC?!+;wqh32G+daBXSzA(l7+`)WY5H*
+zxN4$-v5B6xdBXsPjBQ?{pU&2{p1fGEo~A^$<7<6Ai9r_XJLEi2ERS5-WM=rJMwjp>
+z1iNIw@-{x@xKxSXAuTx@SEcw(%E49+JJCpT(y=d+n9PO0Gv1SmHkYbcxPgDHF}4iY
+zkXU4rkqkwVBz<{mcv~A0K|{zpX}aJcty9s(u-$je2&=1u(<Ijk*osoSbRG#RG2dxi
+zY2dIgjpsHFWw4YgUuLN}C3yiVDS7TfH_01AHBUEe$&x)yg`w@~!r_*o_*~bpU7c<5
+z`bmK&NU6Nw_v-jDi5@dldK4Fn1A<6r>e#Q~UA{gA!f;0EAaDzdQ=}x7g(9gWrWYe~
+zV98=VkHbI!5Rr;+SM;*#tOgYNlfr7;nLU~MD^jSdSpn@gYOa$TQPv+e8DyJ&>aInB
+zDk>JmjH=}<4H4N4z&QeFx><vCqo(8;VBNf?4{-ejyJD7h1Z5Qh!VF^s0~(Sx+W_U{
+zR};ybxF{rNR6jf3&Uli%SD1<DGAon!MxCaTjg2UoiPv{%y|HIy7wF&Vh+2it<&g@k
+z2+Wf#)mx-UNsAjpU<5>1VPY8GU&^1c&71T*@2#dINft%ibtY(bAm%<2YwPL?J0Mt{
+z7l7BR718o5=v|jB!<7PDBafdL>?cCdVmKC;)MCOobo5edt%RTWi<zJmle+?jwNYxN
+z4^6|EAjKcb86Lhb2TiEBh#*!<VO%f-!t(A33YL(fW`@*JF%L#%9n~L_x_&@iQ8p+r
+z50!J0d4(u}33+T-j40yL1x4WL)VTLI3<|eCyY3_SBtK8>ReAMaIU5X9h`@El0sR&Z
+z7Ed+F<Hz;iLDs#Hc0AY<Bv9{VG$$}Nxol9pHZ;R^PVSOq1+c`wf56t4>iyA+QAyWn
+zf7=%(8X<IsS*x5)IZjAvYsetv<jbdR10P8%td<*r6IM&L5LRrcOf|!8RQAgg6~$_=
+zBSd>pcS*C4^-L24TBUu%0;@s!Nzy{e95qjgkzE<W5xLBBDYXZDXN}?0z#DvAb||%H
+zZPS{|8~$Dai+w3|r0z;7J8SaSbF0|4F}$?B9(zK4Hfql>lf0#ou`sYng<}wG1M|L?
+zKl6ITA1X9mt6o@S(#R3B{uwJI8O$&<3{+A?T~t>Kapx6#QJDol6%?i-{b1aRu?&9B
+z*W@$T*o&IQ&5Kc*4LK_)MK-f&Ys^OJ9FfE?0SDbAPd(RB)Oju#S(LK<CirA2f_*u2
+zok`__!UM2k24u<34N&n2<rv2c5C+LG1_2&glf5C-MnxH;!hzUTv-tAoF?gV=0tG&*
+z&3NTXW=(G6=cQ0qDpT;#Hy7t96N4?Q={0R{&UH=JEWgy<75@6brLBmih;_W+NcLKU
+zn<HoD>)?EVandS1qb#KR;OP|86J?;TqI%E8`vszd&-kS%&~;1Als=NaLzRNnj4q=+
+zu5H#z<eB8n3vpKCZ_UBe2i$XZJvzC|oStL%r*N4lp0t3D`s9hT%+m%jPcLdrJAA8K
+z_Xy5FTlYi&>)BDKHo1EJTC?Cd_oq0qEqNAF8PwU7<g1n3gpVtS#>fK!-WwVEp4~4g
+z3SEmE3-$ddli))xY9KN$lxEIfyLzup@utHn=Q{OCoz9?>u%L^JjClW$M8OB`tx<B9
+zZzQvx^C^)R6f_#j34$T{qWzMIebqUHU#Mm4dIX;v?G*C~teYh!pha7{DB@cX4KxPS
+zH^Q;NkvbuF4d_@se8XmvFleR*sC@ep>g4r6Q-6UlVx3tR%%Z!VMb6#|BKRL`I))#g
+zij8#9gk|p&Iwv+4s+=XRDW7VQrI(+9>DikEq!_6vIX8$>poDjSYIPcju%=qluSS&j
+zI-~+ztl1f71O-B+s7Hf<J;>>AZ#}DNSf`7C7*)%(Xzf|ps6Dr7IOGSR417xsU=Rxb
+z1pgk9vv${17h7mZ{)*R{mc%R=!i}8EFV9pl8V=nXCZruBff`$cqN3tpB&R<?rJ^^G
+zLU#yZbVti(nuC|2|IXia=NN6mqd+?dR)7Jc*9;iC!a;f?+=#<s4C&g0_&NB8weC%l
+zS<iNL{)P(<k~BWt3Y%{Xrbk9d#iq+t;G9E%F%_rY<%%AD^lw^bplw!%%|-aF&{mk{
+z8v%Z~T)@9qJANVDtF7i6j_uAG%PQrIzYL<`zWN)?kg5G%9sC$@=vQ^>K^$yH!A8RL
+zJ5KltH$&5%xC7pLZD}6wjD2-uq3&XL8CM$@V9jqalF{mvZ)c4V<q)vM?$E(wfOg3Q
+zv%+110#sykOiRSt?0@;lgu4A3JD@U~_wpzdHgwI1fA5o$81_b21C0iEz!;O~RRRX1
+zGlEi0gdqWrOw3XkgEa2cwZ#ieSM+Bwx5supt!d$Nc0%<IFUjN0oH@W~IsyX(WZ$<d
+z|MaryZKLL%mzThJyCC#$>n?xXbvkB(q%<Z{kVQ;%LF$(<$dK2qdz`UK^3urTrD0B4
+z1&)CdFB?t|pWnGgd`vO!l5yW5V|rGsYb-Keu0g!I*6%Xh0JZtqeMa&LE(4Bo#scEB
+z2+Xh0IF3fHxOvz(nbw5~LC>xbSdjoXJXanVN@I;8I`)XlBX@6BjuQKD28Jrg<b?I+
+zxnRcDtmgY@D96{&H=|gt1$AWNvdJ3yEL}1j876RHewior=;z@yI+m%vO5~lw`>05}
+z^ImmK-Ux<q>*QMn_A|1ionE#AurP8Vi?x)7jG?v#YyVe_9^up@6^t_Zy^T1yKW*t*
+z&Z0+0Eo(==98ig=^`he&G<vo(#Q)G{9SIowKW2Tx<>^K$I!F~1l~gq}%o5#pR6?T+
+zLmZu&_ekx%^nys<^tC@)s$kD<AcM417>`^r8)1^tUazRkWEYPw0P)=%cqnyeFo3nW
+zyV$^0DXPKn5^Qi<LfvSpMIU#o(EG&Rpi2B@a5@RzAAQS3*j%A9U;6sg<98@jyPDmC
+zXKg0?&ACu)O$sr|d)+$ZH;RJR7V`iC489P}wQ3gU*M+C_X7Cw%nw^c(gNH_oV&C^!
+zc5Ja!U#d<n%*)0OuX(xIWS}X!VI4G5%&+mH^jQka0XK?`B*^+~@VtKToDTaE*!8R~
+z<nPU#JZXd+QYE>OtOi4MIX^#3wBPJjenU#2OIAgCHPKXv$OY=e;yf7+_vI7KcjKq%
+z?RVzC24ekYp2lEhIE^J$l&wNX0<}1Poir8PjM`m#zwk-AL0w6WvltT}*JN8WFmtP_
+z6#rK7$6S!nS!}PSFTG6AF7giGJw5%A%14ECde3x95(%>&W3zUF!8x5%*h-zk8b@Bz
+zh`7@ixoCVCZ&$$*YUJpur90Yg0X-P82>c~NMzDy7@Ed|6(#`;{)%t7#Yb>*DBiXC3
+zUFq<q;<NLVE3q+|RY;{7>(UDFjrgOsc%0KJ_L;WQKF0q!MINpQzSsqwv?#Wg+-NO;
+z84#4nk$+3C{2f#}TrRhin=Erdfs77TqBSvmxm0P?01Tn@V(}gI_ltHRzQKPyvQ2=M
+zX#i1-a(>FPaESNx+wZ6J{^m_q3i})1n~JG80c<%-Ky!ZdTs8cn{qWY%x%X^27-Or_
+z`KjiUE$OG9K4lWS16+?aak__C*)XA<mn7dO1IQ<7rt}jYvLS-$H~f<X5+N=(Ek`&&
+zUWHe^|Bwj1`@oeHlPUTz8D*6r?NpHjHK-@Dqy;NDtS}cg%!YayC0fs^iN;OYEP9kK
+zo5Vht9oQS7iDhR-OPXj9?q6@S&eFy#n-1R+kA`A0*{=#t%}!LRAXjjRywc~_uNoSv
+zszK4MM3XQ`!AP4Kj^Rx*7iMfV9^D$9ff(?N=BiGkohxx7DcQNG_tP#nT3_=hI7YLo
+zGAoH*rjQg^W(ap448geJyg*-Zsf^RAr9lW2dRNFv&HLWl7oARenT?<M#Z5`E1my@r
+zEvZ)*EFhV=Xn(d!ux{Tmfc~sd_)m;R7maZ)e8qGMx=q|X7Apwv&(Z7nX5hp;7Fa>{
+z6HmS*8#t_3dl}4;7ZZgn4|Tyy1lOEM1~6Qgl(|BgfQF{Mfjktc<V73_^4Y*JAxZ9&
+zk;vp)O|oP#qgjAs8&wb~jCgfwsBn#A5JV`I8M5Mt;ki^ey-B;1sC5O4oRWjC=0x>h
+zB5kc~4NeehRYO%)3Z!FFHhUVVcV@uEX$eft5Qn&V3g;}hScW_d)K_h5i)vxjKCxcf
+zL>XlZ^*pQNuX*R<VIWU<&k+#O#z05{>JQn)b6;blT3<7@Ap)55)aK3n-H08GIx65W
+zO9B%gE%`!fyT`)hKjm-&=on)l&!i-QH+mXQ&lbXg0d|F{Ac#U;6b$pqQcpqWSgAPo
+zmr$gOoE*0r#7J=cu1$5YZE%uylM!i3L{;GW{ae9uy)+EaV>GqW6QJ)*B2)-W`|kLL
+z)EeeBtpgm;79U_1;Ni5!c^0RbG8yZ0W98JiG~TC8rjFRjGc6Zi8BtoC);q1@8h7<W
+z{%QU=f~@E{*75;EPtq=QOC=`G(0Hdr_HmX;s)IO`uOsm?hi;HPRH2DMN!8p_6N*mR
+zXeVd+rX;e|)D{nmu3FxC){%4`fvkUoMM~{w*jYq7&hHz|64x(?E6&4jG;eJ*jSB0z
+zWIII4*kn~Ve25Pk+1h=4UMO&Fvq`3&FqVW1qQ})@8We8E6!Yt^Nic_&{<S5dR(OO{
+zb5!CWQqPU+0jYF<lXRIyMn^4F&DA<&TE_&-%x*k9PRqAjBu2+9eB|q?j^5xDz3>UV
+zFa&LRzYsq%6d!o5-yrqyjXi>jg&c8bu}{Bz9F2D(B%nnuVAz74zmBGv)PAdFXS2(A
+z=Z?uupM2f-ar0!A)C6l2o8a|+uT*~huH)<BklnFF@?8S@YKGOgvIkgvy?bVNlgCB_
+zoqeDw{3YNZ=l`nrK(ag;cr55JL-h60|J5N{s-NkNhFkQ*iwcZIFaTBfOzrkQWLJ*V
+zICw*3^B@Set{3BbuO`R#p?&bEzj(u;_I4rvE}iY2Q^FV4RYK^P{cWG=Da>!h3i!&$
+zr>76mt|lwexD(W_+5R{e@2SwR15lGxsnEy|gbS-s5?U}l*kcfQlfnQKo5=LZXizrL
+zM=0ty+$#f_qGGri-*t@LfGS?%7&LigUIU#JXvwEdJZvIgPCWFBTPT`@Re5z%%tRDO
+zkMlJCoqf2A=hkU7Ih=IxmPF~fEL90)u76nfFRQwe{m7b&Ww$pnk~$4Lx#s9|($Cvt
+ze|p{Xozhb^g1MNh-PqS_dLY|Fex4|rhM#lmzq&mhebD$5P>M<DmANA7)v1?A&u8?r
+zN#V^qY31R$$uOM7e!;99G3zfzxBI#kn<K!x%{#o+a5>$eqLoV|z=VQY<HWnoG0tOv
+z69l8*cSEJV=QU?Ns^-R%Uq*rJ%^Z2p;<g;km5p_x#;n0NJ&|94gMZ|Q>{)7&sR#tW
+zl(S1i!!Rrg7kv+V@EL51PGpm511he%MbX2-Jl+DtyYA(0gZyZQjPZP@`SAH{n&25@
+zd)emg(p2T3$A!Nmzo|%=z%AhLX)W4hsZNFhmd4<1l6?b3&Fg)G(Zh%J{Cf8Q;?_++
+zgO7O<(-)H|Es@QqUgcXNJEfC-BCB~#dhi6ADVZtL!)Mx|u7>ukD052z!QZ5UC-+rd
+zYXWNRpCmdM{&?M9OMa;OiN{Y#0+F>lBQ=W@M;OXq;-7v3niC$pM8p!agNmq7F04;|
+z@s-_98JJB&s`Pr6o$KZ=8}qO*7m6SMp7kVmmh$jfnG{r@O(auI7Z^jj!x}NTLS9>k
+zdo}&Qc2m4Ws3)5qFw#<$h=g%+QUKiYog33bE)e4*H~6tfd42q+|FT5+vmr6Y$6HGC
+zV!!q>B`1Ho|6E|D<2tYE;4`8WRfm2#AVBBn%_W)mi(~x@g;uyQV3_)~!#A6kmFy0p
+zY~#!R1%h5E{5;rehP%-#kjMLt*{g((o@0-9*8lKVu+t~CtnOxuaMgo2ssI6@kX09{
+zkn~q8Gx<6T)l}7tWYS#q0&~x|-3ho@l}qIr79qOJQcm&Kfr7H54=BQto0)vd1A_*V
+z)8b2{xa5O^u95~TS=HcJF5b9gMV%&M6uaj<DG%?NLS@ZBcw~|?Ph?A!$GyTtN#J(n
+z(N#33Z&MXkLNi3tlx}v1EUFXC!E2$+1Uui1Bx24YZRI7U{9C!4ye6`#_fxLyx><>E
+zPNM~qGjJ~xbg%QTy#(hPtfc46^nN=Y_GmPYY_hTL{q`W3NedZyRL<bGaMku?v;})8
+z39o7JEb=3hqE?4Vw{>^kgU@Q$_KMAjEzz*eip`3u6AhPDcWXzR=Io5EtZRPme>#K9
+z4lN&87i%YYjoCKN_z9YK+{fJu{yrriba#oGM|2l$ir017UH86Eoig3x+;bz32R*;n
+zt)Eyg#PhQbbGr^naCv0?H<=@+Poz)Xw*3Gn00qdSL|zGiyYKOA0CP%qk=rBAlt~hr
+zEvd3Z4nfW%g|c`_sfK$z8fWsXTQm@@eI-FpLGrW<^PIjYw)XC-xFk+M<6>MfG;WJr
+zuN}7b;p^`uc0j(73^=XJcw;|D4B(`)Flm|qEbB?>qBBv2V?`mWA?Q3yRdLkK7b}y&
+z+!3!JBI{+&`~;%Pj#n&&y+<;IQzw5SvqlbC<hrT)sBs!K|EW5H^76b8wi?&5jaqoB
+zdZ2NRMM|}GTQWlnULm3*Tw}|kY|0D0spF;??&YCTeOo~Duw_Bz&0>+V=kLZLAHOQb
+zS{{8E&JXy1p|B&$K!T*GKtSV^{|Uk;`oE*F;?@q1dX|>|KWb@|Dy*lbGV0Gx;gpA$
+z*N16`v*gQ?6Skw(f^|SL;;^ox6jf2AQ$Zl?gvEV&H|-ep*hIS@0TmGu1X1ZmEPY&f
+zKCrV{UgRAiNU*=+Uw%gjIQhTAC@67m)6(_D+N>)(^gK74F%M2NUpWpho}aq|Kxh$3
+zz#DWOmQV4L<sDJGB1~xI&#K@a<rftJ&W$tS7|})}p7LCV^RAnbsUrP_V*uhk=;!pl
+zs4zoj`KucSBFKjBcKXW*EHB;&BS$tidMG;U{H8n7wJ)AAvB2L*UBNbpb;dN7LsCrE
+zL;cL{W0B-y=uz}$?A3Z<^oG{u-AX|Svz(WP+@{ryM8&-@TzJ+nBT;gLmX|TuUS7tX
+zbu7uYkz$71L||aR32Yb{k;9>g&}`XTU41Z|P~5;wN2c?2L{a=)Xi~!m#*=22c~&AW
+zgG#yc!_p##fI&E{xQD9l#^x|9`wSyCMxXe<3^kDIkS0N>=oAz7b`@M>aT?e$IGZR;
+zS;I{gnr4cS^u$#>D(sjkh^T6_$s=*o%vNLC5+6J=HA$&0v6(Y1lm|RDn&v|^CTV{=
+zjVrg_S}WZ|k=zzp>DX08AtfT@LhW&}!rv^);ds7|mKc5^zge_Li>FTNFoA8dbk@K$
+zuuzmDQRL1leikp%m}2_`A7*7=1p2!HBlj0KjPC|W<t!gw4p)|NM)%cW9T$k`o|lfo
+zg*aR{7NSC?*?~1-ovU>T?5{_aa%}rQ+9Mqcf<RjoiaEgO6aLbf%7cdA%8(Z(Lepcg
+z;EK+)sbwoSMUuni>XI0NtjvXz1U)|H>0{6^JpHspI4MfXjV%1Tc1O!tdvd{!IpO+@
+z!nh()i-J3`AXow^MP!oVLVhVW&!CDaQxlD9b|Zsc%IzsZ@d~OfMvTFXoEQg9Nj|_L
+zI+^=(GK9!FGck+y8!KF!nzw8ZCX>?kQr=p@7EL_^;2Mlu1e7@ixfZQ#pqp<X+0Re_
+zrJ{H^$-Z@QA7ETVM2%a&#GG%~hgC@{06tyBwQZmlXSm57v9B9QX(aJLI_U;c+x!4Y
+zc@Lpfn;l;r15OkOarCAT2KT0TI&b@nuFwDm5s2$h*ySA~Ad%ZKk`|FTjsVplUIi{5
+zlFa?pIp_hLcE?CXH;$pLba~E##@hT^OvK63FoxCFx@_5ii6TR$R#n$|+i^+&#se{6
+zDr7|zkeVUxEFj8#1(pWjg_@>yCJ```(m;la2NpJNoLQR};i4E;hd+|QBL@GdQy(Cc
+zTSgZ)4O~hXj86x<7&ho5ePzDrVD`XL7{7PjjNM1|6d5>*1hFPY!E(XDMA+AS;_%E~
+z(dOs)vy29&I`5_yEw0x{8Adg%wvmoW&Q;x?5`HJFB@KtmS+o0ZFkE@f)v>YYh-z&m
+z#>ze?@JK4oE7kFRFD%MPC@x$^p{aW}*CH9Y_(oJ~St#(2)4e-b34D>VG6giMGFA83
+zpZTHM2I*c8HE}5G;?Y<M+?LyWn?03qS587BS{lq0V4R8#J8=B>7RXMA2k{Y?RxHb2
+zZFQv?!*Kr_q;jt3`{?B5Wf}_a7`roT&m1BN9{;5Vqo6JPh*gnN(gj}#=A$-F(SRJj
+zUih_ce0f%K19VL<E3HrXlqqoBf~c20@9ozE$2qZsljz1QN-PVpQS1W!)YMjSijFXX
+z{P)`?A`eAJ?oh<!djz+PC3lVbl99-ayrp8oi=_canYFfMH62C}^0hP3`X)L9+i4`Q
+zm?I7fbusV!Jv(kfxmM>Xi5(<VS*XQmy2&`ZRfWgKV9~k|yVKp~M)9<_9P`znoH<lN
+z$~@NdPe<+%!i}Jugmv9Pnb}eLR?O8Po%je^XGWy*@HH7__y8%?t*~t>VBGOFbc(YF
+zLvvOJl+W<}>_6_4O?LhD>MRGlrk;~J{S#Q;Q9F^;Cu@>EgZAH=-5fp02(VND(v#7n
+zK-`CfxEdonk!!65?3Ry(s$=|CvNV}u$5YpUf?9kZl8h@M!AMR7RG<9#=`_@qF@})d
+ztJDH>=F!5I+h!4#^DN6C$pd6^)_;0Bz7|#^edb9_qFg&eI}x{Roovml5^Yf5;=ehZ
+zGqz-x{I`J$ejkmGTFipKrUbv-+1S_Yga=)I2ZsO16_ye@!%&Op^6;#*Bm;=I^#F;?
+z27Sz-pXm4x-ykSW*3`)y4$89wy6dNOP$(@VYuPfb97XPDTY2FE{Z+{6=}LLA23mAc
+zskjZJ05>b)I7^SfVc)LnKW(&*(kP*jBnj>jtph`ZD@&30362cnQpZW8juUWcDnghc
+zy|tN1T6m?R7E8iyrL%)53`ymXX~_;#r${G`4Q(&7=m7b#jN%wdLlS0lb~r9RMdSuU
+zJ{~>>zGA5N`^QmrzaqDJ(=9y*?@HZyE!yLFONJO!8q5Up#2v>fR6CkquE$PEcvw5q
+zC8FZX!15JgSn{Gqft&>A9r0e#be^C<%<F$|nV^6m7s?pfGWrS!*h<5zg%%}lEg1TI
+z|E5UO7&eitGHgtFuU&)>)psE*nyW^e>tsc8s4Q}OIm})rOhuc{3o)g1r>Q^w5mas)
+zDlZQyjQefhl0PmH%cK05*&v{-M1QCiK=rAP%c#pdCq_StgDW}mmw$S&K6ASE=`u4+
+z5wcmtrP27nAlQCc4qazffZoFV7*l2=Va}SVJD6CgRY^=5Ul=VYLGqR7H^LHA;<kSL
+zyrh(Zd)qJDxpzjXJoFc+eRH#(kkiWb-uI_%f85g24L`FdF1fP}Kg{iZ+*Fo8ju*cl
+z3Aw1YGq0cxadL4N9aS#>H^1g}ekn=4K8SPRCT+pel*@jUXnLz+AIePjz@mUsslCN2
+z({jl?BWf&DS+FlE5Xwp%5zXC7{!C=k9oQLP5B;sLQxd`pg+B@qPRqZ6FU(k~QkQu{
+zF~5P=kLhs+D}8qqa|CQo2=cv$wkqAzBRmz_HL9(HRBj&73T@+B{(zZahlkkJ>EQmQ
+zen<iPJWnXR=;Z=9fu?|et|Rb%*gDj8sMD`ZMBMaR)@W4I!@ZJ=6-0EUr*wDEx&_hw
+zhU+|E`Yc!V0@6Vf^U<QOMIE_YSpmh%i+yFO|G~yVs99EScY@d$n{uR4Xtly{afZWj
+zO}~7A(I*J<@B|oPywvLj91a5kZfNN5H=|EF#}if+=~cl#!%<3XeHAhGPkCdLS{G`f
+z#i{^H6>p59dy+L;sSWYde!z_W+I~-+2Xnm;c;wI_wH=RTgxpMlCW@;Us*0}L74J#E
+z8XbDWJGpBscw?W$&ZxZNxUq(*DKDwNzW7_}AIw$HF6Ix|;AJ3t6lN=v(c9=?n9;Y0
+zK9A0uW4Ib9|Mp-itnzS#5in=Ny+XhGO8#(1_H4%Z6yEBciBiHfn*h;^r9gWb^$UB4
+zJtN8^++GfT`1!WfQt#3sXGi-p<~gIVdMM<#ZZ0e_kdPG%Q5s20NNt3Jj^t$(?5cJ$
+zGZ#FT(Lt>-0fP4b5V3az4_byF12k%}Spc$WsRydi&H|9H5u1RbfPC#lq=z#a9W(r1
+z!*}KST!Yhsem0tO#r!z`znSL-=NnP~f(pw-sE+Z$e7i7t9nBP^5ts1~WFmW+j+<@7
+zIh@^zKO{1%Lpx^$w8-S+T_59v;%N;<ZZyRu1Je84c8pEeE|Tu>EZtJzcfN%&@(Ux5
+z@YzX^MwbbXESD*d(&qT7-eOHD6iaH-^N>p2sVd<d@hTC>q&(`C$;?#mgBANIc5$r|
+z^A$r)@c{Z}N%sbf<VV6f)%mV{w>o?T`tTHz9-YpiMW?6>kr&W9t$Cuk{q^g1<$I~L
+zo++o2!!$;|U93cI#p4hyc!_Mv2QKXxv419}Ej#w#%N+YIBDdnn8;35!f2QZkUG?8O
+zpP47Wf9rnoI^^!9!dy~XsZ&!DU4bVTAi3Fc<9$_krGR&3TI=Az9uMgYU5dd~ksx+}
+zP+bs9y+NgEL>c@l>H1R%@>5SWg2k&@QZL(qNUI4XwDl6(=!Q^U%o984{|0e|mR$p+
+z9BcwttR#7?As?@Q{+j?K6H7R71PuiA^Dl$=f47nUKL|koCwutc_P<-m{|Al3C~o7w
+z=4S=}s5LcJFT1zjS)+10X_r$74`K78pz!nGGH%JV%w75!YSIt#hT7}}K>+@{{a+Im
+z5p#6%^X*txY?}|T17xWW*sa^?G2QHt#@tlcw0GIcy;|NR2vaCBDvn=`h)1il7E5Rx
+z%)mA4$`$OZx)NF5vXZnaJ1)*cA6ryx6Ll~t!LzhxvcTedxT;>JS&e=?-&DXUPaQ2~
+zH*69ezE`hgV{K-|0z|m~ld}=X^-Ob={wpex&}*+Rz{gx)G}gn!C_VN{UN=>^EV=Xc
+zr$-HO09cW&p4^M}V3yBjTP_xrVcc8iU_^Y-JD~(bgw*@GXGB1gYKz5DWO+O`>})|N
+zWrC)MR<YoNN@dNjcYj<b;OF){>93yA)3{&27-M)TJB6Ml3~?zZg#mYsF=#OSTaw&K
+z@hBftpt+2l@)YK@|3DvTjl(8wZtpLp<?0%pKTY3}XX{MHIljL%Fw{_Z|9d-yvblgQ
+z{!wyH{yqQi?Iie*$>9Ik!6G$CSL_idZ$Ti?R)4toe8bb)l|)lNb}?K;O2K9vyn1QG
+zd=v#y-Ld49UVkmfRU>Egc+(Y$^-;6vW;3Lcu*6~etz}0|@+b|+!UCal)DEYGLbHWJ
+zll5Wi^<vfZ?T~^`8=zPM$Z@j*S$t!Y<EhDvm+zMzHqRrjoNgJR4PlwtA%~M-7oKg-
+z@*>$Y<6@S%^y%hdjRh6&{!z1Py|lZ|q&Wub3l41uN2zEF8E&5H5?PL*&V}?*a}Lp%
+zCYi{ghjpRNT^^B+_U59No50Ghih5qn(W5`RkrsDWr{~A1dgtv{sRkH4RU2^A{jb&0
+zxVRnrm|u<;$iI;M6A>$POP)TWGU-gSjAERk*EGmVT(aw$!XUS<asJ?{P8@w6qBfov
+zI%`}^njNd1_{}A_uRkev<-TXKuoiFlFOyqT%8rk1`2%BKM5Z+~M&?E}fqqOZAZVB5
+zNS{DO+i9FHCCFSvH|Q|2xQ%x$MZhjBSt(99856FiHO!aT?oD?|(v2KHy<imYT_Zl)
+zzM{QvD-38PfU~%Cj@UhZn!-(N#6a8!Zp46^fmJDt%0~G+`{28Ol&R+}En*ZB(Ap5-
+zS3xTHV!d88{~H$@*|Xf2m9Ev~cClRLKWq-Dy`0?=Ka(0bKO7k6Ia^0ek#FeuLW^Ka
+z+29SP{BV|X`LItvfG~$^QN1DscL6_hZV#x+g@RJSzbH{*7vi&EuO^0lmWyRo%n-;p
+zrQ@enXxznWo93lX0onG|8<ExHhjsVv&yv#5$}JubQ-~k2)eX#tYEp#B=ZL)3W6xvQ
+z^tSx&3RvXN^2EDb;%<?Qv9hrD;ImRS1@Ev)+k3=jO{~2fBe<e5TLY_Vf+5&KlA(i%
+z-tx@Qc4VuOh0tKo5#`$=9<^cjcq8Ip7qpr<1+>e~7Ql-oRA54^4V(JWS6Q1mG?!vZ
+zx+pE!FEtvqr|Xrcb3oR`%LHFLmU_&{<QAAHttd1Er^!DxXsl03mv0y!k#PYpGSMeW
+zem^VXYsEEPcK*)T#s$EH8n9Tms!@q~oOuVmpZ((3>=p%mGy6MRe2Yz_5WJ8p@IgU2
+zdVvvhhQtiQkChK%*&PsiPCBL9oDOoJX8!$S(V>R}+1M}wzK*U*A{KJ`r=lM;mPrKU
+zQDqqN(W*u-5-?$(SIk<6A0E}34y&@-IVC%S!a1F4kz<3bIKjlyD)ooO_7ft<QDC;4
+zO#}hIX3cX+ou-UMWv@FumqiR;#JOI;$Lna5#MA^fv9k{O*GC+<$Nq+kGZ+M%7QHYI
+zk9IArOT7c%DRktDP2?F4i2($6s%HL>l%S_(6w`!vX&1PZ!K`@D@L6JR)6zO@Dl!<l
+z=BdWEtebJj+jz>YF{R<WP!R4PHXBT&cyt|IAe~n=dcnCOe*w5G5oS~}#&qbcuT(6I
+z-K*(&5{r9`!3B<qxqwHIOne-7;C;+8dR9=$r{8B+k8sIfec{W>Y}d3HZ7?Q5E>w=$
+ze)H_)48Ds*Ov4?zoGb2fe3}{!5Ooc|KCIni1o)(Gj+CO?`*7jsV`hIv@8J(22o4Q?
+zu?Bvi)zDG<OK;2aO}BggmGd-%r>(me?7XKeL|iF9ZRgZdT*}Ffsl62Cu;{Gv9j6dO
+zPt*H2GqC)-C`V`ceuu=tM{7!2yTEj=*5+T~5DYiZ)Hy)*PARYI6R2lZXoOj;v8M4W
+z*O-NX(7_~Q&A3>Oaw&1lBH_H%SwmISX-i3)HfHvBOeVwTT{LUM3}ZuZmg<(>)KE;d
+zbs2!0v6>J;1nQ0UJkUxnkE@Ibi~Q}M=-=Rk;hcOnxO$luOKEVxZc|!XECgex(2`}T
+z3Y;Q_6rL)e+SrOZhQj5_e}Lv>w7n*Pep$yWZNQl>ubBgb_NIWWDn3kNpn+MPQXV;8
+zV|_Ba5jsQ(w&Ey^IM|@|y!AqcJ#3m0#Q6_qvgCG~eoF#mnGmbO(;DP+bW%_aOs1R_
+z@9p#7X2UA^--#Nwx_Hvk2l1`eO{P*#j@q2UELtH|Uh6<W{C0d%;SO*X17Hg*_nhVo
+zUj8d@XC~-{FK%b15_u=5Zi$$rw|PRP{3P&%r4IFKW@%M_k3l}b-a!ZM6ZqfV-oe0z
+zHcS2@f;}*ROge~8O|p+DJW!EVo_da^QYfpcqO^~19<4~HG-T$^cIunesE=MWKhim-
+z7Goy+*ll|&6M44>hxR`h_847wIJo0=5CQQ`6it|%a-I$^&a@we1rc&*;QIu5Ck^?)
+zx*5eSd*mG#=6Hi(5!;5uUi&{HfnT1S8X-)?gE5CZ6KWoqM5|CyrULmuFBKOU8SOp*
+z{IB1$OCcq`S-k*xs;4fmhKsIGZ;GYAY*%(@875NxhM<x^qSdQMzkq<XP|<&O=Wdj5
+zG5b8jqr5|XkTRdFnfoy|e#_<2FW~3dCqmjftH}M+1ln*+nwXqXXr0NK&8fHefdP~`
+z<>q|j*m4CNLI(Vho|N|F);!E0cS5y^$H^Izje?z}oTgyr`9x9G&rlJZw&uqIoBMtz
+zzhU0(9;w02?m#0!)cFi*r+8YvooQ;(s2lLVvyLqAE%Xqe!vtWbIs!l1Bpp(FIht-Z
+zPn#CN-2C|J*GhA2fuHqYQ2mJiXlGTzD}mkr2;ia8Wp}h^;OS7+N^M<nb8{1bSa3A+
+zL8!27%|p8>w|en!1${vN6<B1T15(f#0UdAk{Wr$+OIZmA!F!Rj#Z~!T7({o*mB$j>
+z-x{8N*4UekA~`IV2&K-GzhAqau|}d*pEQ$1MH$cFi03OG^1NetZ_jW^STaEzr&Xho
+zB452St%v3ez2#TFm~`gZ<UBEKV7u<uCXTZP`7$*T39B#gt?T&`4)K;E&|ZM6WSMdG
+zebuH**%SihzOx;;CUDFI*)EgzXx=I3<*D-whBHjKN-pq1#;zw`)Wn{zX$8V;zVw$q
+zbhEvq3kJ(?s``MV!AS6_c(5D)L4tK*Aw)gIAhX&Z%n4p62=O5*U-Y5Ba)ZL6Adcrk
+z)x8`?1tz4OdUR+*taVv0tA0F%j2gu>h$vi=in+y2d!z<{OZ~Kty-5bQ;0O<LNwDnI
+zC}8-6mq`yuqDIHx`*=Y3Ma%=;%#E>=k_ESi8Nx9{*T`LJy6jqR>&|+>OZ;+=0hA04
+zE25t^sE9HG)3^<Ym7m{BQ^G!z>KKR_A5WDkqispweP9!I-@dCO&N!JrD@i{WBHnfQ
+z95o8;d$`AFnca3;N-0iX-CmbbAp5yQ!GoH;h7Cn?m{ammZJI8igP{U73lFnl2&gCs
+zqJ4(Vo~^j`{zOA<UI~9WX4R%(>zScL5B_Sm?Mjtek1d(A6X5ObcZi$;aOYy|g$}BY
+z$GEP3#i60Ju_&3SHzryH!gUFwC9-295u??cf+aYRQ1$+!rc#42YNattd6mZEFI@?C
+zqFM>6+zxEunIHDZ>{Z15u##>N(28Dw!>G(k*dB{NHvip@aP}f`@=Q;!o;zRMWo{Cx
+zo?kyzh8n7#f1g0&g>Cd>O-2g?uPwy8sy8hZbHSsXPmU;@l=HL=zm7mN(=@*|D$i+u
+zs~TllkCTvD$f&-#b9B?}#Lg*-ibK13R_a$RyoN3m5`10tdhAq{+VW)K#Bht-ra1*J
+z+n$N%V>u0rVtx`aKJDwXXrxa<i8EX06UO&LLD=n5qGhcYvn1Mgi;G^)TV4yilP*(Y
+zoKH+I4#~X)gA)B$;S;Huvs1a%d&HL})yYqqyVy1<B|Kl_6$aedKOq)GM61zpA^OQY
+zD*lN>D7nS<>$=c82v7<sDF~4nP`e39${9XIsr;e(ythhyAUnjOkWQ<YzhIcj{t&n{
+zx(8T~Ps>@KVx^S@vT;h=SZE37K>iahpx3;VDzEr9GY=2(%uaqM;^76eSP0QLzo4sI
+z>p_Eei*T$K;|qK`sq;?Hesp}(@VvX2Q4sAMYAJ}b&d$htDMC{FG-$o4k9ApECi1$a
+zXdamjiOGKHBh(4M<3(2x6n-CrmZMCknkQxdSS!qlis#I}btfX;J`JU3RlvtLdrymP
+zG0ZzrsGXVFiq+Wk1=BFay&9ZiCE#(`h~CL+c-Hs@iGTU@YxM%vlg;)`Tf~IknA^02
+zXkN#Txo6aR{j$wP5T#|UH#<s*%`(Km<n&(n-VMO61HPpba9D&s-YZ<E)NH59!I|A9
+zqN-T-CD))<D9dzh{pWi6;9v!e;Gu01;Ra@5B;qlH=@ASvlOB+p<XN`E#p(1Aq3B41
+z)+3^0JXTY<%Czvf6l;_I-72Od>5AP2{rSY8p?<egp~%*QDVvn_i1jVI<vF4YO5Wv6
+ztWwz1KFP<1kO#Hjq^e=sWVsSgwV`63V3pc#=)rascLi7{-yp$_z50Wja%IQ)>jKFv
+zG3kn3y`FaV!*Jq%m39_TQEhD>M@l*bhEPGe1{ft3q#K5AknT=F2_=T^l#ou5ln@D#
+z5Tzs(kRG@qNDa~<d^7jn_a!bDdDr)>HLNvfv7Z0g=bSlb?`QAx|Gfoni|iHJ%K0cy
+z;~Nsaa+{8HP_qrb{nj+xzkdYhSI@W4N_1`z(eSGIkbDP)!Ko|M%}Rqp(~KI2hl~eE
+zvJ!j4m6iwMgKy>fkCLC)`M$z9EV}B+sq1}}kVf$(ig0pWTY?rHz1Sm=4srTGNb^JG
+z=2$9wz-C@aZZZ2!HY#HNejqZRmE=pN(D$Kui$NpfhU`!y_s{@MIxiJdHb1|{6xb`>
+zE74_@QtgtG{4=3P1$^vn&m}7Aw8!1DnT$2thO#~44wl(N#ao8S0@t@m+Z!KD2CfK;
+z)n5DAPKV_etmH1aLDK$<bfKTSGeuYq_HlONO3C#M3PFvqt3PoSz0>?`;sL91iVt$D
+z*SG}=-LIAg(*+JON!-5ivqOMQ1S!OQUgHglDsKik&Mwg;vva523`JwQH6SRz9eTY#
+zTIi23145~kc3r1mSWC_RzD%hs$S#!pkI9!BU80jJCJcwo*FZolQG$q`8C1d9pP@ND
+zG^&-ZraIvhg_FDVSfKGwkcI=avIan%2sK4coUs~Nr8jC*&!G0#?}_^s3r-c}-uAqi
+zM-Lw>Y}I``T;IS%Y|qH;s{F*ZefM!4{I5awr!K+T@uPd*Vu*iPWI}>(-D{zxsN>LG
+z=@747a_Rb2<sth+J2Z?T^N6ka2dx@o>>q?y8xYf?dq2HM5tFO8Y5e4N;Y=xy8yAhI
+zsm>oy%R5;7)7T3V_b2%`aH^tNlsQpFxIFW<Pc_7hO>#iV#8?{6{^cGr{A0@1bA)|K
+z>MMTuZD(pd2t|7vmHtywGXb%%=)S<`OG~}U+jm#xd%H8<zV$)T@@IDRa^1+^lW~x>
+z$v8-C%F?ah3$;hn?{G3(LT!SgvCVi$vwsZssAQvUwT`Q%qSw!LSd!(<CTTRep1wpD
+z+1amWP^M+0sC8ZA)6PVj+g*a{JY^{LZp|zaB+|iUBf2HHkx&1DcY_YMj%(o)N(g~8
+zuOD62JY+Vu*^6K_|7K^R++2{-!+XRjo6R-MpFwn>I!64w1=%Sc1Mck)q1@pZ@)=SY
+zoX}d+L3-RA<kqVpViiwE2+1D(*ikr;H!OUuItq{`ksBj7b-a&@`xR$^jH(snEHH~+
+z(=1=%lU_?$?ERV8-3T`#N?ATVklfraz}x&yFwwIzZ7NQQfnqa96c>|c?G3_BQNm&(
+z!i$AZ7cI(z7q|e9VM##6T3Xorj1JG(9os$;(I$y%mBy(#8{|3l4|x*oBAQL^XhZ0g
+zy1FR1teRrpKq{uLAibTLx#n({qwjlkOvR{OdSAeT5ah4-sNN)n4Clg1T9lzF)&yj;
+zyal1%+s4n1IG;^VPWJ;#olpk8Z42Gj-tjFeQ&PlxB)`oCNoUYKj4U$AeG8rYiD{pK
+zndDf&2;2;)D|KvOZP+e7fcPU9k4M2sfhr@vC~Ly0?S-4dz)ZGAYpCsAhChgbxLd4g
+zhTrbIPkO5SEp_kD>Ha0m12h5n3s;mE8kn515&n<G5W?|M#KpzT&e--JK0@kIpJd@a
+zo$oEcM{PP18Ny#xS;1ngiAr#v&bUmbji#^iady0^<*7sdBUjhh1TZPRkf>zSf+^D=
+zyE{JnJ;43l&BH55CL<=W%CF;6iUI)V5C*6!`**KqvzR2=Fj*3Y4`HYwx}TYD445(K
+z-QtXwtL?m*(F=LVH*H4oM>dXHBW=38q_dZ-_Vr&qpEPxd9Fs95P5W~@Z|Rt+WZP6l
+zPSQ}~Dh4V?Pp1g&H<P(ih9)F<lyKeQW3i>k*Px?lm16C@X6M29Vrk%Rw@E||E-v~$
+zb_E~{z<}#8i`Mx9mkqtd#Z1lZ-E_J8I+2oumc#x1)jdvh{W76NKm6x-RYpM~v!P8$
+zw3e|YVf|}Hse9~oC@N7^j}Fi$hNpyaYnu1}bdXsD=^oI*%WKvbme|<Oza_wpW8gk;
+zu2yC)2m?TABYV?-o`?uFUCrz2#D@wpoKDwtWV7N~cyL3h>BI}$G3>smu#6y)ls|j?
+zF7Bhu9Z)j)C;3cZb+I>0stSK^WLOYV^U{pUYkgv>?+Nt^5j*CUB=eGw-CvU&40>y~
+zGoHLXxY^7k5Xgv62{iQy|5jJQuq0|LU`}lE@flQ2Z*Zn*VWcQjm4FTb>LSVox^S4q
+zLn`LfS@mrjKCmg$nb^af?d?0&$aX6#2u(JyzIJvuJ*lwPrh|0~aEnSACCTezSdG%h
+zmSQg`17j@$Iq)r1&?+eR@1nlX<hZA96|9?2Pc{<?%#({H1;$K9kGnzSr(*CLy;MCq
+z%~Qs5<0+7FZWenzFJQAz8d%>|H`<}_!?BQSF&N+QQnvEAqZe+mIFui!0V49R?|9*$
+zv!K1A01{8xq;L()Tv*Qk0-$Oj6+vCT*TUD{HvxO@3JjxBwM!4g3ydy&eaJw4CoQBF
+zJtULJ!YxgNR7_Ls%LmogyI7uIs=!B&?=MYY^yX+v;j@D_xGeZg>eZk0C;4e|HRNSi
+z6KlD9>q=3v-$4Zik&^ZDhNm1X)+7<A8tsuQP$bTVU`(p}?t_F!BJ>LCH1k!s+T3tn
+z<oekdyD0CJe2We4yeX>Un@={1U&NJLq@K?~w|(=Y<4W{ucX}F<B#7eu{_F0(M`~qI
+zEPqMc=S17TFa*Ut$xJ>dRr6pLw(l2$iK)At<eBP=<9%0^t_Ek7)YPj~HbzFdS?&Z-
+zFWq#s<_owUG*W9*3T5d3x?Z=@Xg0_}q&OpWn<UO2%6U`unYl-6@mymg@taxBjyc#}
+zd)7tZ=4f`2N^@IyGR7RJjM#l%PlXpmAf&TWaZ{@~`%NOfGu<_iX{6IZhLU^5%U~Eu
+z>%t3gYBMlJz#(K0Nqm;=K<FO+Hmo`&$bpQVtC{pgje|zpXK%6B)|FgdwTg%Nz2k)`
+z8X|UntK@qHxvr+JIl!et<9kIpEAP}K!ng>AML!&MMSNz=%k=j*zh77r34Rs37iCY`
+z=_kva_41bdrj(b=4Wc5MO0~q^z#pIWJ>)vDSgIQF=3JVJe1iDy%h)8oNy{s_r&;m`
+zL{DYKSB_5xRb9xKNOS{qAY3qv5sSXVrrf%~*q5HO|CQ&lbKMePa$M5D{vlJcoGrCZ
+zD?fKbZN$6rWwz)w7`9h4DAmh1ij2}EO|bO#A9L0_RW6l*$sPP<sv8r8rA9owl!eeR
+z1NTGO4fH_iJ$h#A4{SmcyR>UJrUbhLC75L9%W5iO$Iw5~Yut-qBeu~hF|xD7-eQ%l
+z412vpq_;t%^F*pYDk%Q35c-erK|6Ve=FxQbAv~ikZ4c9$Y4;ee#ciOD9{yRqf55Qk
+zumv}#+JciT|Gj$uFOxBUze)=?l{B}qaC0_7m`t82<$K53!4Xvi9Tr)ADp3Off?O8o
+zVDG0Yx|tfn@r((m?Nxrh(b0DGjg)$;DfO&$6uY;4&<!k&O=hr#o>F!4jnxkhP}Y3x
+zS?WFFt>=HWzqlQhffVfvM$Ta8Sg*r3j!Eo&rUOW7SCL2~lG7<+XZ;+{&8<DyiSykp
+zA7l-}(I|=ms%tNFTYkoIsuLyg?+I~Z*3Q|??RFu4_0^U6Re;X@@34fx?CAjIypLRX
+z$t)jPOy0bd<@4-yMHz0{9Y1LCV%IkRJ|jg%fPCmT)F-!8_Y#Dx3{FysRp`Q!doW+6
+zZ}IrYb2DD<Y8pA*#%c==4-8brg}Y#8wFDK<c2$i#jeUy3OkIIRUG3<@gcwUTYAl?p
+z`@7Fcaz|&cdl(`^C!Qo@F-$oXtl)ANqe_kyV5z5QcLFH5ktesECpz2i%Uy3K;o$nU
+zRHA31(@H1&5F`A#ssy`goLx2j=rBn*CE>h5g8ElI+P>>yR2U%S93NN<c)T<0U~gz;
+z>!Xhm|C682t6ysH-=o1=Bd*N*V<P)26zv@1P>lnG%l+KZFtjG`UkL;%65qn0UYQ`h
+zh0{9jDQx(`aBe7J0Aj3Z)4}`A|4OMM0a;?{j}qkYwi)~O8$9D}ITiMH2buiU>ixYp
+zhL${nwj6X($*OwmpVG`y5b6v45tX*J8?og}Qju6eJ9H}`X87iEd%BUo7<`2q(HJx+
+zMR<Pt%@%D0sbR}bR2vchjFmv@&giX(?>}d-J4oAf{V1W^a2~`M-YAdZ81<O(x-LLB
+ziYJ(IlIy^J+VaY)YgPSiQ0Us4I~n$rwJ4oe0cPBI>dd4o6NPO{cmZaAS@RS4ir#Sr
+zf<VdxlnqAnRM2AE_ghvSVwSte-XRVIyT(D^slNqE-8jf%6<nCMa`zf|$630Q?axs+
+z8-|ze)?RSqAckM?+w@&cuhDl@^|OO`O*pLVJKYxi4OohAU>FZO-VIL|VN<%nEXr2`
+z$0FK2L#8O_f1w~c@G70JrB@N}r(gJ!Vmkk6{r68w!o$qO?HrFcjeU0_3F5;*!E2%(
+zTx<?~WRM!G0a&ySR$<jsjlFDU!_cQ=rm^f3a0m@pR~S~3x#Q!vBQ8QrLR>>4?gP8w
+z1B?3UVZmz^%d_dIps>>0{cB~mp3{9U<B7u|njwlkXBz*b%D0;yhSH%?j@*Qn*llsX
+zO1Db$I4fzAEAs;fb^Hb!dP&&H(*QyAv^S{c)(B}+d64a7WNv#fMaw`2RTzNS*TvY_
+z7H6;X#FS2^bTGaO6(xFKPOPseR+?{`;POC2m5aaA&EKov%Vz!k+>oPR6uQFecVq&}
+zY{ebB?AlPAD_}(ll{fK99;Wh1cgRbnw)maD^F>*J!R}eHM*W0VYN1TADWMy9H=$00
+z5bHY${oDgwX7(W9LZw?}{!8(_{JB~Xkje6{0x4fgC4kUmpfJ+LT1DYD*TWu4#h{Y7
+zFLronmc=hS=W=j1ar3r1JNjQoWo2hMWsqW*e?TF%#&{GpsaLp}iN~$)ar+7Ti}E&X
+z-nq~+Gkp(`qF0F_4A22>VZn-x>I$?PDZSeG8h_ifoWf^DxIb5%T7UytYo3}F|4#RC
+zUHpg$=)qVqD~=m(!~?Xwocux<fMdw81nD!;t@a*4neQ(aVD(J+A2??uX#HB8h{SA^
+zdwHZPt(_kv#Cy%vSUh54y~cPXj=D^*;zTVk5y{_bC5yAz3CQA`(UWK4rS;tBXU@kM
+zdej%biGz)+Zyb}ApQWbz*^ZVHpgtmw$q*Vpwt!Q&h9PG6;&Z4L%=lGi5uP2+Iw}}%
+zRw^VYFqyiS!j*Ylw*m}O)GZr&wh(LNL_SF4+fnf#U_g+~SMcMFhbA4}sBM0v^=YW-
+z&lY;LS6yEUO8A78NCxHMrs`yWt-AgIrz<}>U1u}9qhhM7d^eqmJPi_e-!IO`*{u7A
+zbu*?L$Mbj-X9n3G2>+Kc#l`@d8}Xb9{l*IN{#<s%V4>M*d;s+3Pdr8FO$EBELR=8{
+zd?LJbSv9fI`{OqTH)5{b?WulgMb)psp+W|@cSp=jtl-&5C}9lw@*0H+gEW(}mAWNz
+zf{~U;;<ij^TC}|2a=b@Y*t)@0v1xP(v60Z1AVFC^6OFVSu>N}|wdSaphgqn<w7=w9
+zK8);m^xjJ26KBA^s+X~_;*<r_i1!(b_J^XZTX2ts<uU`4&%E_cmAS3_5^hk59|kgD
+zMLF}`MyE`hy%MFvhK6uW0T0ZwJE%ubf^cybN1t(tFSjlXmU%iNJM_KhC?w8%lwxG%
+z^l3qjQ#&r)nR&TI7eX29AQRbBd!NtWy|6g3o?g!*>H{FWUy!{y3^=AC*c?RJ5Eb<^
+zCgH_v7^axIUVmHSFL^zlj2R$zow$|y#7>%#U7d#Vp_ezcp3lefMyd5ES=q$>4pWyA
+zp_Zso^^NP~lu2=S6nD(3Z5u=Uy&B&F<ZVfpeB?A^;A;yfb|T-IdCr4F&4;vkGQ(ce
+zh3=uO>1i$J*3;3KhEkD_lgscHGR*;T;U!9vgQa(hI}oh9IzEf_PU_8F+i77t-~gDX
+z490Sb<R_L<O5Q@b5$Zq8%`yG)pr{P@%VAd&n*7r>)LyVZmf18N6w{+37$aO<2!Av0
+ztLaPOv^J<2@p{WnMiDudoghX_`luFZt_4eNU}*~cF5i%eEcNLs;D>QVIwr8mH;=dc
+z09`}JV;aaF;13<?rh<ybd3+ERtA!AF+n4vv*yO!S>@&iS(w>Jc=k~|d_1hcpM(l|O
+zu>!@}me%isTT$xT#hNUvh(ATd0wT4fbv=6htc<!_*5tIlcw;jfC)7eiH`TZ#yg33G
+z*K{nA3s&@UJ|kOpm^FmpZH!jpU$uLLL0hBd*qzwn)R|bYU?5GP?km8IK}b(Rmo(9m
+ztmUrC#OLcS1`w=qT%q{r;x6q#X*G<@Q?b$fk$PV_;x3)8-*Cma`(%rzI}~@X_mynt
+z){EdYfW}JcHE72h7O(F)3GWJ5QyDsqkV#hvVxfwA+tCRWd-}F=Z{E9X{i^#g-uA}M
+z8A};Fz|8*u<?gci0HA-zkJWo>HNEZIw9%E6wlYmwfu2{j0kh1y=$;Yf!|NldgB9ul
+zB{dbE&LfRnr8ITm@;-68wo#VV?8lG3ed&9k1}QBS3}WGV9%26?A1rBkkDR9Z3o+g+
+z)eQg8BY3y(Dh5&z?VLLNdDV`C=muUvCPpGg!oYxIgOI3^%4>5d7jTh~ni!Fg2;fhx
+z(*c%H6Je84kmQh;5tC3*l~7khLxK-e|Cz?FLh!yYe7g|*LwqU?2wv^_ZyK<Of{dhu
+zsv0|3@?TRSx1dhZz(pM4pWCNW)x%RcI9qU7{OJ?KVPb2=ae`t5N2|Np!TnR=miT6l
+z=X6%jw%pdV6l@QFlD~p?kP+pL<B%Y@NatKA$=T#KFRv!+!jsp)t11X)#&Hl3U6lMU
+zJRO~gIozN7FCmvReeSbLXwrCX?C>T$fYVkGJo@AK0$+ml?}zJeB~deT2WL1vz}dxB
+z)y??t!}%M@)u$_I<M8Xr7=Atw2=U{1NPY=Pxyvvn&o=WU(EM~W-`~1~CfLfw1<p(O
+z>yW~)6u1SttJ!awd6N5lx|xBrmyrBh>tb&D*=C+Z3nPfq$1%WgY0bY*?PZ#Hk|=xn
+zGM#0*w4CaB^y0G(J4q=;5NeM@m-P}#mv7QZNF)M!dK^w{mk_!n0`+Y3PQutu-%NBt
+zzgPXug?JLEbUL{e_dk;Vd896&yPe(hliVK!lj%5+@BKdcrEZ2Nc_*i@ve*2lB>u~{
+zFozd2FM|_0+nAGR4TLNHanQn_Oeb!Jr<ML^n#x(-lWYbAxZ^lzL{91ce=r_rMNh&3
+z5ZH&~&=xx-`k!k3r63SzRZbe5pFX5uiE~x{Yij<#VF%9Yp7eo6*ry-Is`SOWzco`o
+zD|OPe5MeBR9K!M!O8w?{d(zJiQDi%gL-lj>UcvzJ?7p9TTNB}ocO3j$7ij!li8#k6
+z@2tSd1>K03K9A#_-MIq)S;T#oE^;>U$)&}okIvDf3lm?kI{d80$>~<aBIV=g^}I;q
+zHz)SwoEc)S_BbfR&P{vn%<b8oJvk9{`Zix4ac<U&X5Y>xKUoS!%q1Pi?WpsUUt(tI
+ztjNjY*y&Rm9(S(DC2GuPHBJs@5M{RGm`c1z<6nwyN^)rMo-AS{M2$oM9|y%fM|}G~
+DHx0+F
+
+literal 0
+HcmV?d00001
+
+diff --git a/trade-processor/gradle/wrapper/gradle-wrapper.properties b/trade-processor/gradle/wrapper/gradle-wrapper.properties
+new file mode 100644
+index 0000000..a4cf193
+--- /dev/null
++++ b/trade-processor/gradle/wrapper/gradle-wrapper.properties
+@@ -0,0 +1,8 @@
++distributionBase=GRADLE_USER_HOME
++distributionPath=wrapper/dists
++distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
++distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
++networkTimeout=10000
++validateDistributionUrl=true
++zipStoreBase=GRADLE_USER_HOME
++zipStorePath=wrapper/dists
+diff --git a/trade-processor/gradlew b/trade-processor/gradlew
+new file mode 100755
+index 0000000..faf9300
+--- /dev/null
++++ b/trade-processor/gradlew
+@@ -0,0 +1,251 @@
++#!/bin/sh
++
++#
++# Copyright © 2015-2021 the original authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#      https://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++#
++# SPDX-License-Identifier: Apache-2.0
++#
++
++##############################################################################
++#
++#   Gradle start up script for POSIX generated by Gradle.
++#
++#   Important for running:
++#
++#   (1) You need a POSIX-compliant shell to run this script. If your /bin/sh is
++#       noncompliant, but you have some other compliant shell such as ksh or
++#       bash, then to run this script, type that shell name before the whole
++#       command line, like:
++#
++#           ksh Gradle
++#
++#       Busybox and similar reduced shells will NOT work, because this script
++#       requires all of these POSIX shell features:
++#         * functions;
++#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
++#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
++#         * compound commands having a testable exit status, especially «case»;
++#         * various built-in commands including «command», «set», and «ulimit».
++#
++#   Important for patching:
++#
++#   (2) This script targets any POSIX shell, so it avoids extensions provided
++#       by Bash, Ksh, etc; in particular arrays are avoided.
++#
++#       The "traditional" practice of packing multiple parameters into a
++#       space-separated string is a well documented source of bugs and security
++#       problems, so this is (mostly) avoided, by progressively accumulating
++#       options in "$@", and eventually passing that to Java.
++#
++#       Where the inherited environment variables (DEFAULT_JVM_OPTS, JAVA_OPTS,
++#       and GRADLE_OPTS) rely on word-splitting, this is performed explicitly;
++#       see the in-line comments for details.
++#
++#       There are tweaks for specific operating systems such as AIX, CygWin,
++#       Darwin, MinGW, and NonStop.
++#
++#   (3) This script is generated from the Groovy template
++#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
++#       within the Gradle project.
++#
++#       You can find Gradle at https://github.com/gradle/gradle/.
++#
++##############################################################################
++
++# Attempt to set APP_HOME
++
++# Resolve links: $0 may be a link
++app_path=$0
++
++# Need this for daisy-chained symlinks.
++while
++    APP_HOME=${app_path%"${app_path##*/}"}  # leaves a trailing /; empty if no leading path
++    [ -h "$app_path" ]
++do
++    ls=$( ls -ld "$app_path" )
++    link=${ls#*' -> '}
++    case $link in             #(
++      /*)   app_path=$link ;; #(
++      *)    app_path=$APP_HOME$link ;;
++    esac
++done
++
++# This is normally unused
++# shellcheck disable=SC2034
++APP_BASE_NAME=${0##*/}
++# Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
++APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
++
++# Use the maximum available, or set MAX_FD != -1 to use that value.
++MAX_FD=maximum
++
++warn () {
++    echo "$*"
++} >&2
++
++die () {
++    echo
++    echo "$*"
++    echo
++    exit 1
++} >&2
++
++# OS specific support (must be 'true' or 'false').
++cygwin=false
++msys=false
++darwin=false
++nonstop=false
++case "$( uname )" in                #(
++  CYGWIN* )         cygwin=true  ;; #(
++  Darwin* )         darwin=true  ;; #(
++  MSYS* | MINGW* )  msys=true    ;; #(
++  NONSTOP* )        nonstop=true ;;
++esac
++
++CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
++
++
++# Determine the Java command to use to start the JVM.
++if [ -n "$JAVA_HOME" ] ; then
++    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
++        # IBM's JDK on AIX uses strange locations for the executables
++        JAVACMD=$JAVA_HOME/jre/sh/java
++    else
++        JAVACMD=$JAVA_HOME/bin/java
++    fi
++    if [ ! -x "$JAVACMD" ] ; then
++        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
++
++Please set the JAVA_HOME variable in your environment to match the
++location of your Java installation."
++    fi
++else
++    JAVACMD=java
++    if ! command -v java >/dev/null 2>&1
++    then
++        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
++
++Please set the JAVA_HOME variable in your environment to match the
++location of your Java installation."
++    fi
++fi
++
++# Increase the maximum file descriptors if we can.
++if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
++    case $MAX_FD in #(
++      max*)
++        # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
++        # shellcheck disable=SC2039,SC3045
++        MAX_FD=$( ulimit -H -n ) ||
++            warn "Could not query maximum file descriptor limit"
++    esac
++    case $MAX_FD in  #(
++      '' | soft) :;; #(
++      *)
++        # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
++        # shellcheck disable=SC2039,SC3045
++        ulimit -n "$MAX_FD" ||
++            warn "Could not set maximum file descriptor limit to $MAX_FD"
++    esac
++fi
++
++# Collect all arguments for the java command, stacking in reverse order:
++#   * args from the command line
++#   * the main class name
++#   * -classpath
++#   * -D...appname settings
++#   * --module-path (only if needed)
++#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and GRADLE_OPTS environment variables.
++
++# For Cygwin or MSYS, switch paths to Windows format before running java
++if "$cygwin" || "$msys" ; then
++    APP_HOME=$( cygpath --path --mixed "$APP_HOME" )
++    CLASSPATH=$( cygpath --path --mixed "$CLASSPATH" )
++
++    JAVACMD=$( cygpath --unix "$JAVACMD" )
++
++    # Now convert the arguments - kludge to limit ourselves to /bin/sh
++    for arg do
++        if
++            case $arg in                                #(
++              -*)   false ;;                            # don't mess with options #(
++              /?*)  t=${arg#/} t=/${t%%/*}              # looks like a POSIX filepath
++                    [ -e "$t" ] ;;                      #(
++              *)    false ;;
++            esac
++        then
++            arg=$( cygpath --path --ignore --mixed "$arg" )
++        fi
++        # Roll the args list around exactly as many times as the number of
++        # args, so each arg winds up back in the position where it started, but
++        # possibly modified.
++        #
++        # NB: a `for` loop captures its iteration list before it begins, so
++        # changing the positional parameters here affects neither the number of
++        # iterations, nor the values presented in `arg`.
++        shift                   # remove old arg
++        set -- "$@" "$arg"      # push replacement arg
++    done
++fi
++
++
++# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
++DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
++
++# Collect all arguments for the java command:
++#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
++#     and any embedded shellness will be escaped.
++#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
++#     treated as '${Hostname}' itself on the command line.
++
++set -- \
++        "-Dorg.gradle.appname=$APP_BASE_NAME" \
++        -classpath "$CLASSPATH" \
++        org.gradle.wrapper.GradleWrapperMain \
++        "$@"
++
++# Stop when "xargs" is not available.
++if ! command -v xargs >/dev/null 2>&1
++then
++    die "xargs is not available"
++fi
++
++# Use "xargs" to parse quoted args.
++#
++# With -n1 it outputs one arg per line, with the quotes and backslashes removed.
++#
++# In Bash we could simply go:
++#
++#   readarray ARGS < <( xargs -n1 <<<"$var" ) &&
++#   set -- "${ARGS[@]}" "$@"
++#
++# but POSIX shell has neither arrays nor command substitution, so instead we
++# post-process each arg (as a line of input to sed) to backslash-escape any
++# character that might be a shell metacharacter, then use eval to reverse
++# that process (while maintaining the separation between arguments), and wrap
++# the whole thing up as a single "set" statement.
++#
++# This will of course break if any of these variables contains a newline or
++# an unmatched quote.
++#
++
++eval "set -- $(
++        printf '%s\n' "$DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS" |
++        xargs -n1 |
++        sed ' s~[^-[:alnum:]+,./:=@_]~\\&~g; ' |
++        tr '\n' ' '
++    )" '"$@"'
++
++exec "$JAVACMD" "$@"
+diff --git a/trade-processor/gradlew.bat b/trade-processor/gradlew.bat
+new file mode 100644
+index 0000000..9b42019
+--- /dev/null
++++ b/trade-processor/gradlew.bat
+@@ -0,0 +1,94 @@
++@rem
++@rem Copyright 2015 the original author or authors.
++@rem
++@rem Licensed under the Apache License, Version 2.0 (the "License");
++@rem you may not use this file except in compliance with the License.
++@rem You may obtain a copy of the License at
++@rem
++@rem      https://www.apache.org/licenses/LICENSE-2.0
++@rem
++@rem Unless required by applicable law or agreed to in writing, software
++@rem distributed under the License is distributed on an "AS IS" BASIS,
++@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++@rem See the License for the specific language governing permissions and
++@rem limitations under the License.
++@rem
++@rem SPDX-License-Identifier: Apache-2.0
++@rem
++
++@if "%DEBUG%"=="" @echo off
++@rem ##########################################################################
++@rem
++@rem  Gradle startup script for Windows
++@rem
++@rem ##########################################################################
++
++@rem Set local scope for the variables with windows NT shell
++if "%OS%"=="Windows_NT" setlocal
++
++set DIRNAME=%~dp0
++if "%DIRNAME%"=="" set DIRNAME=.
++@rem This is normally unused
++set APP_BASE_NAME=%~n0
++set APP_HOME=%DIRNAME%
++
++@rem Resolve any "." and ".." in APP_HOME to make it shorter.
++for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
++
++@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
++set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
++
++@rem Find java.exe
++if defined JAVA_HOME goto findJavaFromJavaHome
++
++set JAVA_EXE=java.exe
++%JAVA_EXE% -version >NUL 2>&1
++if %ERRORLEVEL% equ 0 goto execute
++
++echo. 1>&2
++echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
++echo. 1>&2
++echo Please set the JAVA_HOME variable in your environment to match the 1>&2
++echo location of your Java installation. 1>&2
++
++goto fail
++
++:findJavaFromJavaHome
++set JAVA_HOME=%JAVA_HOME:"=%
++set JAVA_EXE=%JAVA_HOME%/bin/java.exe
++
++if exist "%JAVA_EXE%" goto execute
++
++echo. 1>&2
++echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
++echo. 1>&2
++echo Please set the JAVA_HOME variable in your environment to match the 1>&2
++echo location of your Java installation. 1>&2
++
++goto fail
++
++:execute
++@rem Setup the command line
++
++set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
++
++
++@rem Execute Gradle
++"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
++
++:end
++@rem End local scope for the variables with windows NT shell
++if %ERRORLEVEL% equ 0 goto mainEnd
++
++:fail
++rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
++rem the _cmd.exe /c_ return code!
++set EXIT_CODE=%ERRORLEVEL%
++if %EXIT_CODE% equ 0 set EXIT_CODE=1
++if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
++exit /b %EXIT_CODE%
++
++:mainEnd
++if "%OS%"=="Windows_NT" endlocal
++
++:omega
 diff --git a/trade-processor/openapi.yaml b/trade-processor/openapi.yaml
 new file mode 100644
 index 0000000..a3b5fcc
@@ -20450,10 +18053,10 @@ index 0000000..eaa6e76
 +}
 diff --git a/trade-processor/src/main/resources/application.properties b/trade-processor/src/main/resources/application.properties
 new file mode 100644
-index 0000000..136c55d
+index 0000000..b571214
 --- /dev/null
 +++ b/trade-processor/src/main/resources/application.properties
-@@ -0,0 +1,21 @@
+@@ -0,0 +1,20 @@
 +server.port=${TRADE_PROCESSOR_SERVICE_PORT:18091}
 +server.forward-headers-strategy=framework
 +
@@ -20471,7 +18074,6 @@ index 0000000..136c55d
 +
 +# To avoid "Request header is too large" when application is backed by oidc proxy.
 +server.max-http-request-header-size=1000000
-+springdoc.swagger-ui.disable-swagger-default-url=true
 +
 +logging.level.org.hibernate.SQL=DEBUG
 +logging.level.org.hibernate.type.descriptor.sql.BasicBinder=DEBUG
@@ -20551,13 +18153,13 @@ index 0000000..ca523cb
 +- CORS allowlist: `CORS_ALLOWED_ORIGINS` (default `*`)
 diff --git a/trade-service/SPEC.manifest.json b/trade-service/SPEC.manifest.json
 new file mode 100644
-index 0000000..47a4d35
+index 0000000..5afe733
 --- /dev/null
 +++ b/trade-service/SPEC.manifest.json
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,33 @@
 +{
 +  "schemaVersion": "1.0.0",
-+  "generatedAtUtc": "2026-03-31T12:59:32Z",
++  "generatedAtUtc": "2026-07-22T12:27:30Z",
 +  "component": {
 +    "id": "trade-service",
 +    "kind": "service",
@@ -20571,17 +18173,18 @@ index 0000000..47a4d35
 +  "runtime": {
 +    "defaultPort": 18092,
 +    "dependsOn": ["account-service","reference-data","people-service","trade-feed","trade-processor"],
-+    "requiredEnv": ["TRADING_SERVICE_PORT","ACCOUNT_SERVICE_URL","ACCOUNT_SERVICE_HOST","REFERENCE_DATA_SERVICE_URL","REFERENCE_DATA_HOST","PEOPLE_SERVICE_URL","PEOPLE_SERVICE_HOST","TRADE_FEED_ADDRESS","TRADE_FEED_HOST","CORS_ALLOWED_ORIGINS"]
++    "requiredEnv": ["TRADING_SERVICE_PORT","ACCOUNT_SERVICE_URL","ACCOUNT_SERVICE_HOST","REFERENCE_DATA_SERVICE_URL","REFERENCE_DATA_HOST","PEOPLE_SERVICE_URL","PEOPLE_SERVICE_HOST","TRADE_FEED_ADDRESS","TRADE_FEED_HOST","CORS_ALLOWED_ORIGINS"],
++    "healthHint": "http://<host>:18092/v3/api-docs"
 +  },
 +  "contracts": {
 +    "primary": "specs/001-baseline-uncontainerized-parity/contracts/trade-service/openapi.yaml"
 +  },
 +  "traceability": {
-+    "requirements": ["SYS-FR-001","SYS-FR-006","SYS-FR-010","SYS-FR-011","SYS-FR-012","SYS-NFR-007"],
-+    "stories": ["US-003","US-004","US-007","US-008","US-009"],
-+    "acceptanceCriteria": ["AC-001","AC-004","AC-009","AC-010"],
++    "requirements": ["SYS-FR-001","SYS-FR-006","SYS-FR-010","SYS-FR-011","SYS-FR-012","SYS-NFR-007","SYS-NFR-009","SYS-NFR-010"],
++    "stories": ["US-003","US-004","US-007","US-008","US-009","US-014","US-015"],
++    "acceptanceCriteria": ["AC-001","AC-004","AC-009","AC-010","AC-017","AC-018"],
 +    "flows": ["F3","F4","STARTUP"],
-+    "verificationRefs": ["pipeline/validate-regeneration-readiness.sh","scripts/start-base-uncontainerized-generated.sh","scripts/status-base-uncontainerized-generated.sh","scripts/test-realtime-account-stream-overlay.sh","scripts/test-trade-service-overlay.sh"]
++    "verificationRefs": ["pipeline/smoke-dependency-version-targets.sh","pipeline/validate-lifecycle-script-contract.sh","pipeline/validate-regeneration-readiness.sh","scripts/start-base-uncontainerized-generated.sh","scripts/status-base-uncontainerized-generated.sh","scripts/test-realtime-account-stream-overlay.sh","scripts/test-trade-service-overlay.sh"]
 +  },
 +  "constraints": {
 +    "preIngressCorsRequired": false
@@ -20589,17 +18192,18 @@ index 0000000..47a4d35
 +}
 diff --git a/trade-service/build.gradle b/trade-service/build.gradle
 new file mode 100644
-index 0000000..8262ceb
+index 0000000..434cc4d
 --- /dev/null
 +++ b/trade-service/build.gradle
-@@ -0,0 +1,56 @@
+@@ -0,0 +1,57 @@
 +plugins {
 +  id 'java'
-+  id 'org.springframework.boot' version '3.5.15'
++  id 'org.springframework.boot' version '3.5.16'
 +  id 'io.spring.dependency-management' version '1.1.7'
 +}
 +
-+ext['tomcat.version'] = '10.1.55'
++ext['jackson-bom.version'] = '2.22.1'
++ext['tomcat.version'] = '10.1.57'
 +
 +group = 'finos.traderx.trade-service-specfirst'
 +version = '0.1.0'
@@ -20621,21 +18225,21 @@ index 0000000..8262ceb
 +  implementation 'org.springframework.boot:spring-boot-starter-web'
 +  implementation 'com.h2database:h2:2.4.240'
 +  implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.17'
++  implementation 'org.apache.logging.log4j:log4j-api:2.26.1'
++  implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.26.1'
 +
 +  implementation('org.json:json:20240303') {
 +    because 'previous versions are affected by multiple CVE'
 +  }
-+  implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.3.20'
++  implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.4.10'
 +  implementation('io.socket:socket.io-client:2.1.2') {
 +    exclude group: 'org.json', module: 'json'
 +  }
 +  implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 +  implementation ('ch.qos.logback:logback-core:1.5.34') {
-+    because 'version brought in by spring boot 3.5.15 affected by CVE-2024-12798'
++    because 'version brought in by spring boot affected by CVE-2024-12798'
 +  }
 +  implementation 'ch.qos.logback:logback-classic:1.5.34'
-+  implementation 'org.apache.logging.log4j:log4j-api:2.26.0'
-+  implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.26.0'
 +  implementation 'org.apache.commons:commons-lang3:3.20.0'
 +
 +  testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -20649,6 +18253,1141 @@ index 0000000..8262ceb
 +  exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk7'
 +  exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
 +}
+diff --git a/trade-service/gradle/wrapper/gradle-wrapper.jar b/trade-service/gradle/wrapper/gradle-wrapper.jar
+new file mode 100644
+index 0000000000000000000000000000000000000000..9bbc975c742b298b441bfb90dbc124400a3751b9
+GIT binary patch
+literal 43705
+zcma&Obx`DOvL%eWOXJW;<L>V64viP??$)@wHcsJ<yG!Hl?(U7dFYnCW{r1k?dA}jz
+z`Gcs6s9#i`JSR_PKBXuF4uJsz0|NsB0z&+G{=YvI5Lgg7F;yWtDS2@QSt$`Qc@;4=
+zRY(xfzuvO0rR}uJ{>68)>bJS6*&iHnskXE8MjvIPVl|FrmV}Npeql07fCw6`pw`0s
+zGauF(<*@v{3t!qoUU*=j)6;|-(yg@jvDx&fV^trtZt27?4Tkn729qrItVh@PMwG5$
+z+oXHSPM??iHZ!cVP~gYact-CwV`}~Q+R}PPNRy+T-geK+>fHrijpllon_F4N{@b-}
+z1M0=a!VbVmJM8Xk@NRv)m&aRYN}FSJ{LS;}2ArQ5baSjfy40l@T5)1r-^0fAU6f_}
+zzScst%$Nd-^ElV~H0TetQhMc%S{}Q4lssln=|;LG?Ulo}*mhg8YvBAUY7YFdXs~vv
+zv~{duzVw%C#GxkBwX=TYp1Dh*Uaum2?RmsvPaLlzO^fIJ`L?&OV?Y&kKj~^kWC`Ly
+zfL-}J^4a0Ojuz9O{jUbIS;^JatJ5+YNNHe}6nG9Yd6P-lJiK2ms)A^xq^H2fKrTF)
+zp!6=`Ece~57>^9(RA4OB9;f1FAhV%zVss%#rDq$9ZW3N2cXC7dMz;|UcRFecBm`DA
+z1pCO!#6zKp#@mx{2>Qcme8y$Qg_gnA%(`Vtg3ccwgb~D(&@y8#Jg8nNYW*-P{_M#E
+zZ|wCsQoO1(iIKd-2B9xzI}?l#Q@G5d$m1Lfh0q;iS5FDQ&9_2X-H)VDKA*fa{b(sV
+zL--krNCXibi1+*C2;4qVjb0KWUVGjjRT{A}Q*!cFmj0tRip2ra>WYJ>ZK4C|V~RYs
+z6;~+*)5F^x^aQqk9tjh)L;DOLlD8j+0<>kHc8<MT8<q;@cs^TP%TBGLJb3?hF`f1u
+zr^#HdaN9hgmYP%3&4eX^>MN|68PxQV`tJFbgxSfq-}b(_h`luA0&<H)Ks&ZC5avn$
+zblv>;Vk<@5<kF$(jU%Y1<)oJ9n#F!_Nzr$1q5g8vk%4E5n+!%&?C??!2P`6+_1%cB
+zz~CmX+0avvVR!Fm9DBz=5OYDMzyT5o=mbbC1@y!;y!`Xf(U~IBp=}v8UBCUG8>1i0
+z_cu6{_*=vlvYbKjDawLw+t^H?OV00_73Cn3goU<yjj&HS+sgjt5ulpVMAFPV!h#%(
+z;O+R^(R7duR?KDiP~~*Sz}yNf2S{i|h1xTKnI_B>5?})UYFuoSX6Xqw;TKcrsc|r#
+z$sMWYl@cs#SVopO$hpHZ)cdU-+Ui%z&Sa#lMI~zWW@vE%QDh@bTe0&V9nL>4Et9`N
+zGT8(X{l@A~loDx}BDz`m6@tLv@$mTlVJ;4MGuj!;9Y=%;;_kj#o8n5tX%@M)2I@}u
+z_{I!^7N1BxW9`g&Z+K#lZ@7_dXdsqp{W9_`)zgZ=sD~%WS5s$`7z#XR!Lfy(4se(m
+zR@a3twgMs19!-c4jh`PfpJOSU;vShBKD|I0@rmv_x|+ogqslnLLOepJpPMOxhRb*i
+zGHkw<C6i>f#?ylQ@k9QJL?!}MY4i7joSzMcEhrDKJH&?2v{-tgCqJe+Y0njl7HYff
+z{&~M;JUXVR$qM1FPucIEY(IBAuCHC@^~QG6O!dAjzQBxDOR~lJEr4KS9R*idQ^p{D
+zS#%NQADGbAH~6wAt}(1=Uff-1O#ITe)31zCL$e9~{w)gx)g>?zFE{Bc9nJT6xR!i8
+z)l)~9&~zSZTH<f>k{?iQL^MQo$wLi}`B*qnvUy+Y*jEraZMnEhuj`Fu+>b5xD1_Tp
+z)8|wedv42#3AZUL7x&G@p@&zcUvPkv<gOT$sg9nDsP`h2d9g#)Sfr@kmW^OuGVzBe
+z-mcj_6tCQbJjPpCR0_6&eS`PLDmBn1jc_}#l=&oN(1kZX%4pnohcH*OTaAUFUQR9I
+zJsE{W;L}Y`SMW2`Yxlamz6R=sERGI$HJ&wT!!xuJCXi~%#!zT5#JMaroI8+$NZU!j
+zFFo1(OoSgnZ`tOBNEeS}AJTa*w)!5g*s2NJdIyH_O<3^t7uCBd5c|%jlVJAD=GPv6
+zGy{$r4IuY4V;#IhoM9(k9N?|GBT!0wNQtL*(Wla6D)K3^HTQh9<!?y8pnvCIy%Of4
+zum(WCu{ljigy+8e*vg{OEP4h-N6?BPRwPrLau9K*^W?WW;LAPzYRy1|S<{}2ayMO6
+z8Gk5*s)+cT;R6e$f61Q!-QhR7$s`=CY0vN!#Gm}?vOh0St8%mcv%@1{x_S+@@wk7+
+zFHA$hX%gbrT2VQ8hV%{#=997-Aa7v_qGy2j`{6(KD}jjYS=X4TTgcc_#&`99oP{`1
+z+?qRA0-j~Bi$<R4kd7i0PY(>g=YJS6?1B7ZEXr4b>M+9Gli$gK-Sgh{O@>q7TUg+H
+zNJj`6q#O@>4HpPJEHvNij`sYW&u%#=215HKNg;C!0#hH1vlO<x`KH1(L52Jfzqckp
+zK+CZ7Ysjx9Ry1%Exbc$7q$%?P{F`qK)zp<pKl6?{P-tc#d(^voQM{*HzaqZ$MF6+j
+zS~SbNnOTb~v^`{pTqA`20=exoU<o^ZUk`ng!~@i!3dZcf;2^$k_C@g8WV8ec1R9H3
+z1`mCus@E!98f~!1rPz5UtUeu7G^^TU%W)2pTm^QP5I*2-sUu2=PL2Gs`-60K_$N2v
+zq}PJt3O#wc`jCA!5t<`h+K4FljR)C<HUy;}xwV&b`+VADm9(!vPCRX?^<oG+Vqeyc
+zzAmc*_iJ~=?~J-H*{$GHN4NIN0}j0yD3GR_r7^*==U{*u<)Ms-C|SiYB&zk-Wp@Y%
+zp&S*-{+zxwY`#DQ<w|BzbKuAp({yI0gR5k4q=KVfX|Z@&C2D=%htF<kWp>5+dFq9&
+zS)8{5_%hz?#D#wn&nm@aB?1_|@kpA<uzp&}l&AD1u)JhYR;ZXh9aBhZCzAtxS13Bp
+zA6Zy}vU8v^?dRy1PIC=7_PA-v<La!D;#*&-5%sU))yJ_yayZVijq+d8MU%ahLUSA$
+zb0EHFFV2D{O}X^o(5AJif==$^X=iGGhpJ4KYw@<T@0PxkDnjx1LyF6S1hcurMfQm5
+zJhtbDMr1*Q{|1EZ*mS}Qd33Qo7~2#jY)+05;Xfi)zKK9EDUF$=6E5F1W+xgADW`s2
+zH|$E3Fed+2a!z;4mZn&JN5DxUfPSaKxluwruV#d2eoAHtR&D=*wdN6FVZ6oI2g0Hw
+zOP;PSG}*`dJEr(*FvR10V<#_MSwpBkIpj_jL>@{%jYcs{K%$a4W{<UY0d}<G_tvcW
+zMNcwn<nVcftdCFzNuiwF_|8?DI$6#{zbc7GvkUvU3|!{Ax?HKf@j9mrId!xHE6!-2
+z{C)xYPtH9rOV?L9kcZN6$krD3qudB?$8^ttXzA!P2B|T6$sO-q_YsmhfI9ntr>k@F
+zPyTav?jb;F(|GaZhm6&M#g|`ckO+|mCtAU)5_(<C;Peqq9IE<_AsNiFs{{>hn&Ogd
+z9Ku}orOMu@K^Ac>eRh3+0-y^F`j^noa*OkS3p^tLV`TY$F$cPXZJ48!xz1d7%vfA(
+zUx2+sDPqHfiD-_wJDb38K^LtpN2B0w=$A10z%F9f_P2aDX63w7zDG5CekVQJGy18I
+zB!tI`6rZr7TK10L(8bpiaQ>S@b7r_u@lh^vakd0e6USWw7W%d_Ob%M!a`K>#I3r-w
+zo2^+9Y)Sb?P9)x0iA#^ns+Kp{JFF|$09jb6ZS2}_<-=$?^#IUo5;g`4ICZknr!_aJ
+zd73%QP^e-$%Xjt|28xM}ftD|V@76V_qvNu#?Mt*A-OV{E4_zC4Ymo|(cb+w^`Wv==
+z>)c%_U0w`d$^`lZQp@midD89ta_qTJW~5lRrIVwjRG_9aRiQGug%f3p@<N8PMQE{a
+zd_6w48$rsd^cXZQ7Dwk9nz}YC&*86L&Yst+a`$%*_e1yJh%kgNQXk4z5r6m?Y@2xN
+zly?J=iN07}T>;*%Y@J5uQ|#dJ+P{Omc`d2VR)DXM*=ukjVqIpkb<9gn9{*+&#p)Ek
+zN=4zwNWHF~=Gqc<UjtcOL9OLcIawlSDS7cyPainIsyG~{9o!H&xa9hYf#oyhSccci
+zt8ciEDfpw+|JDHKvIGdAID*M?Ww(Uo_>Lkd!q0p(S2_K=Q`$whZ}r@ec_cb9hhg9a
+z6CE=1n8Q;hC?;ujo0numJBSYY6)GTq^=kB~`-qE*h%*V6-ip=c4+Yqs*7C@@b4YAi
+zuLjsmD!5M7r7d5ZPe>4$;iv|zq=9=;B$lI|xuAJwi~j~^Wuv!Qj2iEPWjh<cjq`B2
+zQQyz_oTCXImfm@9L;Jg(EcYq6*mZ2Ar7Wg-A&#d%mn;}2vkz#+K|`?Os_iMQICL7M
+z%X3DlLx`B&@S70b+8_uUYlQ7Jjwqbip^{Sy&<=Xy_(h{9O0(ZA&bm55akipSI@h-P
+zouFPBu_Do|z_f_JGMu+d26M|qD0mf|&pPvU(0X6B(p676+94<iS<G;?SQn?!TsCT<
+zW`oSdht$$w66GB-l}L1v_Gel0yjn`(hShw}$Zca>9Z&#<HMI*Z2_1}T(Ag7?VQuOk
+z`{mYjKhEP<qwlCQ<3{~SgOxwbx2t!SbHzjBYU=s|B(D4sC75oIbo;F+(N+m9uUJay
+z3zRQ;6klQ`P7c#H*XA(0OTAp7rMZSXB;)Q$&ymhbN*ra}sd<0WM1I3@<CsDWXd;ki
+z&@?%;r2lEn-Rstvl;9}rizIur@q3(@kvLvHJ^t^eGQ9G#)J~{}lP*OWXqf7ze8OWy
+z5Rgs^5D>+G>lZQpZ@(xfBrhc{rlLwOC;opt<Bi<dsH_Yf{WPKs9reW6WSuhO9Lv`J
+z^%&id)VSO@jT9{?+)0RW%3gsMRWsJNqP+s@Agpg+Fbck0IbJz}ettAGj7<$cpWvte
+z6!<*<{!y4dAH~kmjKRziU~Fx|U}SB<AYx}@1F$ugwXii2ax`<XF|l<Pb2l=vceb#z
+zr8lw$I63{F=af?zmj-7-$zEDn&|(O{iskxs=4#PjtBP81^sD$wd-1XbZiaEHaTAOo
+zQD4&~nfoQEH>JZDj4Xfu3$u6rt_=YY0~lxoy~fq=*L_&RmD7dZWBUmY&12S;(Ui^y
+zBpHR0?Gk|`U&CooNm_(kkO~pK+cC%uVh^cnNn)MZjF@l{_bvn4`Jc}8QwC5_)k$zs
+zM2qW1Zda%bIgY^3NcfL)9ug`05r5c%8ck)J6{fluBQhVE>h+IA&Kb}~$55m-^c1S3
+zJMXGlOk+01qTQUFlh5Jc3xq|7McY$nCs$5=`8Y;|il#Ypb{O9}GJZD8!kYh{TKqs@
+z-mQn1K4q$yGeyMcryHQgD6Ra<6^5V(>6_qg`3uxbl|T&cJVA*M_+OC#>w(xL`RoPQ
+zf1ZCI3G%;<gu?&p>o-x>RzO!mc}K!XX{1rih0$~9XeczHgHdPfL}4IPi~5EV#ZcT9
+zdgkB3+NPbybS-d;{8%bZW^U+x@Ak+uw;a5JrZ<t9b~FAko|dNnqw@`fG4fl;gO}GN
+zja@xAhij0PWn_9yAtqa|Q~JyS@OCX>H!WbNvl<c^f{)!@kr}sV306x!m(JFK2Su#H
+zA{l>!b~r4*vs#he^bqz`W93PkZna2oYO9dBrKh2QCWt{dGOw)%Su%1bIjtp4dKjZ^
+zWfhb$M0MQiDa4)9rkip9DaH0_tv=XxNm>6MKeWv>`KNk@QVkp$Lhq_~>M6S$oliq2
+zU6i7bK;TY)m>-}X7hDTie>cc$J|`*}t=MAMfWIALRh2=O{L57{#fA_9LMnrV(HrN6
+zG0K_P5^#$eKt{J|#l~U0WN_3)p^LLY(XEqes0OvI?3)GTNY&S13X+9`6PLVFRf8K)
+z9x@c|2T72+-KOm|kZ@j4EDDec>03FdgQlJ!&FbUQQH+nU^=U3Jyrgu97&#-W4C*;_
+z(WacjhBDp@&Yon<9(BWPb;Q?Kc0gR5ZH~aRNkPAWbDY!FiYVSu!~Ss^9067|JCrZk
+z-{Rn2KEBR|Wti<xxNV#Db47^*a|{iSLoUSn+}XCk5${GR@Qb+|Eox;WbSB?b>_iy)
+zXnh2wiU5Yz2L!W{{_#LwNWXeNPHkF=jj<Oca}a<VYq$(Z)L~2{hsCZ>XmHC@n*oiz
+zIoM~Wvo^T@@t!QQW?Ujql-GBOlnB|HjN@x~K8z)c(X}%%5Zcux09vC8=@tvgY>czq
+z3D(U&FiETaN9aP}FDP3ZSIXIffq>M3{~eTB{uauL07oYiM=~K(XA{SN!rJLyXeC+Y
+zOdeebgHOc2aCIgC=8>-Q>zfuXV*=a&gp{l#E@K|{qft@YtO>xaF>O7sZz%8);e86?
+z+jJlFB{0fu6%8ew^_<+v>>%6eB8|t*_v7gb{x=vLLQYJKo;p7^o9!9A1)fZZ8i#ZU
+z<|E?bZakjkEV8xGi?n+{Xh3EgFKdM^;4D;5fHmc04PI>6oU>>WuLy6jgpPhf8$K4M
+zjJo*MbN0rZbZ!5DmoC^@hbqXiP^1l7I5;Wtp2i9Jkh+KtDJoXP0O8qmN;Sp(+%upX
+zAxXs*qlr(ck+-QG_mMx<HJPMiiyFhyvyc$BVLB{06!#fNnvcq+4(CeJ9NSp(yBP{p
+zz9+FDyloDA-5BFzU$X6O5`cUWFMHGQXtH9zX=W;Z0SMrXCMHY77EA&39fq<AIjYX_
+zL-)E@whkh@FYnG!*@-)hr`+%$^!mR-H_bvW274&&>?hQNXVV~LT{$Q$ShX+&x?Q7v
+z@8t|UDylH6@RZ?WsMVd3B0z5zf50BP6U<&X_}+y3uJ0c5OD}+J&2T8}A%2Hu#Nt_4
+zoOoTI$A!hQ<2pk5wfZDv+7Z{yo+Etqry=$!*pvYyS+kA4xnJ~3b~TBmA8Qd){w_bE
+zqDaLIjnU8m$wG#&T!}{e0qmHHipA{$j`%KN{&#_Kmjd&#X-hQN+ju$5Ms$iHj4r?)
+z&5m8tI}L$ih&95AjQ9EDfPKSmMj-@j?Q+h~C3<|Lg2zVtfKz=ft{YaQ1i6Om&EMll
+zzov%MsjSg=u^%EfnO+W}@)O<s4y0<!F*}jN{~^*=<<M!`pCE38_&X5u{wE+7HZiqx
+zG!eIObaGa4G5p`k`7da0P_t5)HNf!I6NGD^#Jcju!NjqqL7(FK$?;p8B-cTjS(f#p
+zHML@9bjCH8>6u0LwoX709h3Cxdc2Rwgjd%LLTChQvHZ+y<1q6kbJXj3_pq1&MBE{8
+zd;aFotyW>4WHB{JSD8Z9M@jBitC1RF;!B8;Rf-B4nOiVbGlh9w51(8WjL&e{_iXN(
+zAvuMDIm_>L?rJPxc>S`bqC|W$njA0MKWa?V$u6mN@PLKYqak!bR!b%c^ze(M`ec(x
+zv500337YCT4gO3+9>oVIJLv$pkf`01S(DUM+4u!HQob|IFHJHm#>eb#eB1X5;bMc|
+z>QA4Zv}$S?fWg~31?Lr(C>MKhZg>gplRm`2WZ--iw%&&YlneQYY|PXl;_4*>vkp;I
+z$VYTZq|B*(3(y17#@ud@o)XUZPYN*rStQg5U1Sm2gM}7hf_G<>*T%6ebK*tF(kbJc
+zNPH4*xMnJNgw!ff{YXrhL&V$6`ylY={qT_xg9z<NbPza#S5_;7-HDWW5RigZ=LV6*
+zC(tYTyWThzXHf4MXBa7hZbsubd?Ryu_#A)%-?VnWgzy8ET!tu|{8#c_&gaH`oCBdA
+zDZ_rb+3zi849gP{1S5P<jk#MGP++DGAy-3vwo{u^X(9-1cLI-eD^5-vRFWj~@&pA;
+zVHMOE7R0Uo3r+HxoApr;N3Ucb6+Fi&Rw>nQWw9>PlG~IbhnpsG_94Kk_(V-o&v7#F
+znra%uD-}KOX2dkak**hJnZZQyp#ERyyV^lNe!Qrg=VHiyr7*%j#PMvZMuYNE8o;JM
+zGrnDWmGGy)(UX{rLzJ*<yAEppP~EY>QEBd(VwMBXnJ@>*F8eOFy|FK*Vi0tYDw;#E
+zu#6eS;%Nm2KY+7dHGT3m{TM7sl=z8|V0e!DzEkY-RG8vTWDdSQFE|?+&FYA146@|y
+zV(JP>LWL;TSL6rao@W5fWqM1-xr$gRci#RQV2DX-x4@`w{uEUgoH4G|`J%H!N?*Qn
+zy~rjzuf(E7E!A9R2bSF|{{U(zO+;e29K_dGmC^p7MCP!=Bz<LU?&i-}KG6X?-t~{t
+z6;cwZkN#6(bfNz)LHYiZ1eLM1bF=-Y%KTGzRGb0MCjXM5S?b4b=q6Yne5@ub&Z1fi
+zwe1K(xpIl(UuqiL&9zbE3--S?_yjh~vM9{@56fnz)vH22_-yvCYe2Y7H${#(Jncbu
+zdEOFD?GkNqW$#j4@v}(bNmkD>q@}&AdF5=rt<!COJnb)nu<w2#Fc9&zR-N5X<)-uZ
+z$<fUbN+So80PB;-k3&vQQgFt#a4A~G5i7YfkwVod(g_caMdbNUgH}RSd$;2i>Cwka
+zTT1A?5o}i*sXCsRXBt)`?nOL$zxuP3i*rm<aImxvw^U@{B*fUS0^1}v7Fr7%=t{5R
+zr{ZxLLkwm{RxNy^ZS6xw>3Gmbmr6}9HCLvL*45d|(zP;q&(v%}S5yBmRVdYQQ24zh
+z6qL2<2>StU$_Ft29Iy<fP{_A}(TLFc`ulnZB85D4f`?3P{(NRH&`r%oRcE}aoRUTu
+zE?7Y|z|k@bRY%JdWY5F(IA^2{CsLJ|)7+Sk)-1LuGjdpW2<~xRpIawD7|b}pzW)Q9
+zAY5MSu{bw_VLh`wPo4Jb7n0QMsV))LK}%s$WqXQ<7NQ-5!+}@QkF+dLPzuz#x@W)<
+znhWO;3yF&C)0P|n)1lp<2aeQ_$@3&mI?kFLSzhC?s<NQdC{FP%I#bp;kORX{l<3x0
+zI8yQp7E^WBY)WEgiAkeUv{*@dstpdRH)q&jD@2v`EidG8QsD}**_mj0v08)ZlDq;v
+z=LqggR_Jz_t>F!6=!@;tW=o8vNzVy*hh}XhZhUbxa&;9~woye<_YmkUZ)S?PW{7t;
+zmr%({tBlRLx=ffLd60`e{PQR3NUniWN2W^~7Sy~MPJ>A#!6PLnlw7O0(`=PgA}JLZ
+ztqhiNcKvobCcB<yMplTfXcPqrYE+vVszVQmm@rg}2{rJGaO7?|y?`3a_S!XcQLG&V
+z?bgXaiD}w%%A$ShO3yHwQZ52?;xk}hq`az4Qz(&ZI4P8rn`^{UhqrR}d!P@Af>el2
+z-N82?4-()eGOisnWcQ9Wp23|ybG?*g!2j#>m3~0__IX1o%dG4b;VF@^B+mRgKx|ij
+zWr5G4jiRy}5n*(qu!W`y54Y*t8g`$YrjSunUmOsqykYB4-D(*(A~?QpuFWh;)A;5=
+zPl|=x+-w&H9B7EZGjUMqXT}MkcSfF}bHeRFLttu!vHD{Aq)3HVhvtZY^&-lxYb2%`
+zDXk7>V#WzPfJs6u{?ZhXpsMdm3kZscOc<^P&e&684Rc1-d=+=VOB)NR;{?0NjTl~D
+z1MXak$#X4{VNJyD$b;U~Q@;zlGoPc@ny!u7Pe;N2l4;i8Q=8>R3<TEv>H{>HU<axH
+zp`GSL-T`v+`h{A=aX;JW4CEU!(+?Uoa0aOL$De+GUOkWsAqa2ZK4FC`K3!1~Zy9HB
+zzvq?1%x_y$*Bv$0)GEimNLh#E5__f1Mpw)(hNBlqy(D20`q=1`jdMVFIk`mBE8>(z
+z%hV2?rSinAg6&wuv1DmXo<vm47<QjMysD@bzHIj93EKq|LsScFN}?1q^I)(oMd!rn
+zn|DubZt_^bCFb75g5Trh|4Qx?zo0F<A>k`5@a3@H0BrqsF~L$pRYHNEXXuRIWom0l
+zR9hrZpn1LoYc+G@q@VsFyMDNX;>_Vf%4>6$Y@j;KSK#g)TZRmjJxB!_NmUMTY(cAV
+zmew<J38CI3YanL~W|fbwxrqJqw<my@*XH*?z?)KSw#4MywnI6A#4U@pFSNEc`Lrv-
+z-S!+OS6bh_zm$&432UozL4&En7L86;ghp^8;$ppb%xO{FV^Pm{yQ`>n7H{z`M3^Z&
+z2O$pWlDuZHAQJ{xjA}B;fuojAj8WxhO}_9>qd0|p0nBXS6IIRMX|8Qa!YDD{9NYYK
+z%JZrk2!Ss(Ra@NRW<7U#%8SZdWMFDU@;q<}%F{|6n#Y|?FaBgV$7!@|=NSVox<B(`
+zIq)S_BbU4&5Y;#+zzGVxaXAWCz*U+(@Q+o!?%YbO5Lnd}NLZ#m2X87gxZsJLNwk+3
+z@~G>lJI4G-G(rn}bh|?m<PI-QoC(rF$EW8<oaZlKv17e{ZZEs5gI5rI>KkaBF$-Yr
+zA;t0r?^5Nz;u6gwxURapQ0$(-su(S+24Ffmx-aP(@8d>GhMtC5x*iEXIKthE*mk$`
+zOj!Uri|EAb4>03C1xaC#(q_I<;t}U7;1Jq<Pun#t0_d*_eJ@mw@913m0*PYiG@}tB
+ztP(s*U6EvObA-KfU!e+*)h*+A8wNY(z9PpR7|ng1RQ75YwD8Ip`2*1~IH(z=Ujxyl
+z<ntP1@(4b<498kKUoYg<(N=o2;8F4n|CejK@H@|3g8~6DMEW~D{f`P>ISVHz3tO{)
+zD(Yu@=>I9FDmDtUiWt81;BeaU{_=es^#QI7>uYl@e$$lGeZ~Q(f$?^3>$<<{n`Bn$
+zn8ba<y1J3mk7QrBkS`^06lBb%XobuZz0Uc3vJW$}oz5rqH-CVXbQ?TYcYWkt$y+%%
+zDGW6>mZlL@6r^RZHV_c5WV7m2(G6X|OI!+04eAnNA5=0v1Z3lxml2#p<Q2Hk_3rET
+z#;|JLdCr%w6PIsdU-R${5=&H%MpF|6*IQEs*~vt<`)osFM7~B}S2*^XM|R%(!bK5x
+z?B98-@YWD?D?WIa89ue2g+&}MCA&<zv{-XU9dkW^Z!-wg1^SV3v?-k+`&iNJ0Tmf1
+z6uA?;4A2J1dJC}17}snGhxuUKB>~Zo57ri;4>;#16sSXXEK#QlH>=b$inEH0`G#<_
+zvp;{+iY)BgX$R!`HmB{S&1TrS=V;*5SB$7*&%4rf_2wQS2ed2E%Wtz@y$4ecq4w<)
+z-?1vz_&u>s?BMrCQG6t9;t&gvYz;@K@$k!Zi=`tgpw*v-#U1Pxy%S9%52`uf$XMv~
+zU}7FR5L4F<#9i%$P=t29nX9VBVv)-y7S$ZW;gmMVBvT$BT8d}B#XV^@;wXErJ-W2A
+zA=Jft<sUW%eIzvD`%|;&1KUO!vBts9$jx)aLl#J~zQpxlFUxMboZ!i0c9Fc`OtVN_
+zc!Oz?NJ1z_+?YXWzG9yyn`e=Y8ro2cgXxj=V=SljU>QR<YtbUwpQ+@vL?uI{$gmcZ
+zYC3@UzzpYKLZewwpeTE~#NkBl55_$s{)OK@ziuA6Ps5h_w}$OMst5l!aNPioCjY)3
+z3|9SgY>L>vNO(!n4mcd3O27bHYZD!a0kI)6b4hzzL9)l-OqWn)a~{VP;=Uo|D~?AY
+z#8grAAASNOkFMbRDdlqVUfB;GIS-B-_YXNlT_8~a|LvRMVXf!<^uy;)d$^OR(u)!)
+zHHH=FqJF-*BXif9uP~`SXlt0pYx|W&7jQnCbjy|8b-i>NWb@!6bx;1L&$v&+!%9BZ
+z0nN-l`&}xvv|wwxmC-ZmoFT_B#BzgQZxtm|4N<cR35n#bARS74OQDTms<32~v8v=`
+z7-caF<C)1AG)W4zO)YE8SJ$Y@<CJ4$G=}`=!37S-py?UnU1Gh2h2n_6&p(Ao5Qqf6
+z=k(-OuAx!R!Y>+|;+(YW&Jtj^g!)iqPG++Z%x0LmqnF875%Ry&2QcCamx!T@FgE@H
+zN39P6e#I5y6Yl&K4eUP{^biV`u9{&CiCG#U6xgGR<Po=AznL^)f6o>Qr)zew;Z%x+
+z-gC>y%gvx<e=sLpgCWdgi6XpJK8=uXJkkm8YE@{r>|dM=OrO`N@P+h2klPtb<Ry(x
+zpu?Xm?4btAWLp$6D_`$o&fb}lDqgV$`64jZuZt*NMiKvp57y55K7Ikao<AXqBElPW
+zh~1j8oF$DxMm1(>YvjS!mNnk4yE0+I&YrSRi?F^plh}hIp_+OKd#o7ID;b;%*c0ES
+z!J))9D&YufGIvNVwT|qsGWiZAwFODugFQ$VsNS%gMi8OJ#i${a4!E3<-4Jj<9SdSY
+z<OXh$_?#e&cT#EB-U!=XwtowFV|9Uhv$sUK3q>&xe|D0V1c`dZv+$8>(}RE|zL{E3
+z-$5Anhp#7}oO(xm#}tF+W=K<zEDOn&&TBZukL{eI>E*3(xxKxhBt-uuJP}`_K#0A<
+zE%rhMg?=b$ot^i@BhE3&)bNBpt1V*O`g?8hhcsV-n#=|9wGCOYt8`^#T&H7{U`yt2
+z{l9Xl5CVsE=`)w4A^%PbIR6uG_5Ww9k`=q<@t9Bu662;o{8PTj<F}p=3(;yTV~Qyf
+zgQDdrLzMjDw7>DBzzbY#tL;$wrpjONqZ{^Ds4oanFm~uyPm#y1Ll3(H57YDWk9TlC
+zq;kebC!e=`FU&q2ojmz~GeLxaJHfs0#F%c(i+~gg$#$XOHIi@<TM;Hv2aC}$s8#Sv
+z+Dd3KT+?=#!iTV?Ms~47n*H>1mA72g2pFEdZSvp}m0zgQb5u2?tSRp#oo!bp`FP}<
+zaK4iuMpH+Jg{bb7n9N6e<k8B#=)v)d%-lnDQKtnG^2KYKtU2;<n>R*NZfgL7QiLxI
+zk6{uKr>xxJ42sR%bJ%m8QgrL|fzo9@?9eQiMW8O`j3teoO_R8cXPe_XiLnlYkE3U4
+zN!^F)Z4ZWcA8gekEPLtFqX-Q~)te`LZnJK_pgdKs)<s7#%|5P$s1t)kN+!Um>Dp50
+zdUq)JjlJeELskKg^6KY!sIou-HUnSFRsqG^lsHuRs`Z{f(Ti9eyd3cwu*Kxp?Ws7l
+z3cN>hGPXTnQK@qBgqz(n*qdJ2wbafELi?b90fK~+#XIkFGU4+Hihn<y_>Wq;{{)1J
+zv*Txl@GlnIMOjzjA1z%g?GsB2(6Zb-8fooT*8b0KF2CdsIw}~Hir$d3TdVHRx1m3c
+z4C3#h@1Xi@{t4zge-#B6jo*ChO%s-R%+9%-E|y<*4;L>$766RiygaLR?X%izyqMXA
+zb|<FVRVPIkP%(S)yIvuu+5z_83buf`qe#ezb);jn)u$oPrWvD(s&~KHbqKNL%cobC
+zN-|C-DK*$CAI~b2Ac6>N=Z-0PSFeH;W6aQ3(5VZWVC>5Ibgi&cj*c%_3=o#VyUJv*
+zM&bjyFOzlaFq;ZW(q?|yyi|_zS%oIuH^T*MZ6NNXBj;&yM3eQ7!CqXY?`7+*+GN47
+zNR#%*ZH<^x{(0@hS8l{seisY~IE*<IWx!UK-u2j(e2O!c*%v`vbRdmnwY3~F@WfqY
+z%qQlFf<s6fB4WlqklvTVl*JK;YI>)BD+R6^OJX}<2HRzo^fC$n>#yTOAZbk<pxtmH
+zJ~q1kaL=GoN56akk-6RD`q2mzV0mH8>4%=Bei=<kddu{Z(hj1<vW)@wW7M&+@6=2s
+zZD&Op_jWe#TTdH<JbSg3bLF85E$EBmVzcroiC)+RvF8h>JEe=o$jm`or0YDw*G?d>
+z=i$eEL7^}_?UI^9$;1Tn9b>$KOM@NAnvWrcru)r`?LodV%lz55O3y(%FqN;cKgj7t
+zlJ7BmLTQ*NDX#uel<G9Op(1@^PULS#3C#Zq5&eylEB%v#D2Qdisi+`5Pk=N?QpqNe
+zn3Q0BprVD+s9yvAi-Ka>GbCY>k+&H*iSK?x-{w;f5G%%!^e4QT9z<_0vHbXW^MLR}
+zeC*jezrU|{*_F`I0mi)9=sUj^G03i@MjXx@ePv@(Udt2CCXVOJhRh4yp~fpn>ssHZ
+z?k(C>2uOMWKW5FVsBo#Nk!oqYbL`?#i~#!{3w^qmCto05uS|hKkT+iPrC-}hU_nbL
+zO622#mJupB21nChpime}&M1+whF2XM?prT-Vv)|EjWYK(yGYwJLRRMCkx;nMSpu?0
+zNwa*<?h%^Uxlo#rhlXX^1ry~0-r)@+JQ4MlP_WRi_c8}Pe;l(#WnThfspZ$^3+`@%
+zmW}tS#o_f`H(V@)Qt__Qwx4kv+ooP8ZrPBV-j<==nbQ*DT}dlBw*|*N7vHSJyQH}0
+zm|S-J1_lheA!DE{g6^Xv;AA#SxCooopboet4w*f2U~sm_9-x1=xp|LI-xxj9006QY
+z1mgxK<wER;C#1B$%?%3n>{0n+Yg6=SR3-S&;<?krxZxGO!Tw^S=d_=26`yQ0@waRw
+z@SmVU&DQEaY5x6V*rbHQm)eLi0+(WkiJ>vq=-lRqN`s9~#)OOaIcy3GZ&~l4g@2h|
+zThAN#=dh{3U<aA#cPR4&ofsaO#bX_do9RRvi_^pV^V=?kpT`)pH$SJl(tC+UO9KU%
+zw*Fj&O-G3~P~VA<unl1F2&AK=52kP@qipFV?Oj1#&{KUN^>N7Xil;nb8@%)wx5t!l
+z0RSe_yJQ+_y#qEYy$B)m2yDlul^|m9V2Ia$1CKi6Q19~GTbzqk*{y4;ew=_B4V8zw
+zScDH&QedBl&M*-S+bH}@IZUSkUfleyM45G>CnYY{hx8J9q}ME?Iv%XK`#DJRNmAYt
+zk2uY?A*uyBA<BiMLU_*M#NCCxjGD{)FKf5%TR%^0(tj%ZEC|pB`lh!G8#P^_7rgl6
+zHD8H9#lPg#uyjB59dckNv=l!fBEB{M6vF+Eh;w^K5=@MUOHXMhDuV2p%rP)^5%vfh
+zn^LIqAcivg*z)=%xYv);q@8+WaMY5huI1GOD-9N$`j-dE7hH0tcwmf1#`ceO!mOHP
+zCyw-!`T<sF+;H*u*8-P5M#r^Q!nW)d+HW6<4*Bj<y{xwPJ5aVv2w6&T;_`2#jdBoY
+zJBy`lJrSwb+PH8(hrh;>=nlYjkcNPMGi*552=*Q>%l?gDK_XYh<zL<ke_eZ$ot|PF
+zZVgv}4Sq{EZ4ogcRofdp&JliroypZ_e}$4iKs?X|D!2Ac$5!nj(ZskdL0_wd=BN37
+zZG}#$eUO#D_A!-?os3(Syu!QKCTTw$pZe08wZZN8KnynfmowC;MZ_o?kig}nxLgNw
+zM?*Zz05oY7v>*Rya_c)ve{=ps`QYE0n!n!)_$TrGi_}J|>1v}(VE7I~aP-wns#?>Y
+zu+O7`5kq32zM4mAQpJ50vJsUDT_^s&^k-llQMy9!@wRnxw@~kXV6{;z_wLu3i=F3m
+z&eVsJmuauY)8(<=pNUM5!!fQ4uA6hBkJoElL1asWNkYE#qaP?a+biwWw~vB48PRS7
+zY;DSHvgbIB$)!uJU)xA!yLE*kP0owzYo`v@wfdux#~f!dv#u<u)VAl7h<(Ox?_8|-
+zieXQ0tIl#N(#Ubvm=#=RRW-l$qV+J9qkYE;+MW4sd~tDdcA{`>Nc_$SF@Qq9#3q5R
+zfuQnPPN_(z;#X#nRHTV>TWL_Q%}5N-a=PhkQ^GL+$=QYfoDr2JO-zo#j;mCsZVUQ)
+zJ96e^OqdLW6b-T@CW@eQg)EgIS9*k`xr$1yDa1NWqQ|gF^2pn#dP}3NjfRYx$pTrb
+zwGrf8=bQAjXx*8?du*?rlH2x~^pXjiEmj^XwQo{<CPx+@82|8@X@<D@6UUi%p$ehj
+zhXQlcfF2phkkCDxVFxfI?!~Bx<^Y(i{JB%4bav+Pbd2%<Y>`NMonBN=Q@Y21!H)D(
+zA~%|VhiTjaRQ%|#Q9d*K4j~JDXOa4wmHb0L)hn*;Eq#*GI}@#ux4}bt+olS(M4$>c
+z=v8x74V_5~xH$sP+LZCTrMxi)VC%(Dg!2)KvW|Wwj@pwmH6%8zd*x0rUUe$e(Z%AW
+z@Q{4LL9#(A-9QaY2*+q8Yq2P`pbk3!V3mJkh3uH~uN)+p?67d(r|Vo0CebgR#u}i?
+zBxa^w%U|7QytN%L9bKaeYhwdg7(z=AoMeP0)M3XZA)NnyqL%D_x-(jXp&tp*`%Qsx
+z6}=lGr;^m1<{;e=QQZ!FNxvLcvJVGPkJ63at5%*`W?46!6|5FHYV0qhizSMT>Zoe8
+zsJ48kb2@=*txGRe;?~KhZgr-ZZ&c0rNV7eK+h$I-UvQ=552@psVrvj#Ys@EU4p8`3
+zsNqJu-o=#@9N!Pq`}<=|((u)>^r0k^*%r<{YTMm+mOPL>EoSREuQc-e2~C#ZQ&Xve
+zZ}OUzmE4{N-7cqhJiUoO_V#(nHX11fdfVZJT>|6CJGX5RQ+Ng$Nq9xs-C86-)~`>p
+zW--X53<fjk))~(Y7xt;2-3Mp_sh^OGttxT8JXcE>J`O~vS{WWjsAuGq{K#8f#2iz`
+zzSSNIf6;?5sXrHig%X(}0q^Y=eYwvh{TWK-fT>($8Ex>!vo_oGFw#ncr{<A-F%$p&
+zc|DGKq;$_R8E0EodRv?$JW^Po<Ex>vmERi^m7lRi%8Imph})ZopLoIWt*eFWSPuBK
+zu>;Pu2B#+e_W|IZ0_Q9E9(s@0>C*1ft`V{*UWz^K<0Ispxi@4umgGXW!j%7n+NC~*
+zBDhZ~k6sS44(G}<L8r7U{uvHTXWzD_JuHzxZ-XY|N?p*qndC=U0c*Cl@BtNW7i{&R
+z-Me?NHPa(a(vIZUFSMee2{hPx14nk+e_C|^?Bd;r8#<I5LFO<RoqQ`w{VLAmJAmJ-
+zf-f}_R{!XhIih6nYvLOxM^4vM+l^NaQ|ty{<XIb6;HnNe&IB3k;~%;YB%OMx`D8+)
+z&)Zf1-i7=>*zg||X#9Weto;u*Ty;fP!+v*7be%cYG|yEOBomch#m8Np!Sw`L)q+T`
+zmrTMf2^}7j=RPwgpO9@eXfb{Q>GW#{X=+xt`AwTl!=TgYm)aS2x5*`FSUaaP_I{Xi
+zA#irF%G33Bw>t?^1YqX%czv|JF0+@Pzi%!KJ?z!u$A`Catug*tYPO`_Zho5iip0@!
+z;`rR0-|Ao!YUO3yaujlSQ+j-@*{m9dHLtve!sY1Xq_T2L3&=8N;n!!Eb8P0Z^p4PL
+zQDdZ?An2uzbIakOpC|d@=xEA}v-srucnX3Ym{~I#Ghl~JZU(a~Ppo9Gy1oZH&Wh%y
+zI=KH_s!Lm%lAY&`_KGm*Ht)j*C{-t}Nn71drvS!o|I|g>ZKjE3&Mq0TCs6}W;p>%M
+zQ(e!h*U~b;rsZ1OPigud>ej=&hRzs@b>>sq6@Yjhnw?M26YLnDH_Wt#*7S$-BtL08
+zVyIKBm$}^vp?ILpIJ<dp3ooa+cndqkSQ3UA!R3}}yC4bxfeA6S8LO9hE~vx|Yi68@
+zNr?jvc2@*eXxky?<YJ*9EIA;CdIbdqd2SQpx9uQtXD#8(J3Vt<5%NQ*o02|K+6bY0
+z;sT8vn@o8e%0|hi^#v|34DqvO58NzmQDAp!LXk*AcbC{I;vTjGcE|?=;e?ESe2XV{
+zRUgP)(rNkqS#Yhf8ziDbO6ep!K;GEwl%7iVkc_KR&%z8}O~7*V=?=DsoCZuiU?(w*
+zHV&rJy*1isBFt8he4l73U>etMkW1VtIc&7P3z0M|{y5gA!Yi5x4}UNz5C0Wdh02!h
+zNS>923}vrkzl07CX`hi)nj-B?#n?B<Q|A1|76WLZEE&m-hhR<X$5TK&X`9{ZnvFM%
+zu_h)S<XvC@S;kBiJJBt>J2Vk0zOGsF<~{Fo7OMCN_85daxhk*pO}x_8;<dX=<+?Qg
+z#r>-h>}pcw26V6CqR-=x2vRL?GB#y%tYqi;J}kvxaz}*iFO6YO0ha6!fHU9#UI2Nv
+z_(`F#QU1B+P;E!t#Lb)^KaQYYSewj4L!_w$RH%@IL-M($?DV<J?Z?(&T(jN~E*h4k
+zjT$bEE;1X$dKstuB%kL?N}i|18#(T<X%h{nQolXBTKBIbWb9u%<<*n%KAruYiv41M
+z(BV$!uq)MDNOGLcUNoFp1O|t~h!*SC05{|sLBD8s0{dGDvJFAn@fT!9#{nXqzUzhA
+ze1Wde$2)jpHttd7Vt%dJc<P1PQ_QtXhR)w~A<pGWwkJB}X>@lGj%3ZgVdHe^q>n(x
+zyd5PDpGbvR-&p*eU9$#e5#g3-W_Z@loCSz}f~{94>k6VRG`e5lI=SE0AJ7Z_+=nnE
+zTuHEW)W|a8{fJS>2<PuTj25j+DhXW(hd~r?Xh^MxKJCimxGsmwzKdi%?KCIX3{&)m
+zZ0nj+u3m}byL|gc@7el5sG0YZn703R7lHPF8j}A(O#keT{0lwVD2_|_3ZlF(l>TaX
+zuRoa=LCP~kP)kx4L+OqTjtJOtXiF=y;*eUFgCn^Y@`gtyp?n14PvWF=zhNGGsM{R-
+z^DsGx<p*94-ySu{F;3A%Gw(MuWcO5hc=1Fn6S6X-V`dR&jLKv;9Ov9;sNX7hCxxgJ
+z&)GGfI53?p5EUqj1kN{nL`cLj*Ny6Bb93QS#TWv+m?{)VTv#I?UM_EBDq&18Y1rBF
+zqj?j71ovsu1jc{FMqN`ZbtUe%y6G-sBQrAwb$+jv1%VjW_k<x<OD8=u&hN{;<-bn?
+z@rS2|Sdn<vp_N-gJ^Y{ISs}UnqwiH29Bq1>toDtx+g^hZi@E2Y(msb-hm{d<UuZ5B
+zF*RQXF90n8n5t!zMgUN!64)`l%MNqK%g0zqOLUu+a4FnHHt`Hf2k1Gsi_Mzb@Z^^=
+zxAOB&;5(e``nO6J%C~>WiHdoQvdX88EdM<JUQYg{sbyjNxshlKux2o|_*{in1UQ?k
+zIs#lx9Gw8xBIYJWRwj=B5<C|bZKqjrjCXeSc*C*6yaFuS2rWqx!(UR;j8e_%Q^I^0
+zj8p#CwJD3Wf>>^DS#f}&kCGpPFDu*KjEpv$FZtLpeT>@)mf|z#ZWEsueeW~hF78Hu
+zfY9a+Gp?<)s{Poh_qdcSATV2oZJo$OH<l8JXo;z<PcbGCYR0J9l8&nxRHHiz--^d2
+z8~J{Itr^Z$OtgTuQ6<JD;bmdLugNLaS^G}k$rEM-rW(6=U_mp(C><Q9gp1ZnUy!F0
+zwAdk5rFR<Ua`+2&K+(bk94CxMi5A;34dG4kTAucma$dNI_rA^e+RlExjm~4DcUPQV
+zUJ~3S<PG_W`@twX<bCoilw=BO0H-v<O^nbfi=xlVu&Cv1VWy=dd07F7ytH8mMU5a{
+zu#nKXVN5wbwo#QA!H4;0Ko9C5V@W}ba=cKzOSE;+-oDrv!(>~K@QzE2kCADZ@xX(;
+z)0i=kcAi%nvlsYagvUp(z0>3`39iKG9WBDu3z)h38p|hLGdD+Khk394PF3qkX!02H
+z#rNE`T~P9vwNQ_pNe0toMCRCBHuJUmNUl)KFn6Gu2je+p>{<9^oZ4Gfb!)rLZ3CR3
+z-<Jj6ofd&sk<LvELH)*PRT^`1cMjr9jc63Nl_{PuyZKn7*LCLu65p@97#0uR(E?9W
+zX`bZ}=9-Z$>o&b;Bh>51JOt=)$-9+Z!P}c@cKev_4F1ZZGs$I(A{*PoK!6j@ZJrAt
+zv2LxN#p1z2_0Ox|Q8PVblp9N${kXkpsNVa^tNWhof)8x8&VxywcJz#7&P&d8vvxn`
+zt75mu>yV=Dl#SuiV!^1BPh5R)`}k@Nr2+s8VGp?%Le>+fa{3&(XYi<NKc?C)>~{k{
+z-u4#CgYIdhp~GxLC+_wT%I*)tm4=w;ErgmAt<5i6c~)7JD2olIaK<AIVJAZuKkE<l
+z4Bm0%W2+6b=&ak;y7abRJFYhw&)H;bM_b*mAs4cDPr8CDbB=hVJk3YURR<;YVVe}i
+zH4VPi#sF`j{_5B)vN4u|e)jM(|JKI}{da==@2O^OXJqx+GG_R^W?=2&Wa0X`P-$%<
+zWMpLG<Rk~M1(^Mh#54JvEUXHm_-Lca3M)$jz5TrWVT^)HDZzq*6uqcRSEO&-H)J!v
+zox0RpNqqerD+o-nP(VP(;6Ij>8by{u-!tZWT#RQddptXRfEZxmfpt|@bs<*uh?Y_<
+zD>W09Iy4iM@@80&!e^~gj!N`3lZwosC!!ydvJtc0nH==K)v#ta_I}4Tar|;TLb|+)
+zSF(;=?$Z0?ZFdG6>Qz)6oPM}y1&zx_Mf`A&chb<i`Nr1_JKCJ^T_*s={KuqB@lhf>
+znSERvt9%wdPDBIU(07X+CY74u`J{@SSgesGy~)!Mqr#yV6$=w-dO;C`JDmv=YciTH
+zvcrN1kVvq|(3O)NNdth>X?ftc`W2X|FGnWV%s})+uV*bw>aoJ#0|$pIqK6K0Lw!@-
+z3pkPbzd`ljS=H2Bt0NYe)u+%kU%DWwWa>^vKo=lzDZHr>ruL5Ky&#q7davj-_$C6J
+z>V8D-XJ}0cL$8}Xud{T_{19#W5y}D9HT~$&YY-@=Th219U+#nT{tu=d|B)3K`pL53
+zf7`I*|L@^<akj8#_&*rXa0J-fn>dPEIDJkI3_oA9vsH7n7O}Ja<law4{uj~>R{G~8
+zfi$?kmKvu20(l`dV7=0S43VwVKvtF!7njv1Q{Ju#ysj=|dASq&iTE8ZTbd-iiu|2&
+zmll%Ee1|M?n9pf~?_tdQ<7%JA53!ulo1b^h#s|Su2S4r{TH7BRB3iIOiX5|vc^;5(
+zKfE1+ah18YA9o1EPT(AhBtve5(%GMbspXV)|1wf5VdvzeYt8GVGt0e*3|ELBhwRaO
+zE<IB-Cn|oj1SDl{xp8zad#YcCdtrs+9}i$s<*@)jbR<MzYyAq(U%KqfE2&l%Q`Tlq
+zFFOj{{w{t{I93tgk%#X+S#qY@HW9M}>|yMhl;Bm?8Ju3-;D<d0gaE$FN@5itD4g&V
+zgQbZVdU+i-wHuALtd^lmCPv@8>NnxM3Roelg`^!S%e({t)jvYtJCKPqN`LmMg^V&S
+z$9OIFLF$%Py~{l?#ReyMzpWixvm(n(Y^Am*#>atEZ8#YD&?>NUU=zLxOdSh0m6mL?
+z_twklB0SjM!3+7U^>-vV=KyQZI-6<(EZiwmNBzGy;Sjc#hQk%D;ba<AuKL_OVlNJ8
+zzJ~Op&$U`bGuaaEPGBR);C}uHL4psgioidnP6KL62R)y#$^To}F#LDexcw6-48nGH
+z&YxHT*vkPdY(F<p{z3^E)4$-vMrqU*T?nO|IF@Z74ohmQ)xMgvN&|_c7OfAIO#XAt
+zaL2E?e(>y$v#zczt%mFCHL*817X4R;E$~N5(N$1Tv{VZh7d4mhu?HgkE>O+^-C*R@
+zR0ima8PsEV*WFvz`NaB+lhX3&LUZcW<oTbF57ud5qxRCovnmT%0KJe~XJK}Gj*7_g
+z0&W(W*y&*@eIfyjN}|^Vg@Xk+l%k}&LK6+_!9US75W3aKwKA7N7eaP%(H`-gc7jx_
+zq4R52zNWM^&eZyQ!NoQEuNB3ura1z?O0n};Cx@E>WJJrG7ZjQrOWD%_jxv=)`cbCk
+zMgelcftZ%1-p9u!I-Zf_LLz{hcn5NRbxkWby@sj2XmYfAV?iw^0?hM<$&ZDctdC`;
+zsL|C-7d;w$z2Gt0@hsltNlytoPnK&$>ksr(=>!7}Vk#;)Hp)LuA7(2(Hh(y3LcxRY
+zim!`~j6`~<bW*$8$<<~?JS18Peo3DUOk=IRLX_ufFFmtupg*V26|}Y8;Di!sKr{px
+zU!wn|6erEM{4t*~C;Z!(|BF)mSIk8}_js-C0LEmZCZ+%vYv=#^U(wOd%<)qwWIx%%
+z#P)x%MYM{N-K;vs`}xdVg@cSV9;IsBd_FC#oCthSxj&+MND|t@FCnpb@*2FC0f*D2
+z?G^cWl=jPk-fVXO^6GAO{DQL0%m8{~;|J@R4tRbB$asqPCv~(P@*H}1{&>B+sRBv4
+z<mz=pCM?&uNVBoEf!$<Jl`Auv$WWg;Z6o}=Da&vNrmd(0r*Nq_WttlLt&FC;g7G}~
+zz%kSd_><#B{@38kH;sLB4eH2+8IPWklhd25r5j2VR}YK$lpZ%7eVF5CBr#~=kUp`i
+zlb+>Z%i%BJH}5dmfg1>h7U5Q(-F{1d=aHDbMv9TugohX5lq#szPAvPE|HaokMQIi_
+zTcTNsO53(oX=hg2w!XA&+qP}nwr$(C)pgG8emS@Mf7m0&*kiA!wPLS`88c=aD$niJ
+zp?3j%NI^uy|5*MzF`k4hFbsyQZ@wu!*IY+U&&9PwumdmyfL(S0#!2RFfmtzD3m9V7
+zsNOw9RQofl-XBfKBF^~~{oUVouka#r3EqRf=SnleD=r1Hm@<buigJ1Zgh}+47#N}=
+zA;FL!#2C23SP8!!apVBYzJ3fxxO$`OHLK}}G5fYfk`4&0f}B0=8mk!Hn*#TLB6~0w
+zVDX$-aLCK?dMa|C-1DpnLg1Y;dn>~`y8U7R)w16fgHvK-6?-TFth)f3WlklbZh+}0
+zx*}7oDF4U^1tX4^$qd%987I}g;+o0*$Gsd=J>~Uae~XY6UtbdF)J8TzJXoSrqHVC)
+zJ@pMgE#;zmuz?N2MIC+{&)tx=<l|D;tZlZQyALE=2ji-YLMO_Re>7A%$yq-{GAzyz
+zLzZLf=%2Jqy8wGHD;>^x57VG)sDZxU+EMfe0L{@1DtxrFOp)=zKY1i%HUf~Dro#8}
+zUw_Mj10K7iDsX}+fThqhb@&GI7PwONx!5z;`yLmB_92z0sBd#HiqTzDvAsTdx+%W{
+z2YL#U=9r!@3pNXMp_nvximh+@HV3psUaVa-lOB<kAlb5{e|+s3GRS<WGPVcKv}ufw
+zsm@L)j21fBT_PZS23MbS<jhcW_7ZmN8)9;FrTXBPApWUlG*$QXnli9;L`ce(&0uB<
+zK<7{*B6<8;LFx#98e~1Ipcz1=a?doj&-~;#cS-Pk$4@XT{MS|f&qHIFc^#?##d3%L
+zF_vTgzyFp0k4KXHb4gb>ekVuMf1RUd26~P*|MLouQrb}XM-bEw(UgQxMI6M&l3Nha
+z{MBcV=tl(b_4}oFdAo}<FNiIc;2!TENsPY_{u&vbEN_gH<2W2+zqz;HID|PS7~k-+
+z?orh+BjNq^{SNz=&lq$2>WX$~$Mj-z70FowdoB{TN|h<oa=NkAgwvViq7Zbbs20=(
+zjFf3J3IkKmvhA(1BFfTs0<}wn4tMNcYw*#d5+3#m^D7`Q>2BdYs?$imcj{IQpEf9q
+z)rzpttc0?iwop<FB}NoH|4vN8(!wS{7iPRZAtgAKfwm99$&fQSncFCAHTtkEGq%pm
+zWTY7<`y7xseX%vxnS$7Cg0<;j2&4>SmEoB&V!1aoZqEWEeO-MKMx(4iK7&Fhc(94c
+zdy}SOnSCOHX+A8q@i>gB@mQ~Anv|yiUsW!bO9hb&5JqTfDit9X6xDEz*mQEiNu$ay
+zwqkTV%WLat|Ar+xCOfYs0UQNM`sdsnn*zJr>5T=qOU4#Z(d90!IL76DaHIZeWKyE1
+zqwN%9+~lPf2d7)vN2*Q?En?DEPcM+GQwvA<#;X3v=fqsxmjYtLJpc3)A8~*g(KqFx
+zZEnqqruFDnEagXUM>TC7ngwKMjc2Gx%#Ll#=N4qkOuK|;>4%=0Xl7k`E69@QJ-*Vq
+zk9p5!+Ek#bjuPa<@Xv7ku4uiWo|_wy)6tIr`aO!)h>m5zaMS-@{HGIXJ0UilA7*I}
+z?|NZ!Tp8@o<g6{t!6GGpEZ3+xJO<~FK>-lnyde*H+@8IHME8VTQOGh96&XX3E+}OB
+zA>VLAGW+urF&J{H{9Gj3&u+Gyn?JAVW84_XBeGs1;mm?2SQm9^!3UE@(_FiMwgkJI
+zZ*caE={wMm`7>9R?z3Ewg!{PdFDrbzCmz=RF<@(yQJ<VyM+ly^hkKwrU?N(EcGTG)
+zusbNv5i$F3@Zf=?+&aeDOWDQ7$Qe9+B5{<3u0W4YeBR!LFJjuu&@SMl|F6jRfqiyz
+z{O`I${Euua!vE}0|0A#|Qib%yQO5k~F=XS~vL;+>_A6?PCd_MdUf5vv6G#9Mf)i#G
+z($OxDT~8RNZ>1R-vw|nN699a}MQN4gJE_9gA-0%>a?Q<9;f3ymgoi$O<?iymZH(Er
+zNGvX8A0}*i-nw7954=`Bwhd<ZUjO(yu}|0@?)GI5gP?*)IHp?Eg%^jP>I!=aE6Elw
+z2I`l!qe-1J$T$X&x9Zz#;3!P$I);jdOgYY1nqny-k=4|Q4F!mkqACSN`blRji>z1`
+zc8M57`~1lgL+Ha%@V9_G($HFBXH%k;Swyr>EsQvg%6rNi){Tr&+NAMga2;@85531V
+z_h+h{jdB&-l+%aY{$oy2hQfx`d{&?#psJ78iXrhrO)McOFt-o80(W^LKM{Zw93O}m
+z;}G!51qE?hi=Gk2VRUL2kYOBRuAzktql%_KYF4>944&lJKfbr+uo@)hklCHkC=i)E
+zE*%WbWr@9zoNjumq|kT<9Hm*%&ahcQ)|TCjp@uymEU!&mqqgS;d|v)QlBsE0Jw|+^
+zFi9xty2hOk?rlGYT3)Q7i4k65@$RJ-d<38o<`}3KsOR}t8sAShiVWevR8z^Si4>dS
+z)$&ILfZ9?H#H&l<RT2S~_Jj4$4(IRHJFV0?A!G0Qhg^SAVSGNU@RS<f${jo1F-$bS
+zyW`W1oDY=>umngpj7`|rKQQ`|tmMmFR+y-9PP`;-425w+#PRKKnx7o-Rw8;}*Ctyw
+zKh~1oJ5+0hNZ79!1fb(t7IqD8*O1I_hM;o*V~vd_LKqu7c_thyLalEF8Y3oAV=ODv
+z$F_m(Z>ucO(@?+g_vZ`S9+=~Msu6W-V5I-V6h7->50nQ@+TELlpl{SIfYYNvS6T6D
+z`9cq=at#zEZUmTfTiM3*vUamr!OB~g$#?9$&QiwDMbSaEmciWf3O2E<mlP_PonDwt
+zyitcRzTVrxyJMiqOZ6|7#G@nv5X=6&i;>8?oE0ApScg38hb&iN%K+kvRt#d))-tr^
+zD+%!d`<L4%gYWIkY!vD!A?&@isi9mjq}hc5uLusOi**W156CB;6jndj83!M&a=e4K
+zV{K2_%pB}vEiuAw60U0jUrMlCDCQLmYx75m`l(uEE8=2*7U?XVZesIds6ZgImrC6J
+zaSGNgykYte(u*RGC_Cdgw_=To1Sk<7c@waaCe^q4t!2!@1+<vcCZJJd`WP{XR`nxw
+zGu<m<ZH}qgdl57!HcrTLPnp>i!OOE3in0Q_HzNXE!JcZ<0;cu6P_@;_TIyMZ@Wv!J
+z)HSXAYKE%-oBk`Ye@W3S<fT|RJJ2x9j}N_gm*>hYu-bfC<JlS4ISeU0#72JEq&iV@
+z);;bzD{y$YwCJZhLJpC1#?j@p;n13~AR-U_7}H;)tO$ka&g;YU0hclMs2jggs@V)}
+z1ctUKqL*50yB=^24iD^`6e#NM3t6q_UJr0(0eheaY{0bzc8rmE8>AZ}1|J16hFnLy
+z?Bmg2_kLhlZ*?`5R8(1%Y?{O?xT)IMv{-)VWa9#<mvE`6Fsm;~;S~jwikf)Rjguu$
+z5vQddW;F{QVK_+$;)+G^5Vmb(r-Npc&G#KXM)uo^^@C#o|I{V8-x8LCrE4E&Qq(N-
+zMS66xhsVfaLJl|yc8xV__In+|p9mrG(%HWN_C^hqh)+P9$S6+nJmaAfIxP%v9WfYQ
+zL5;Uu-6T=cz->1pKH|oVRm4!lLmls=u}Lxs44@g^Zwa0Z_h>Rk<(_mHN47=Id4oba
+zQ-=qXGz^cNX(b*=NT0<^23+hpS&#OXzzVO@$Z2)D`@oS=#(s+eQ@+FSQcpXD@9npp
+zlxNC&q-PFU6|!;RiM`?o&Sj&)<4xG3#ozRyQxcW4=EE;E)wcZ&zUG*5elg;{9!j}I
+z9slay#_bb<)N!IKO16`n3^@w=Y%duKA-{8q``*!w9SW|SRbxcNl50{k&CsV@b`5Xg
+zWGZ1lX)zs_M65Yt&lO%mG0^IFxzE_CL_6$rDFc&#xX5EXEKbV8E2FOAt>Ka@e0aHQ
+zMBf>J$FLrCGL@$VgPKSbRkkqo>sOXmU!Yx+Dp7E3SRfT`v~!mjU3qj-*!!YjgI*^)
+z+*05x78FVnVwSGKr^A|FW*0B|HYgc{c;e3Ld}z4rMI7hVBKaiJRL_e$<k+t<^`D)J
+zEhcFT+>rxDW^8!nGLdJ<7ex9dFoyj|EkODflJ#Xl`j&bTO<I#P8edX2Zurtkc%j^@
+zNt6$0k5j7Tz*Hvqfi_&6#Q9+R)Fv6`GmW+`8bq@}anEonN&wkBMSbC3p65Q!BQJn9
+z($6ofVPsfai#?XWp7#{34OEeYG<ZeV`;e33{@dz|B}sgh&`J@Iq}UpnS6~gr0^_2`
+z<OPZ;lTV0rmf6o448!Uqt;aNgDOUMFk-WHp5yxc_@Pw(=_HnwV*fc`$ZOS^5Tv^Xj
+zs6|mx8FjhE6;^Q`ZD8?b*C=D)QP^dT)L|ZTke)O$7uVN>%=$v)c+gJsLK_%H3}A_}
+z6%rfG?a7+k7Bl(HW;wQ7BwY=YFMSR3J43?!;#~E&)-RV_L!|S%XEPYl&#`s!LcF>l
+zn&K8eemu&CJp2hOHJKaYU#hxEutr+O161ze&=j3w12)UKS%+LAwbjqR8sDoZH<g6`
+zeO;HbwrZ9reV{8OM|L-k?0OY=6?byB5<#Ri|6=ZM<cbTpfiMCe6D0+uuN~Snj^GI6
+zBGP94F2>nD<cul@`WjtmWkT9y3u`g7Ep4O>=m0(p62!zg<Af@s3vh7(o9SiY*ZKN>
+zxt!Sj65S<M*Zjht+%5QyX@dTS`ynS|*dw2j79o<R`%(HG^UA0FiEur$J4e>?6WPmm
+zL&U9c`6G}T`irf=NcOiZ!V)qhnvMNOPjVkyO2^CGJ+dKTnNAPa?!AxZEpO7yL_LkB
+zWpolpaDfSaO-&Uv=dj7`03^BT3_HJOAjn~X;wz-}03kNs@D^()_{*BD|0mII!J>5p
+z1h06PTyM#3BWzAz1FPewjtrQfvecWhkRR=^gKeFDe$rmaYAo!np6iuio3>$w?az$E
+zwGH|zy@OgvuXok}C)o1_&N6B3P7ZX&-yimXc1hAbXr!K&vclCL%hjVF$yHpK6i_Wa
+z*<Rda^MN8#r#%H(uhk!|+(Xdsw2E^5cUpnFp8p1^_KFVpjUj=6sF40s6^Zu$9=(bF
+zx1x^nKdB2b8!ICz8ygEJ+y4>CMg1RAH1(EuuA01@lA$sM<OVE;c)%cNQLi9uaS;hG
+z%fi;i)%@4^r8O+Wz2GPMFlZFnH;_-_U9)NAegHj_!}O-ZO`FT{#><S(uSx^)-K{gT
+zhG&r*35&meRW|1;vN}suvoTt-WY!oM-loV8;oR{IcSbtH!As;82qoT?HqV9V3*~qm
+z!SuufxJRefmX+!kF&rvO-e(?VCk%)$MRmimz$37siP-FuaN<K+5pNn#@=eC8%!@nb
+z2*5!qsZ<fp+A*NXf=8**@y(*g7NiBCiEV7bSE-BMr;5Zd;AV+}D!T7#a7AZhy$tZ}
+zBZj0LQc#mui!Lo2Q3KNe2agi@n?}tiW0Rj<VeQ<_*D6y|ViQ@=M%oDn5H>fe*s@9-
+z$jNWqM;a%d3?(>Hzp*MiOUM*?8eJ$=(0fYFis!YA;0m8s^Q=M0Hx4ai3eLn%CBm14
+zOb8lfI!^UAu_RkuHmKA-8gx8Z;##oCpZV{{NlNSe<<V1a7ju;v(TY8|0upX`)YP)i
+zhF9S0sKf|T)6o+<$QQ8snYX%z2pId%K2VdBjyrL|U&7n?j2gqBIlgc7sqRmR3rF|l
+zlUaMtZ*=q~vwXXK9=bFWx14^H@c)%dSINC6uKh#1>i;9!MfIN!&;JI-{|n{(A19|s
+z9oiGesEN<ynV})!iaH~auE<DSv%{<&k~X$kQz2b-qcNkA8P@0{SIU`uY<?@NmTQBx
+z)D?^>cLf@NN^9R0uIrgg(46r%kjR{0SbnjBqPq()wDJ@LC2{kUu_j$VR=l`#RdaRe
+zxx;b7bu+@I<Nh=^5@s63-0S!f#dfXn@}AC1>ntWaV$si1_nrQpo*IWGLBhhMS13qH
+zTy4NpK<-3aVc;M)5v(8JeksSAGQJ%6(PXGnQ-g^GQPh|xCop?zVXlFz>42%rbP@jg
+z)n<qUy~a=5h*jh6P7t^JBt^vIyENcV7ST}KUA-3{?3CB)-Fh4a#gMRWaLCBu<v>)%
+zM9anq5(R=uo4tq~W7wES$g|Ko<i2Il^N$GIC?!+;wqh32G+daBXSzA(l7+`)WY5H*
+zxN4$-v5B6xdBXsPjBQ?{pU&2{p1fGEo~A^$<7<6Ai9r_XJLEi2ERS5-WM=rJMwjp>
+z1iNIw@-{x@xKxSXAuTx@SEcw(%E49+JJCpT(y=d+n9PO0Gv1SmHkYbcxPgDHF}4iY
+zkXU4rkqkwVBz<{mcv~A0K|{zpX}aJcty9s(u-$je2&=1u(<Ijk*osoSbRG#RG2dxi
+zY2dIgjpsHFWw4YgUuLN}C3yiVDS7TfH_01AHBUEe$&x)yg`w@~!r_*o_*~bpU7c<5
+z`bmK&NU6Nw_v-jDi5@dldK4Fn1A<6r>e#Q~UA{gA!f;0EAaDzdQ=}x7g(9gWrWYe~
+zV98=VkHbI!5Rr;+SM;*#tOgYNlfr7;nLU~MD^jSdSpn@gYOa$TQPv+e8DyJ&>aInB
+zDk>JmjH=}<4H4N4z&QeFx><vCqo(8;VBNf?4{-ejyJD7h1Z5Qh!VF^s0~(Sx+W_U{
+zR};ybxF{rNR6jf3&Uli%SD1<DGAon!MxCaTjg2UoiPv{%y|HIy7wF&Vh+2it<&g@k
+z2+Wf#)mx-UNsAjpU<5>1VPY8GU&^1c&71T*@2#dINft%ibtY(bAm%<2YwPL?J0Mt{
+z7l7BR718o5=v|jB!<7PDBafdL>?cCdVmKC;)MCOobo5edt%RTWi<zJmle+?jwNYxN
+z4^6|EAjKcb86Lhb2TiEBh#*!<VO%f-!t(A33YL(fW`@*JF%L#%9n~L_x_&@iQ8p+r
+z50!J0d4(u}33+T-j40yL1x4WL)VTLI3<|eCyY3_SBtK8>ReAMaIU5X9h`@El0sR&Z
+z7Ed+F<Hz;iLDs#Hc0AY<Bv9{VG$$}Nxol9pHZ;R^PVSOq1+c`wf56t4>iyA+QAyWn
+zf7=%(8X<IsS*x5)IZjAvYsetv<jbdR10P8%td<*r6IM&L5LRrcOf|!8RQAgg6~$_=
+zBSd>pcS*C4^-L24TBUu%0;@s!Nzy{e95qjgkzE<W5xLBBDYXZDXN}?0z#DvAb||%H
+zZPS{|8~$Dai+w3|r0z;7J8SaSbF0|4F}$?B9(zK4Hfql>lf0#ou`sYng<}wG1M|L?
+zKl6ITA1X9mt6o@S(#R3B{uwJI8O$&<3{+A?T~t>Kapx6#QJDol6%?i-{b1aRu?&9B
+z*W@$T*o&IQ&5Kc*4LK_)MK-f&Ys^OJ9FfE?0SDbAPd(RB)Oju#S(LK<CirA2f_*u2
+zok`__!UM2k24u<34N&n2<rv2c5C+LG1_2&glf5C-MnxH;!hzUTv-tAoF?gV=0tG&*
+z&3NTXW=(G6=cQ0qDpT;#Hy7t96N4?Q={0R{&UH=JEWgy<75@6brLBmih;_W+NcLKU
+zn<HoD>)?EVandS1qb#KR;OP|86J?;TqI%E8`vszd&-kS%&~;1Als=NaLzRNnj4q=+
+zu5H#z<eB8n3vpKCZ_UBe2i$XZJvzC|oStL%r*N4lp0t3D`s9hT%+m%jPcLdrJAA8K
+z_Xy5FTlYi&>)BDKHo1EJTC?Cd_oq0qEqNAF8PwU7<g1n3gpVtS#>fK!-WwVEp4~4g
+z3SEmE3-$ddli))xY9KN$lxEIfyLzup@utHn=Q{OCoz9?>u%L^JjClW$M8OB`tx<B9
+zZzQvx^C^)R6f_#j34$T{qWzMIebqUHU#Mm4dIX;v?G*C~teYh!pha7{DB@cX4KxPS
+zH^Q;NkvbuF4d_@se8XmvFleR*sC@ep>g4r6Q-6UlVx3tR%%Z!VMb6#|BKRL`I))#g
+zij8#9gk|p&Iwv+4s+=XRDW7VQrI(+9>DikEq!_6vIX8$>poDjSYIPcju%=qluSS&j
+zI-~+ztl1f71O-B+s7Hf<J;>>AZ#}DNSf`7C7*)%(Xzf|ps6Dr7IOGSR417xsU=Rxb
+z1pgk9vv${17h7mZ{)*R{mc%R=!i}8EFV9pl8V=nXCZruBff`$cqN3tpB&R<?rJ^^G
+zLU#yZbVti(nuC|2|IXia=NN6mqd+?dR)7Jc*9;iC!a;f?+=#<s4C&g0_&NB8weC%l
+zS<iNL{)P(<k~BWt3Y%{Xrbk9d#iq+t;G9E%F%_rY<%%AD^lw^bplw!%%|-aF&{mk{
+z8v%Z~T)@9qJANVDtF7i6j_uAG%PQrIzYL<`zWN)?kg5G%9sC$@=vQ^>K^$yH!A8RL
+zJ5KltH$&5%xC7pLZD}6wjD2-uq3&XL8CM$@V9jqalF{mvZ)c4V<q)vM?$E(wfOg3Q
+zv%+110#sykOiRSt?0@;lgu4A3JD@U~_wpzdHgwI1fA5o$81_b21C0iEz!;O~RRRX1
+zGlEi0gdqWrOw3XkgEa2cwZ#ieSM+Bwx5supt!d$Nc0%<IFUjN0oH@W~IsyX(WZ$<d
+z|MaryZKLL%mzThJyCC#$>n?xXbvkB(q%<Z{kVQ;%LF$(<$dK2qdz`UK^3urTrD0B4
+z1&)CdFB?t|pWnGgd`vO!l5yW5V|rGsYb-Keu0g!I*6%Xh0JZtqeMa&LE(4Bo#scEB
+z2+Xh0IF3fHxOvz(nbw5~LC>xbSdjoXJXanVN@I;8I`)XlBX@6BjuQKD28Jrg<b?I+
+zxnRcDtmgY@D96{&H=|gt1$AWNvdJ3yEL}1j876RHewior=;z@yI+m%vO5~lw`>05}
+z^ImmK-Ux<q>*QMn_A|1ionE#AurP8Vi?x)7jG?v#YyVe_9^up@6^t_Zy^T1yKW*t*
+z&Z0+0Eo(==98ig=^`he&G<vo(#Q)G{9SIowKW2Tx<>^K$I!F~1l~gq}%o5#pR6?T+
+zLmZu&_ekx%^nys<^tC@)s$kD<AcM417>`^r8)1^tUazRkWEYPw0P)=%cqnyeFo3nW
+zyV$^0DXPKn5^Qi<LfvSpMIU#o(EG&Rpi2B@a5@RzAAQS3*j%A9U;6sg<98@jyPDmC
+zXKg0?&ACu)O$sr|d)+$ZH;RJR7V`iC489P}wQ3gU*M+C_X7Cw%nw^c(gNH_oV&C^!
+zc5Ja!U#d<n%*)0OuX(xIWS}X!VI4G5%&+mH^jQka0XK?`B*^+~@VtKToDTaE*!8R~
+z<nPU#JZXd+QYE>OtOi4MIX^#3wBPJjenU#2OIAgCHPKXv$OY=e;yf7+_vI7KcjKq%
+z?RVzC24ekYp2lEhIE^J$l&wNX0<}1Poir8PjM`m#zwk-AL0w6WvltT}*JN8WFmtP_
+z6#rK7$6S!nS!}PSFTG6AF7giGJw5%A%14ECde3x95(%>&W3zUF!8x5%*h-zk8b@Bz
+zh`7@ixoCVCZ&$$*YUJpur90Yg0X-P82>c~NMzDy7@Ed|6(#`;{)%t7#Yb>*DBiXC3
+zUFq<q;<NLVE3q+|RY;{7>(UDFjrgOsc%0KJ_L;WQKF0q!MINpQzSsqwv?#Wg+-NO;
+z84#4nk$+3C{2f#}TrRhin=Erdfs77TqBSvmxm0P?01Tn@V(}gI_ltHRzQKPyvQ2=M
+zX#i1-a(>FPaESNx+wZ6J{^m_q3i})1n~JG80c<%-Ky!ZdTs8cn{qWY%x%X^27-Or_
+z`KjiUE$OG9K4lWS16+?aak__C*)XA<mn7dO1IQ<7rt}jYvLS-$H~f<X5+N=(Ek`&&
+zUWHe^|Bwj1`@oeHlPUTz8D*6r?NpHjHK-@Dqy;NDtS}cg%!YayC0fs^iN;OYEP9kK
+zo5Vht9oQS7iDhR-OPXj9?q6@S&eFy#n-1R+kA`A0*{=#t%}!LRAXjjRywc~_uNoSv
+zszK4MM3XQ`!AP4Kj^Rx*7iMfV9^D$9ff(?N=BiGkohxx7DcQNG_tP#nT3_=hI7YLo
+zGAoH*rjQg^W(ap448geJyg*-Zsf^RAr9lW2dRNFv&HLWl7oARenT?<M#Z5`E1my@r
+zEvZ)*EFhV=Xn(d!ux{Tmfc~sd_)m;R7maZ)e8qGMx=q|X7Apwv&(Z7nX5hp;7Fa>{
+z6HmS*8#t_3dl}4;7ZZgn4|Tyy1lOEM1~6Qgl(|BgfQF{Mfjktc<V73_^4Y*JAxZ9&
+zk;vp)O|oP#qgjAs8&wb~jCgfwsBn#A5JV`I8M5Mt;ki^ey-B;1sC5O4oRWjC=0x>h
+zB5kc~4NeehRYO%)3Z!FFHhUVVcV@uEX$eft5Qn&V3g;}hScW_d)K_h5i)vxjKCxcf
+zL>XlZ^*pQNuX*R<VIWU<&k+#O#z05{>JQn)b6;blT3<7@Ap)55)aK3n-H08GIx65W
+zO9B%gE%`!fyT`)hKjm-&=on)l&!i-QH+mXQ&lbXg0d|F{Ac#U;6b$pqQcpqWSgAPo
+zmr$gOoE*0r#7J=cu1$5YZE%uylM!i3L{;GW{ae9uy)+EaV>GqW6QJ)*B2)-W`|kLL
+z)EeeBtpgm;79U_1;Ni5!c^0RbG8yZ0W98JiG~TC8rjFRjGc6Zi8BtoC);q1@8h7<W
+z{%QU=f~@E{*75;EPtq=QOC=`G(0Hdr_HmX;s)IO`uOsm?hi;HPRH2DMN!8p_6N*mR
+zXeVd+rX;e|)D{nmu3FxC){%4`fvkUoMM~{w*jYq7&hHz|64x(?E6&4jG;eJ*jSB0z
+zWIII4*kn~Ve25Pk+1h=4UMO&Fvq`3&FqVW1qQ})@8We8E6!Yt^Nic_&{<S5dR(OO{
+zb5!CWQqPU+0jYF<lXRIyMn^4F&DA<&TE_&-%x*k9PRqAjBu2+9eB|q?j^5xDz3>UV
+zFa&LRzYsq%6d!o5-yrqyjXi>jg&c8bu}{Bz9F2D(B%nnuVAz74zmBGv)PAdFXS2(A
+z=Z?uupM2f-ar0!A)C6l2o8a|+uT*~huH)<BklnFF@?8S@YKGOgvIkgvy?bVNlgCB_
+zoqeDw{3YNZ=l`nrK(ag;cr55JL-h60|J5N{s-NkNhFkQ*iwcZIFaTBfOzrkQWLJ*V
+zICw*3^B@Set{3BbuO`R#p?&bEzj(u;_I4rvE}iY2Q^FV4RYK^P{cWG=Da>!h3i!&$
+zr>76mt|lwexD(W_+5R{e@2SwR15lGxsnEy|gbS-s5?U}l*kcfQlfnQKo5=LZXizrL
+zM=0ty+$#f_qGGri-*t@LfGS?%7&LigUIU#JXvwEdJZvIgPCWFBTPT`@Re5z%%tRDO
+zkMlJCoqf2A=hkU7Ih=IxmPF~fEL90)u76nfFRQwe{m7b&Ww$pnk~$4Lx#s9|($Cvt
+ze|p{Xozhb^g1MNh-PqS_dLY|Fex4|rhM#lmzq&mhebD$5P>M<DmANA7)v1?A&u8?r
+zN#V^qY31R$$uOM7e!;99G3zfzxBI#kn<K!x%{#o+a5>$eqLoV|z=VQY<HWnoG0tOv
+z69l8*cSEJV=QU?Ns^-R%Uq*rJ%^Z2p;<g;km5p_x#;n0NJ&|94gMZ|Q>{)7&sR#tW
+zl(S1i!!Rrg7kv+V@EL51PGpm511he%MbX2-Jl+DtyYA(0gZyZQjPZP@`SAH{n&25@
+zd)emg(p2T3$A!Nmzo|%=z%AhLX)W4hsZNFhmd4<1l6?b3&Fg)G(Zh%J{Cf8Q;?_++
+zgO7O<(-)H|Es@QqUgcXNJEfC-BCB~#dhi6ADVZtL!)Mx|u7>ukD052z!QZ5UC-+rd
+zYXWNRpCmdM{&?M9OMa;OiN{Y#0+F>lBQ=W@M;OXq;-7v3niC$pM8p!agNmq7F04;|
+z@s-_98JJB&s`Pr6o$KZ=8}qO*7m6SMp7kVmmh$jfnG{r@O(auI7Z^jj!x}NTLS9>k
+zdo}&Qc2m4Ws3)5qFw#<$h=g%+QUKiYog33bE)e4*H~6tfd42q+|FT5+vmr6Y$6HGC
+zV!!q>B`1Ho|6E|D<2tYE;4`8WRfm2#AVBBn%_W)mi(~x@g;uyQV3_)~!#A6kmFy0p
+zY~#!R1%h5E{5;rehP%-#kjMLt*{g((o@0-9*8lKVu+t~CtnOxuaMgo2ssI6@kX09{
+zkn~q8Gx<6T)l}7tWYS#q0&~x|-3ho@l}qIr79qOJQcm&Kfr7H54=BQto0)vd1A_*V
+z)8b2{xa5O^u95~TS=HcJF5b9gMV%&M6uaj<DG%?NLS@ZBcw~|?Ph?A!$GyTtN#J(n
+z(N#33Z&MXkLNi3tlx}v1EUFXC!E2$+1Uui1Bx24YZRI7U{9C!4ye6`#_fxLyx><>E
+zPNM~qGjJ~xbg%QTy#(hPtfc46^nN=Y_GmPYY_hTL{q`W3NedZyRL<bGaMku?v;})8
+z39o7JEb=3hqE?4Vw{>^kgU@Q$_KMAjEzz*eip`3u6AhPDcWXzR=Io5EtZRPme>#K9
+z4lN&87i%YYjoCKN_z9YK+{fJu{yrriba#oGM|2l$ir017UH86Eoig3x+;bz32R*;n
+zt)Eyg#PhQbbGr^naCv0?H<=@+Poz)Xw*3Gn00qdSL|zGiyYKOA0CP%qk=rBAlt~hr
+zEvd3Z4nfW%g|c`_sfK$z8fWsXTQm@@eI-FpLGrW<^PIjYw)XC-xFk+M<6>MfG;WJr
+zuN}7b;p^`uc0j(73^=XJcw;|D4B(`)Flm|qEbB?>qBBv2V?`mWA?Q3yRdLkK7b}y&
+z+!3!JBI{+&`~;%Pj#n&&y+<;IQzw5SvqlbC<hrT)sBs!K|EW5H^76b8wi?&5jaqoB
+zdZ2NRMM|}GTQWlnULm3*Tw}|kY|0D0spF;??&YCTeOo~Duw_Bz&0>+V=kLZLAHOQb
+zS{{8E&JXy1p|B&$K!T*GKtSV^{|Uk;`oE*F;?@q1dX|>|KWb@|Dy*lbGV0Gx;gpA$
+z*N16`v*gQ?6Skw(f^|SL;;^ox6jf2AQ$Zl?gvEV&H|-ep*hIS@0TmGu1X1ZmEPY&f
+zKCrV{UgRAiNU*=+Uw%gjIQhTAC@67m)6(_D+N>)(^gK74F%M2NUpWpho}aq|Kxh$3
+zz#DWOmQV4L<sDJGB1~xI&#K@a<rftJ&W$tS7|})}p7LCV^RAnbsUrP_V*uhk=;!pl
+zs4zoj`KucSBFKjBcKXW*EHB;&BS$tidMG;U{H8n7wJ)AAvB2L*UBNbpb;dN7LsCrE
+zL;cL{W0B-y=uz}$?A3Z<^oG{u-AX|Svz(WP+@{ryM8&-@TzJ+nBT;gLmX|TuUS7tX
+zbu7uYkz$71L||aR32Yb{k;9>g&}`XTU41Z|P~5;wN2c?2L{a=)Xi~!m#*=22c~&AW
+zgG#yc!_p##fI&E{xQD9l#^x|9`wSyCMxXe<3^kDIkS0N>=oAz7b`@M>aT?e$IGZR;
+zS;I{gnr4cS^u$#>D(sjkh^T6_$s=*o%vNLC5+6J=HA$&0v6(Y1lm|RDn&v|^CTV{=
+zjVrg_S}WZ|k=zzp>DX08AtfT@LhW&}!rv^);ds7|mKc5^zge_Li>FTNFoA8dbk@K$
+zuuzmDQRL1leikp%m}2_`A7*7=1p2!HBlj0KjPC|W<t!gw4p)|NM)%cW9T$k`o|lfo
+zg*aR{7NSC?*?~1-ovU>T?5{_aa%}rQ+9Mqcf<RjoiaEgO6aLbf%7cdA%8(Z(Lepcg
+z;EK+)sbwoSMUuni>XI0NtjvXz1U)|H>0{6^JpHspI4MfXjV%1Tc1O!tdvd{!IpO+@
+z!nh()i-J3`AXow^MP!oVLVhVW&!CDaQxlD9b|Zsc%IzsZ@d~OfMvTFXoEQg9Nj|_L
+zI+^=(GK9!FGck+y8!KF!nzw8ZCX>?kQr=p@7EL_^;2Mlu1e7@ixfZQ#pqp<X+0Re_
+zrJ{H^$-Z@QA7ETVM2%a&#GG%~hgC@{06tyBwQZmlXSm57v9B9QX(aJLI_U;c+x!4Y
+zc@Lpfn;l;r15OkOarCAT2KT0TI&b@nuFwDm5s2$h*ySA~Ad%ZKk`|FTjsVplUIi{5
+zlFa?pIp_hLcE?CXH;$pLba~E##@hT^OvK63FoxCFx@_5ii6TR$R#n$|+i^+&#se{6
+zDr7|zkeVUxEFj8#1(pWjg_@>yCJ```(m;la2NpJNoLQR};i4E;hd+|QBL@GdQy(Cc
+zTSgZ)4O~hXj86x<7&ho5ePzDrVD`XL7{7PjjNM1|6d5>*1hFPY!E(XDMA+AS;_%E~
+z(dOs)vy29&I`5_yEw0x{8Adg%wvmoW&Q;x?5`HJFB@KtmS+o0ZFkE@f)v>YYh-z&m
+z#>ze?@JK4oE7kFRFD%MPC@x$^p{aW}*CH9Y_(oJ~St#(2)4e-b34D>VG6giMGFA83
+zpZTHM2I*c8HE}5G;?Y<M+?LyWn?03qS587BS{lq0V4R8#J8=B>7RXMA2k{Y?RxHb2
+zZFQv?!*Kr_q;jt3`{?B5Wf}_a7`roT&m1BN9{;5Vqo6JPh*gnN(gj}#=A$-F(SRJj
+zUih_ce0f%K19VL<E3HrXlqqoBf~c20@9ozE$2qZsljz1QN-PVpQS1W!)YMjSijFXX
+z{P)`?A`eAJ?oh<!djz+PC3lVbl99-ayrp8oi=_canYFfMH62C}^0hP3`X)L9+i4`Q
+zm?I7fbusV!Jv(kfxmM>Xi5(<VS*XQmy2&`ZRfWgKV9~k|yVKp~M)9<_9P`znoH<lN
+z$~@NdPe<+%!i}Jugmv9Pnb}eLR?O8Po%je^XGWy*@HH7__y8%?t*~t>VBGOFbc(YF
+zLvvOJl+W<}>_6_4O?LhD>MRGlrk;~J{S#Q;Q9F^;Cu@>EgZAH=-5fp02(VND(v#7n
+zK-`CfxEdonk!!65?3Ry(s$=|CvNV}u$5YpUf?9kZl8h@M!AMR7RG<9#=`_@qF@})d
+ztJDH>=F!5I+h!4#^DN6C$pd6^)_;0Bz7|#^edb9_qFg&eI}x{Roovml5^Yf5;=ehZ
+zGqz-x{I`J$ejkmGTFipKrUbv-+1S_Yga=)I2ZsO16_ye@!%&Op^6;#*Bm;=I^#F;?
+z27Sz-pXm4x-ykSW*3`)y4$89wy6dNOP$(@VYuPfb97XPDTY2FE{Z+{6=}LLA23mAc
+zskjZJ05>b)I7^SfVc)LnKW(&*(kP*jBnj>jtph`ZD@&30362cnQpZW8juUWcDnghc
+zy|tN1T6m?R7E8iyrL%)53`ymXX~_;#r${G`4Q(&7=m7b#jN%wdLlS0lb~r9RMdSuU
+zJ{~>>zGA5N`^QmrzaqDJ(=9y*?@HZyE!yLFONJO!8q5Up#2v>fR6CkquE$PEcvw5q
+zC8FZX!15JgSn{Gqft&>A9r0e#be^C<%<F$|nV^6m7s?pfGWrS!*h<5zg%%}lEg1TI
+z|E5UO7&eitGHgtFuU&)>)psE*nyW^e>tsc8s4Q}OIm})rOhuc{3o)g1r>Q^w5mas)
+zDlZQyjQefhl0PmH%cK05*&v{-M1QCiK=rAP%c#pdCq_StgDW}mmw$S&K6ASE=`u4+
+z5wcmtrP27nAlQCc4qazffZoFV7*l2=Va}SVJD6CgRY^=5Ul=VYLGqR7H^LHA;<kSL
+zyrh(Zd)qJDxpzjXJoFc+eRH#(kkiWb-uI_%f85g24L`FdF1fP}Kg{iZ+*Fo8ju*cl
+z3Aw1YGq0cxadL4N9aS#>H^1g}ekn=4K8SPRCT+pel*@jUXnLz+AIePjz@mUsslCN2
+z({jl?BWf&DS+FlE5Xwp%5zXC7{!C=k9oQLP5B;sLQxd`pg+B@qPRqZ6FU(k~QkQu{
+zF~5P=kLhs+D}8qqa|CQo2=cv$wkqAzBRmz_HL9(HRBj&73T@+B{(zZahlkkJ>EQmQ
+zen<iPJWnXR=;Z=9fu?|et|Rb%*gDj8sMD`ZMBMaR)@W4I!@ZJ=6-0EUr*wDEx&_hw
+zhU+|E`Yc!V0@6Vf^U<QOMIE_YSpmh%i+yFO|G~yVs99EScY@d$n{uR4Xtly{afZWj
+zO}~7A(I*J<@B|oPywvLj91a5kZfNN5H=|EF#}if+=~cl#!%<3XeHAhGPkCdLS{G`f
+z#i{^H6>p59dy+L;sSWYde!z_W+I~-+2Xnm;c;wI_wH=RTgxpMlCW@;Us*0}L74J#E
+z8XbDWJGpBscw?W$&ZxZNxUq(*DKDwNzW7_}AIw$HF6Ix|;AJ3t6lN=v(c9=?n9;Y0
+zK9A0uW4Ib9|Mp-itnzS#5in=Ny+XhGO8#(1_H4%Z6yEBciBiHfn*h;^r9gWb^$UB4
+zJtN8^++GfT`1!WfQt#3sXGi-p<~gIVdMM<#ZZ0e_kdPG%Q5s20NNt3Jj^t$(?5cJ$
+zGZ#FT(Lt>-0fP4b5V3az4_byF12k%}Spc$WsRydi&H|9H5u1RbfPC#lq=z#a9W(r1
+z!*}KST!Yhsem0tO#r!z`znSL-=NnP~f(pw-sE+Z$e7i7t9nBP^5ts1~WFmW+j+<@7
+zIh@^zKO{1%Lpx^$w8-S+T_59v;%N;<ZZyRu1Je84c8pEeE|Tu>EZtJzcfN%&@(Ux5
+z@YzX^MwbbXESD*d(&qT7-eOHD6iaH-^N>p2sVd<d@hTC>q&(`C$;?#mgBANIc5$r|
+z^A$r)@c{Z}N%sbf<VV6f)%mV{w>o?T`tTHz9-YpiMW?6>kr&W9t$Cuk{q^g1<$I~L
+zo++o2!!$;|U93cI#p4hyc!_Mv2QKXxv419}Ej#w#%N+YIBDdnn8;35!f2QZkUG?8O
+zpP47Wf9rnoI^^!9!dy~XsZ&!DU4bVTAi3Fc<9$_krGR&3TI=Az9uMgYU5dd~ksx+}
+zP+bs9y+NgEL>c@l>H1R%@>5SWg2k&@QZL(qNUI4XwDl6(=!Q^U%o984{|0e|mR$p+
+z9BcwttR#7?As?@Q{+j?K6H7R71PuiA^Dl$=f47nUKL|koCwutc_P<-m{|Al3C~o7w
+z=4S=}s5LcJFT1zjS)+10X_r$74`K78pz!nGGH%JV%w75!YSIt#hT7}}K>+@{{a+Im
+z5p#6%^X*txY?}|T17xWW*sa^?G2QHt#@tlcw0GIcy;|NR2vaCBDvn=`h)1il7E5Rx
+z%)mA4$`$OZx)NF5vXZnaJ1)*cA6ryx6Ll~t!LzhxvcTedxT;>JS&e=?-&DXUPaQ2~
+zH*69ezE`hgV{K-|0z|m~ld}=X^-Ob={wpex&}*+Rz{gx)G}gn!C_VN{UN=>^EV=Xc
+zr$-HO09cW&p4^M}V3yBjTP_xrVcc8iU_^Y-JD~(bgw*@GXGB1gYKz5DWO+O`>})|N
+zWrC)MR<YoNN@dNjcYj<b;OF){>93yA)3{&27-M)TJB6Ml3~?zZg#mYsF=#OSTaw&K
+z@hBftpt+2l@)YK@|3DvTjl(8wZtpLp<?0%pKTY3}XX{MHIljL%Fw{_Z|9d-yvblgQ
+z{!wyH{yqQi?Iie*$>9Ik!6G$CSL_idZ$Ti?R)4toe8bb)l|)lNb}?K;O2K9vyn1QG
+zd=v#y-Ld49UVkmfRU>Egc+(Y$^-;6vW;3Lcu*6~etz}0|@+b|+!UCal)DEYGLbHWJ
+zll5Wi^<vfZ?T~^`8=zPM$Z@j*S$t!Y<EhDvm+zMzHqRrjoNgJR4PlwtA%~M-7oKg-
+z@*>$Y<6@S%^y%hdjRh6&{!z1Py|lZ|q&Wub3l41uN2zEF8E&5H5?PL*&V}?*a}Lp%
+zCYi{ghjpRNT^^B+_U59No50Ghih5qn(W5`RkrsDWr{~A1dgtv{sRkH4RU2^A{jb&0
+zxVRnrm|u<;$iI;M6A>$POP)TWGU-gSjAERk*EGmVT(aw$!XUS<asJ?{P8@w6qBfov
+zI%`}^njNd1_{}A_uRkev<-TXKuoiFlFOyqT%8rk1`2%BKM5Z+~M&?E}fqqOZAZVB5
+zNS{DO+i9FHCCFSvH|Q|2xQ%x$MZhjBSt(99856FiHO!aT?oD?|(v2KHy<imYT_Zl)
+zzM{QvD-38PfU~%Cj@UhZn!-(N#6a8!Zp46^fmJDt%0~G+`{28Ol&R+}En*ZB(Ap5-
+zS3xTHV!d88{~H$@*|Xf2m9Ev~cClRLKWq-Dy`0?=Ka(0bKO7k6Ia^0ek#FeuLW^Ka
+z+29SP{BV|X`LItvfG~$^QN1DscL6_hZV#x+g@RJSzbH{*7vi&EuO^0lmWyRo%n-;p
+zrQ@enXxznWo93lX0onG|8<ExHhjsVv&yv#5$}JubQ-~k2)eX#tYEp#B=ZL)3W6xvQ
+z^tSx&3RvXN^2EDb;%<?Qv9hrD;ImRS1@Ev)+k3=jO{~2fBe<e5TLY_Vf+5&KlA(i%
+z-tx@Qc4VuOh0tKo5#`$=9<^cjcq8Ip7qpr<1+>e~7Ql-oRA54^4V(JWS6Q1mG?!vZ
+zx+pE!FEtvqr|Xrcb3oR`%LHFLmU_&{<QAAHttd1Er^!DxXsl03mv0y!k#PYpGSMeW
+zem^VXYsEEPcK*)T#s$EH8n9Tms!@q~oOuVmpZ((3>=p%mGy6MRe2Yz_5WJ8p@IgU2
+zdVvvhhQtiQkChK%*&PsiPCBL9oDOoJX8!$S(V>R}+1M}wzK*U*A{KJ`r=lM;mPrKU
+zQDqqN(W*u-5-?$(SIk<6A0E}34y&@-IVC%S!a1F4kz<3bIKjlyD)ooO_7ft<QDC;4
+zO#}hIX3cX+ou-UMWv@FumqiR;#JOI;$Lna5#MA^fv9k{O*GC+<$Nq+kGZ+M%7QHYI
+zk9IArOT7c%DRktDP2?F4i2($6s%HL>l%S_(6w`!vX&1PZ!K`@D@L6JR)6zO@Dl!<l
+z=BdWEtebJj+jz>YF{R<WP!R4PHXBT&cyt|IAe~n=dcnCOe*w5G5oS~}#&qbcuT(6I
+z-K*(&5{r9`!3B<qxqwHIOne-7;C;+8dR9=$r{8B+k8sIfec{W>Y}d3HZ7?Q5E>w=$
+ze)H_)48Ds*Ov4?zoGb2fe3}{!5Ooc|KCIni1o)(Gj+CO?`*7jsV`hIv@8J(22o4Q?
+zu?Bvi)zDG<OK;2aO}BggmGd-%r>(me?7XKeL|iF9ZRgZdT*}Ffsl62Cu;{Gv9j6dO
+zPt*H2GqC)-C`V`ceuu=tM{7!2yTEj=*5+T~5DYiZ)Hy)*PARYI6R2lZXoOj;v8M4W
+z*O-NX(7_~Q&A3>Oaw&1lBH_H%SwmISX-i3)HfHvBOeVwTT{LUM3}ZuZmg<(>)KE;d
+zbs2!0v6>J;1nQ0UJkUxnkE@Ibi~Q}M=-=Rk;hcOnxO$luOKEVxZc|!XECgex(2`}T
+z3Y;Q_6rL)e+SrOZhQj5_e}Lv>w7n*Pep$yWZNQl>ubBgb_NIWWDn3kNpn+MPQXV;8
+zV|_Ba5jsQ(w&Ey^IM|@|y!AqcJ#3m0#Q6_qvgCG~eoF#mnGmbO(;DP+bW%_aOs1R_
+z@9p#7X2UA^--#Nwx_Hvk2l1`eO{P*#j@q2UELtH|Uh6<W{C0d%;SO*X17Hg*_nhVo
+zUj8d@XC~-{FK%b15_u=5Zi$$rw|PRP{3P&%r4IFKW@%M_k3l}b-a!ZM6ZqfV-oe0z
+zHcS2@f;}*ROge~8O|p+DJW!EVo_da^QYfpcqO^~19<4~HG-T$^cIunesE=MWKhim-
+z7Goy+*ll|&6M44>hxR`h_847wIJo0=5CQQ`6it|%a-I$^&a@we1rc&*;QIu5Ck^?)
+zx*5eSd*mG#=6Hi(5!;5uUi&{HfnT1S8X-)?gE5CZ6KWoqM5|CyrULmuFBKOU8SOp*
+z{IB1$OCcq`S-k*xs;4fmhKsIGZ;GYAY*%(@875NxhM<x^qSdQMzkq<XP|<&O=Wdj5
+zG5b8jqr5|XkTRdFnfoy|e#_<2FW~3dCqmjftH}M+1ln*+nwXqXXr0NK&8fHefdP~`
+z<>q|j*m4CNLI(Vho|N|F);!E0cS5y^$H^Izje?z}oTgyr`9x9G&rlJZw&uqIoBMtz
+zzhU0(9;w02?m#0!)cFi*r+8YvooQ;(s2lLVvyLqAE%Xqe!vtWbIs!l1Bpp(FIht-Z
+zPn#CN-2C|J*GhA2fuHqYQ2mJiXlGTzD}mkr2;ia8Wp}h^;OS7+N^M<nb8{1bSa3A+
+zL8!27%|p8>w|en!1${vN6<B1T15(f#0UdAk{Wr$+OIZmA!F!Rj#Z~!T7({o*mB$j>
+z-x{8N*4UekA~`IV2&K-GzhAqau|}d*pEQ$1MH$cFi03OG^1NetZ_jW^STaEzr&Xho
+zB452St%v3ez2#TFm~`gZ<UBEKV7u<uCXTZP`7$*T39B#gt?T&`4)K;E&|ZM6WSMdG
+zebuH**%SihzOx;;CUDFI*)EgzXx=I3<*D-whBHjKN-pq1#;zw`)Wn{zX$8V;zVw$q
+zbhEvq3kJ(?s``MV!AS6_c(5D)L4tK*Aw)gIAhX&Z%n4p62=O5*U-Y5Ba)ZL6Adcrk
+z)x8`?1tz4OdUR+*taVv0tA0F%j2gu>h$vi=in+y2d!z<{OZ~Kty-5bQ;0O<LNwDnI
+zC}8-6mq`yuqDIHx`*=Y3Ma%=;%#E>=k_ESi8Nx9{*T`LJy6jqR>&|+>OZ;+=0hA04
+zE25t^sE9HG)3^<Ym7m{BQ^G!z>KKR_A5WDkqispweP9!I-@dCO&N!JrD@i{WBHnfQ
+z95o8;d$`AFnca3;N-0iX-CmbbAp5yQ!GoH;h7Cn?m{ammZJI8igP{U73lFnl2&gCs
+zqJ4(Vo~^j`{zOA<UI~9WX4R%(>zScL5B_Sm?Mjtek1d(A6X5ObcZi$;aOYy|g$}BY
+z$GEP3#i60Ju_&3SHzryH!gUFwC9-295u??cf+aYRQ1$+!rc#42YNattd6mZEFI@?C
+zqFM>6+zxEunIHDZ>{Z15u##>N(28Dw!>G(k*dB{NHvip@aP}f`@=Q;!o;zRMWo{Cx
+zo?kyzh8n7#f1g0&g>Cd>O-2g?uPwy8sy8hZbHSsXPmU;@l=HL=zm7mN(=@*|D$i+u
+zs~TllkCTvD$f&-#b9B?}#Lg*-ibK13R_a$RyoN3m5`10tdhAq{+VW)K#Bht-ra1*J
+z+n$N%V>u0rVtx`aKJDwXXrxa<i8EX06UO&LLD=n5qGhcYvn1Mgi;G^)TV4yilP*(Y
+zoKH+I4#~X)gA)B$;S;Huvs1a%d&HL})yYqqyVy1<B|Kl_6$aedKOq)GM61zpA^OQY
+zD*lN>D7nS<>$=c82v7<sDF~4nP`e39${9XIsr;e(ythhyAUnjOkWQ<YzhIcj{t&n{
+zx(8T~Ps>@KVx^S@vT;h=SZE37K>iahpx3;VDzEr9GY=2(%uaqM;^76eSP0QLzo4sI
+z>p_Eei*T$K;|qK`sq;?Hesp}(@VvX2Q4sAMYAJ}b&d$htDMC{FG-$o4k9ApECi1$a
+zXdamjiOGKHBh(4M<3(2x6n-CrmZMCknkQxdSS!qlis#I}btfX;J`JU3RlvtLdrymP
+zG0ZzrsGXVFiq+Wk1=BFay&9ZiCE#(`h~CL+c-Hs@iGTU@YxM%vlg;)`Tf~IknA^02
+zXkN#Txo6aR{j$wP5T#|UH#<s*%`(Km<n&(n-VMO61HPpba9D&s-YZ<E)NH59!I|A9
+zqN-T-CD))<D9dzh{pWi6;9v!e;Gu01;Ra@5B;qlH=@ASvlOB+p<XN`E#p(1Aq3B41
+z)+3^0JXTY<%Czvf6l;_I-72Od>5AP2{rSY8p?<egp~%*QDVvn_i1jVI<vF4YO5Wv6
+ztWwz1KFP<1kO#Hjq^e=sWVsSgwV`63V3pc#=)rascLi7{-yp$_z50Wja%IQ)>jKFv
+zG3kn3y`FaV!*Jq%m39_TQEhD>M@l*bhEPGe1{ft3q#K5AknT=F2_=T^l#ou5ln@D#
+z5Tzs(kRG@qNDa~<d^7jn_a!bDdDr)>HLNvfv7Z0g=bSlb?`QAx|Gfoni|iHJ%K0cy
+z;~Nsaa+{8HP_qrb{nj+xzkdYhSI@W4N_1`z(eSGIkbDP)!Ko|M%}Rqp(~KI2hl~eE
+zvJ!j4m6iwMgKy>fkCLC)`M$z9EV}B+sq1}}kVf$(ig0pWTY?rHz1Sm=4srTGNb^JG
+z=2$9wz-C@aZZZ2!HY#HNejqZRmE=pN(D$Kui$NpfhU`!y_s{@MIxiJdHb1|{6xb`>
+zE74_@QtgtG{4=3P1$^vn&m}7Aw8!1DnT$2thO#~44wl(N#ao8S0@t@m+Z!KD2CfK;
+z)n5DAPKV_etmH1aLDK$<bfKTSGeuYq_HlONO3C#M3PFvqt3PoSz0>?`;sL91iVt$D
+z*SG}=-LIAg(*+JON!-5ivqOMQ1S!OQUgHglDsKik&Mwg;vva523`JwQH6SRz9eTY#
+zTIi23145~kc3r1mSWC_RzD%hs$S#!pkI9!BU80jJCJcwo*FZolQG$q`8C1d9pP@ND
+zG^&-ZraIvhg_FDVSfKGwkcI=avIan%2sK4coUs~Nr8jC*&!G0#?}_^s3r-c}-uAqi
+zM-Lw>Y}I``T;IS%Y|qH;s{F*ZefM!4{I5awr!K+T@uPd*Vu*iPWI}>(-D{zxsN>LG
+z=@747a_Rb2<sth+J2Z?T^N6ka2dx@o>>q?y8xYf?dq2HM5tFO8Y5e4N;Y=xy8yAhI
+zsm>oy%R5;7)7T3V_b2%`aH^tNlsQpFxIFW<Pc_7hO>#iV#8?{6{^cGr{A0@1bA)|K
+z>MMTuZD(pd2t|7vmHtywGXb%%=)S<`OG~}U+jm#xd%H8<zV$)T@@IDRa^1+^lW~x>
+z$v8-C%F?ah3$;hn?{G3(LT!SgvCVi$vwsZssAQvUwT`Q%qSw!LSd!(<CTTRep1wpD
+z+1amWP^M+0sC8ZA)6PVj+g*a{JY^{LZp|zaB+|iUBf2HHkx&1DcY_YMj%(o)N(g~8
+zuOD62JY+Vu*^6K_|7K^R++2{-!+XRjo6R-MpFwn>I!64w1=%Sc1Mck)q1@pZ@)=SY
+zoX}d+L3-RA<kqVpViiwE2+1D(*ikr;H!OUuItq{`ksBj7b-a&@`xR$^jH(snEHH~+
+z(=1=%lU_?$?ERV8-3T`#N?ATVklfraz}x&yFwwIzZ7NQQfnqa96c>|c?G3_BQNm&(
+z!i$AZ7cI(z7q|e9VM##6T3Xorj1JG(9os$;(I$y%mBy(#8{|3l4|x*oBAQL^XhZ0g
+zy1FR1teRrpKq{uLAibTLx#n({qwjlkOvR{OdSAeT5ah4-sNN)n4Clg1T9lzF)&yj;
+zyal1%+s4n1IG;^VPWJ;#olpk8Z42Gj-tjFeQ&PlxB)`oCNoUYKj4U$AeG8rYiD{pK
+zndDf&2;2;)D|KvOZP+e7fcPU9k4M2sfhr@vC~Ly0?S-4dz)ZGAYpCsAhChgbxLd4g
+zhTrbIPkO5SEp_kD>Ha0m12h5n3s;mE8kn515&n<G5W?|M#KpzT&e--JK0@kIpJd@a
+zo$oEcM{PP18Ny#xS;1ngiAr#v&bUmbji#^iady0^<*7sdBUjhh1TZPRkf>zSf+^D=
+zyE{JnJ;43l&BH55CL<=W%CF;6iUI)V5C*6!`**KqvzR2=Fj*3Y4`HYwx}TYD445(K
+z-QtXwtL?m*(F=LVH*H4oM>dXHBW=38q_dZ-_Vr&qpEPxd9Fs95P5W~@Z|Rt+WZP6l
+zPSQ}~Dh4V?Pp1g&H<P(ih9)F<lyKeQW3i>k*Px?lm16C@X6M29Vrk%Rw@E||E-v~$
+zb_E~{z<}#8i`Mx9mkqtd#Z1lZ-E_J8I+2oumc#x1)jdvh{W76NKm6x-RYpM~v!P8$
+zw3e|YVf|}Hse9~oC@N7^j}Fi$hNpyaYnu1}bdXsD=^oI*%WKvbme|<Oza_wpW8gk;
+zu2yC)2m?TABYV?-o`?uFUCrz2#D@wpoKDwtWV7N~cyL3h>BI}$G3>smu#6y)ls|j?
+zF7Bhu9Z)j)C;3cZb+I>0stSK^WLOYV^U{pUYkgv>?+Nt^5j*CUB=eGw-CvU&40>y~
+zGoHLXxY^7k5Xgv62{iQy|5jJQuq0|LU`}lE@flQ2Z*Zn*VWcQjm4FTb>LSVox^S4q
+zLn`LfS@mrjKCmg$nb^af?d?0&$aX6#2u(JyzIJvuJ*lwPrh|0~aEnSACCTezSdG%h
+zmSQg`17j@$Iq)r1&?+eR@1nlX<hZA96|9?2Pc{<?%#({H1;$K9kGnzSr(*CLy;MCq
+z%~Qs5<0+7FZWenzFJQAz8d%>|H`<}_!?BQSF&N+QQnvEAqZe+mIFui!0V49R?|9*$
+zv!K1A01{8xq;L()Tv*Qk0-$Oj6+vCT*TUD{HvxO@3JjxBwM!4g3ydy&eaJw4CoQBF
+zJtULJ!YxgNR7_Ls%LmogyI7uIs=!B&?=MYY^yX+v;j@D_xGeZg>eZk0C;4e|HRNSi
+z6KlD9>q=3v-$4Zik&^ZDhNm1X)+7<A8tsuQP$bTVU`(p}?t_F!BJ>LCH1k!s+T3tn
+z<oekdyD0CJe2We4yeX>Un@={1U&NJLq@K?~w|(=Y<4W{ucX}F<B#7eu{_F0(M`~qI
+zEPqMc=S17TFa*Ut$xJ>dRr6pLw(l2$iK)At<eBP=<9%0^t_Ek7)YPj~HbzFdS?&Z-
+zFWq#s<_owUG*W9*3T5d3x?Z=@Xg0_}q&OpWn<UO2%6U`unYl-6@mymg@taxBjyc#}
+zd)7tZ=4f`2N^@IyGR7RJjM#l%PlXpmAf&TWaZ{@~`%NOfGu<_iX{6IZhLU^5%U~Eu
+z>%t3gYBMlJz#(K0Nqm;=K<FO+Hmo`&$bpQVtC{pgje|zpXK%6B)|FgdwTg%Nz2k)`
+z8X|UntK@qHxvr+JIl!et<9kIpEAP}K!ng>AML!&MMSNz=%k=j*zh77r34Rs37iCY`
+z=_kva_41bdrj(b=4Wc5MO0~q^z#pIWJ>)vDSgIQF=3JVJe1iDy%h)8oNy{s_r&;m`
+zL{DYKSB_5xRb9xKNOS{qAY3qv5sSXVrrf%~*q5HO|CQ&lbKMePa$M5D{vlJcoGrCZ
+zD?fKbZN$6rWwz)w7`9h4DAmh1ij2}EO|bO#A9L0_RW6l*$sPP<sv8r8rA9owl!eeR
+z1NTGO4fH_iJ$h#A4{SmcyR>UJrUbhLC75L9%W5iO$Iw5~Yut-qBeu~hF|xD7-eQ%l
+z412vpq_;t%^F*pYDk%Q35c-erK|6Ve=FxQbAv~ikZ4c9$Y4;ee#ciOD9{yRqf55Qk
+zumv}#+JciT|Gj$uFOxBUze)=?l{B}qaC0_7m`t82<$K53!4Xvi9Tr)ADp3Off?O8o
+zVDG0Yx|tfn@r((m?Nxrh(b0DGjg)$;DfO&$6uY;4&<!k&O=hr#o>F!4jnxkhP}Y3x
+zS?WFFt>=HWzqlQhffVfvM$Ta8Sg*r3j!Eo&rUOW7SCL2~lG7<+XZ;+{&8<DyiSykp
+zA7l-}(I|=ms%tNFTYkoIsuLyg?+I~Z*3Q|??RFu4_0^U6Re;X@@34fx?CAjIypLRX
+z$t)jPOy0bd<@4-yMHz0{9Y1LCV%IkRJ|jg%fPCmT)F-!8_Y#Dx3{FysRp`Q!doW+6
+zZ}IrYb2DD<Y8pA*#%c==4-8brg}Y#8wFDK<c2$i#jeUy3OkIIRUG3<@gcwUTYAl?p
+z`@7Fcaz|&cdl(`^C!Qo@F-$oXtl)ANqe_kyV5z5QcLFH5ktesECpz2i%Uy3K;o$nU
+zRHA31(@H1&5F`A#ssy`goLx2j=rBn*CE>h5g8ElI+P>>yR2U%S93NN<c)T<0U~gz;
+z>!Xhm|C682t6ysH-=o1=Bd*N*V<P)26zv@1P>lnG%l+KZFtjG`UkL;%65qn0UYQ`h
+zh0{9jDQx(`aBe7J0Aj3Z)4}`A|4OMM0a;?{j}qkYwi)~O8$9D}ITiMH2buiU>ixYp
+zhL${nwj6X($*OwmpVG`y5b6v45tX*J8?og}Qju6eJ9H}`X87iEd%BUo7<`2q(HJx+
+zMR<Pt%@%D0sbR}bR2vchjFmv@&giX(?>}d-J4oAf{V1W^a2~`M-YAdZ81<O(x-LLB
+ziYJ(IlIy^J+VaY)YgPSiQ0Us4I~n$rwJ4oe0cPBI>dd4o6NPO{cmZaAS@RS4ir#Sr
+zf<VdxlnqAnRM2AE_ghvSVwSte-XRVIyT(D^slNqE-8jf%6<nCMa`zf|$630Q?axs+
+z8-|ze)?RSqAckM?+w@&cuhDl@^|OO`O*pLVJKYxi4OohAU>FZO-VIL|VN<%nEXr2`
+z$0FK2L#8O_f1w~c@G70JrB@N}r(gJ!Vmkk6{r68w!o$qO?HrFcjeU0_3F5;*!E2%(
+zTx<?~WRM!G0a&ySR$<jsjlFDU!_cQ=rm^f3a0m@pR~S~3x#Q!vBQ8QrLR>>4?gP8w
+z1B?3UVZmz^%d_dIps>>0{cB~mp3{9U<B7u|njwlkXBz*b%D0;yhSH%?j@*Qn*llsX
+zO1Db$I4fzAEAs;fb^Hb!dP&&H(*QyAv^S{c)(B}+d64a7WNv#fMaw`2RTzNS*TvY_
+z7H6;X#FS2^bTGaO6(xFKPOPseR+?{`;POC2m5aaA&EKov%Vz!k+>oPR6uQFecVq&}
+zY{ebB?AlPAD_}(ll{fK99;Wh1cgRbnw)maD^F>*J!R}eHM*W0VYN1TADWMy9H=$00
+z5bHY${oDgwX7(W9LZw?}{!8(_{JB~Xkje6{0x4fgC4kUmpfJ+LT1DYD*TWu4#h{Y7
+zFLronmc=hS=W=j1ar3r1JNjQoWo2hMWsqW*e?TF%#&{GpsaLp}iN~$)ar+7Ti}E&X
+z-nq~+Gkp(`qF0F_4A22>VZn-x>I$?PDZSeG8h_ifoWf^DxIb5%T7UytYo3}F|4#RC
+zUHpg$=)qVqD~=m(!~?Xwocux<fMdw81nD!;t@a*4neQ(aVD(J+A2??uX#HB8h{SA^
+zdwHZPt(_kv#Cy%vSUh54y~cPXj=D^*;zTVk5y{_bC5yAz3CQA`(UWK4rS;tBXU@kM
+zdej%biGz)+Zyb}ApQWbz*^ZVHpgtmw$q*Vpwt!Q&h9PG6;&Z4L%=lGi5uP2+Iw}}%
+zRw^VYFqyiS!j*Ylw*m}O)GZr&wh(LNL_SF4+fnf#U_g+~SMcMFhbA4}sBM0v^=YW-
+z&lY;LS6yEUO8A78NCxHMrs`yWt-AgIrz<}>U1u}9qhhM7d^eqmJPi_e-!IO`*{u7A
+zbu*?L$Mbj-X9n3G2>+Kc#l`@d8}Xb9{l*IN{#<s%V4>M*d;s+3Pdr8FO$EBELR=8{
+zd?LJbSv9fI`{OqTH)5{b?WulgMb)psp+W|@cSp=jtl-&5C}9lw@*0H+gEW(}mAWNz
+zf{~U;;<ij^TC}|2a=b@Y*t)@0v1xP(v60Z1AVFC^6OFVSu>N}|wdSaphgqn<w7=w9
+zK8);m^xjJ26KBA^s+X~_;*<r_i1!(b_J^XZTX2ts<uU`4&%E_cmAS3_5^hk59|kgD
+zMLF}`MyE`hy%MFvhK6uW0T0ZwJE%ubf^cybN1t(tFSjlXmU%iNJM_KhC?w8%lwxG%
+z^l3qjQ#&r)nR&TI7eX29AQRbBd!NtWy|6g3o?g!*>H{FWUy!{y3^=AC*c?RJ5Eb<^
+zCgH_v7^axIUVmHSFL^zlj2R$zow$|y#7>%#U7d#Vp_ezcp3lefMyd5ES=q$>4pWyA
+zp_Zso^^NP~lu2=S6nD(3Z5u=Uy&B&F<ZVfpeB?A^;A;yfb|T-IdCr4F&4;vkGQ(ce
+zh3=uO>1i$J*3;3KhEkD_lgscHGR*;T;U!9vgQa(hI}oh9IzEf_PU_8F+i77t-~gDX
+z490Sb<R_L<O5Q@b5$Zq8%`yG)pr{P@%VAd&n*7r>)LyVZmf18N6w{+37$aO<2!Av0
+ztLaPOv^J<2@p{WnMiDudoghX_`luFZt_4eNU}*~cF5i%eEcNLs;D>QVIwr8mH;=dc
+z09`}JV;aaF;13<?rh<ybd3+ERtA!AF+n4vv*yO!S>@&iS(w>Jc=k~|d_1hcpM(l|O
+zu>!@}me%isTT$xT#hNUvh(ATd0wT4fbv=6htc<!_*5tIlcw;jfC)7eiH`TZ#yg33G
+z*K{nA3s&@UJ|kOpm^FmpZH!jpU$uLLL0hBd*qzwn)R|bYU?5GP?km8IK}b(Rmo(9m
+ztmUrC#OLcS1`w=qT%q{r;x6q#X*G<@Q?b$fk$PV_;x3)8-*Cma`(%rzI}~@X_mynt
+z){EdYfW}JcHE72h7O(F)3GWJ5QyDsqkV#hvVxfwA+tCRWd-}F=Z{E9X{i^#g-uA}M
+z8A};Fz|8*u<?gci0HA-zkJWo>HNEZIw9%E6wlYmwfu2{j0kh1y=$;Yf!|NldgB9ul
+zB{dbE&LfRnr8ITm@;-68wo#VV?8lG3ed&9k1}QBS3}WGV9%26?A1rBkkDR9Z3o+g+
+z)eQg8BY3y(Dh5&z?VLLNdDV`C=muUvCPpGg!oYxIgOI3^%4>5d7jTh~ni!Fg2;fhx
+z(*c%H6Je84kmQh;5tC3*l~7khLxK-e|Cz?FLh!yYe7g|*LwqU?2wv^_ZyK<Of{dhu
+zsv0|3@?TRSx1dhZz(pM4pWCNW)x%RcI9qU7{OJ?KVPb2=ae`t5N2|Np!TnR=miT6l
+z=X6%jw%pdV6l@QFlD~p?kP+pL<B%Y@NatKA$=T#KFRv!+!jsp)t11X)#&Hl3U6lMU
+zJRO~gIozN7FCmvReeSbLXwrCX?C>T$fYVkGJo@AK0$+ml?}zJeB~deT2WL1vz}dxB
+z)y??t!}%M@)u$_I<M8Xr7=Atw2=U{1NPY=Pxyvvn&o=WU(EM~W-`~1~CfLfw1<p(O
+z>yW~)6u1SttJ!awd6N5lx|xBrmyrBh>tb&D*=C+Z3nPfq$1%WgY0bY*?PZ#Hk|=xn
+zGM#0*w4CaB^y0G(J4q=;5NeM@m-P}#mv7QZNF)M!dK^w{mk_!n0`+Y3PQutu-%NBt
+zzgPXug?JLEbUL{e_dk;Vd896&yPe(hliVK!lj%5+@BKdcrEZ2Nc_*i@ve*2lB>u~{
+zFozd2FM|_0+nAGR4TLNHanQn_Oeb!Jr<ML^n#x(-lWYbAxZ^lzL{91ce=r_rMNh&3
+z5ZH&~&=xx-`k!k3r63SzRZbe5pFX5uiE~x{Yij<#VF%9Yp7eo6*ry-Is`SOWzco`o
+zD|OPe5MeBR9K!M!O8w?{d(zJiQDi%gL-lj>UcvzJ?7p9TTNB}ocO3j$7ij!li8#k6
+z@2tSd1>K03K9A#_-MIq)S;T#oE^;>U$)&}okIvDf3lm?kI{d80$>~<aBIV=g^}I;q
+zHz)SwoEc)S_BbfR&P{vn%<b8oJvk9{`Zix4ac<U&X5Y>xKUoS!%q1Pi?WpsUUt(tI
+ztjNjY*y&Rm9(S(DC2GuPHBJs@5M{RGm`c1z<6nwyN^)rMo-AS{M2$oM9|y%fM|}G~
+DHx0+F
+
+literal 0
+HcmV?d00001
+
+diff --git a/trade-service/gradle/wrapper/gradle-wrapper.properties b/trade-service/gradle/wrapper/gradle-wrapper.properties
+new file mode 100644
+index 0000000..a4cf193
+--- /dev/null
++++ b/trade-service/gradle/wrapper/gradle-wrapper.properties
+@@ -0,0 +1,8 @@
++distributionBase=GRADLE_USER_HOME
++distributionPath=wrapper/dists
++distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
++distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
++networkTimeout=10000
++validateDistributionUrl=true
++zipStoreBase=GRADLE_USER_HOME
++zipStorePath=wrapper/dists
+diff --git a/trade-service/gradlew b/trade-service/gradlew
+new file mode 100755
+index 0000000..faf9300
+--- /dev/null
++++ b/trade-service/gradlew
+@@ -0,0 +1,251 @@
++#!/bin/sh
++
++#
++# Copyright © 2015-2021 the original authors.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#      https://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++#
++# SPDX-License-Identifier: Apache-2.0
++#
++
++##############################################################################
++#
++#   Gradle start up script for POSIX generated by Gradle.
++#
++#   Important for running:
++#
++#   (1) You need a POSIX-compliant shell to run this script. If your /bin/sh is
++#       noncompliant, but you have some other compliant shell such as ksh or
++#       bash, then to run this script, type that shell name before the whole
++#       command line, like:
++#
++#           ksh Gradle
++#
++#       Busybox and similar reduced shells will NOT work, because this script
++#       requires all of these POSIX shell features:
++#         * functions;
++#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
++#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
++#         * compound commands having a testable exit status, especially «case»;
++#         * various built-in commands including «command», «set», and «ulimit».
++#
++#   Important for patching:
++#
++#   (2) This script targets any POSIX shell, so it avoids extensions provided
++#       by Bash, Ksh, etc; in particular arrays are avoided.
++#
++#       The "traditional" practice of packing multiple parameters into a
++#       space-separated string is a well documented source of bugs and security
++#       problems, so this is (mostly) avoided, by progressively accumulating
++#       options in "$@", and eventually passing that to Java.
++#
++#       Where the inherited environment variables (DEFAULT_JVM_OPTS, JAVA_OPTS,
++#       and GRADLE_OPTS) rely on word-splitting, this is performed explicitly;
++#       see the in-line comments for details.
++#
++#       There are tweaks for specific operating systems such as AIX, CygWin,
++#       Darwin, MinGW, and NonStop.
++#
++#   (3) This script is generated from the Groovy template
++#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
++#       within the Gradle project.
++#
++#       You can find Gradle at https://github.com/gradle/gradle/.
++#
++##############################################################################
++
++# Attempt to set APP_HOME
++
++# Resolve links: $0 may be a link
++app_path=$0
++
++# Need this for daisy-chained symlinks.
++while
++    APP_HOME=${app_path%"${app_path##*/}"}  # leaves a trailing /; empty if no leading path
++    [ -h "$app_path" ]
++do
++    ls=$( ls -ld "$app_path" )
++    link=${ls#*' -> '}
++    case $link in             #(
++      /*)   app_path=$link ;; #(
++      *)    app_path=$APP_HOME$link ;;
++    esac
++done
++
++# This is normally unused
++# shellcheck disable=SC2034
++APP_BASE_NAME=${0##*/}
++# Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
++APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
++
++# Use the maximum available, or set MAX_FD != -1 to use that value.
++MAX_FD=maximum
++
++warn () {
++    echo "$*"
++} >&2
++
++die () {
++    echo
++    echo "$*"
++    echo
++    exit 1
++} >&2
++
++# OS specific support (must be 'true' or 'false').
++cygwin=false
++msys=false
++darwin=false
++nonstop=false
++case "$( uname )" in                #(
++  CYGWIN* )         cygwin=true  ;; #(
++  Darwin* )         darwin=true  ;; #(
++  MSYS* | MINGW* )  msys=true    ;; #(
++  NONSTOP* )        nonstop=true ;;
++esac
++
++CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
++
++
++# Determine the Java command to use to start the JVM.
++if [ -n "$JAVA_HOME" ] ; then
++    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
++        # IBM's JDK on AIX uses strange locations for the executables
++        JAVACMD=$JAVA_HOME/jre/sh/java
++    else
++        JAVACMD=$JAVA_HOME/bin/java
++    fi
++    if [ ! -x "$JAVACMD" ] ; then
++        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
++
++Please set the JAVA_HOME variable in your environment to match the
++location of your Java installation."
++    fi
++else
++    JAVACMD=java
++    if ! command -v java >/dev/null 2>&1
++    then
++        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
++
++Please set the JAVA_HOME variable in your environment to match the
++location of your Java installation."
++    fi
++fi
++
++# Increase the maximum file descriptors if we can.
++if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
++    case $MAX_FD in #(
++      max*)
++        # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
++        # shellcheck disable=SC2039,SC3045
++        MAX_FD=$( ulimit -H -n ) ||
++            warn "Could not query maximum file descriptor limit"
++    esac
++    case $MAX_FD in  #(
++      '' | soft) :;; #(
++      *)
++        # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
++        # shellcheck disable=SC2039,SC3045
++        ulimit -n "$MAX_FD" ||
++            warn "Could not set maximum file descriptor limit to $MAX_FD"
++    esac
++fi
++
++# Collect all arguments for the java command, stacking in reverse order:
++#   * args from the command line
++#   * the main class name
++#   * -classpath
++#   * -D...appname settings
++#   * --module-path (only if needed)
++#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and GRADLE_OPTS environment variables.
++
++# For Cygwin or MSYS, switch paths to Windows format before running java
++if "$cygwin" || "$msys" ; then
++    APP_HOME=$( cygpath --path --mixed "$APP_HOME" )
++    CLASSPATH=$( cygpath --path --mixed "$CLASSPATH" )
++
++    JAVACMD=$( cygpath --unix "$JAVACMD" )
++
++    # Now convert the arguments - kludge to limit ourselves to /bin/sh
++    for arg do
++        if
++            case $arg in                                #(
++              -*)   false ;;                            # don't mess with options #(
++              /?*)  t=${arg#/} t=/${t%%/*}              # looks like a POSIX filepath
++                    [ -e "$t" ] ;;                      #(
++              *)    false ;;
++            esac
++        then
++            arg=$( cygpath --path --ignore --mixed "$arg" )
++        fi
++        # Roll the args list around exactly as many times as the number of
++        # args, so each arg winds up back in the position where it started, but
++        # possibly modified.
++        #
++        # NB: a `for` loop captures its iteration list before it begins, so
++        # changing the positional parameters here affects neither the number of
++        # iterations, nor the values presented in `arg`.
++        shift                   # remove old arg
++        set -- "$@" "$arg"      # push replacement arg
++    done
++fi
++
++
++# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
++DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
++
++# Collect all arguments for the java command:
++#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
++#     and any embedded shellness will be escaped.
++#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
++#     treated as '${Hostname}' itself on the command line.
++
++set -- \
++        "-Dorg.gradle.appname=$APP_BASE_NAME" \
++        -classpath "$CLASSPATH" \
++        org.gradle.wrapper.GradleWrapperMain \
++        "$@"
++
++# Stop when "xargs" is not available.
++if ! command -v xargs >/dev/null 2>&1
++then
++    die "xargs is not available"
++fi
++
++# Use "xargs" to parse quoted args.
++#
++# With -n1 it outputs one arg per line, with the quotes and backslashes removed.
++#
++# In Bash we could simply go:
++#
++#   readarray ARGS < <( xargs -n1 <<<"$var" ) &&
++#   set -- "${ARGS[@]}" "$@"
++#
++# but POSIX shell has neither arrays nor command substitution, so instead we
++# post-process each arg (as a line of input to sed) to backslash-escape any
++# character that might be a shell metacharacter, then use eval to reverse
++# that process (while maintaining the separation between arguments), and wrap
++# the whole thing up as a single "set" statement.
++#
++# This will of course break if any of these variables contains a newline or
++# an unmatched quote.
++#
++
++eval "set -- $(
++        printf '%s\n' "$DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS" |
++        xargs -n1 |
++        sed ' s~[^-[:alnum:]+,./:=@_]~\\&~g; ' |
++        tr '\n' ' '
++    )" '"$@"'
++
++exec "$JAVACMD" "$@"
+diff --git a/trade-service/gradlew.bat b/trade-service/gradlew.bat
+new file mode 100644
+index 0000000..9b42019
+--- /dev/null
++++ b/trade-service/gradlew.bat
+@@ -0,0 +1,94 @@
++@rem
++@rem Copyright 2015 the original author or authors.
++@rem
++@rem Licensed under the Apache License, Version 2.0 (the "License");
++@rem you may not use this file except in compliance with the License.
++@rem You may obtain a copy of the License at
++@rem
++@rem      https://www.apache.org/licenses/LICENSE-2.0
++@rem
++@rem Unless required by applicable law or agreed to in writing, software
++@rem distributed under the License is distributed on an "AS IS" BASIS,
++@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++@rem See the License for the specific language governing permissions and
++@rem limitations under the License.
++@rem
++@rem SPDX-License-Identifier: Apache-2.0
++@rem
++
++@if "%DEBUG%"=="" @echo off
++@rem ##########################################################################
++@rem
++@rem  Gradle startup script for Windows
++@rem
++@rem ##########################################################################
++
++@rem Set local scope for the variables with windows NT shell
++if "%OS%"=="Windows_NT" setlocal
++
++set DIRNAME=%~dp0
++if "%DIRNAME%"=="" set DIRNAME=.
++@rem This is normally unused
++set APP_BASE_NAME=%~n0
++set APP_HOME=%DIRNAME%
++
++@rem Resolve any "." and ".." in APP_HOME to make it shorter.
++for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
++
++@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
++set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
++
++@rem Find java.exe
++if defined JAVA_HOME goto findJavaFromJavaHome
++
++set JAVA_EXE=java.exe
++%JAVA_EXE% -version >NUL 2>&1
++if %ERRORLEVEL% equ 0 goto execute
++
++echo. 1>&2
++echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
++echo. 1>&2
++echo Please set the JAVA_HOME variable in your environment to match the 1>&2
++echo location of your Java installation. 1>&2
++
++goto fail
++
++:findJavaFromJavaHome
++set JAVA_HOME=%JAVA_HOME:"=%
++set JAVA_EXE=%JAVA_HOME%/bin/java.exe
++
++if exist "%JAVA_EXE%" goto execute
++
++echo. 1>&2
++echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
++echo. 1>&2
++echo Please set the JAVA_HOME variable in your environment to match the 1>&2
++echo location of your Java installation. 1>&2
++
++goto fail
++
++:execute
++@rem Setup the command line
++
++set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
++
++
++@rem Execute Gradle
++"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
++
++:end
++@rem End local scope for the variables with windows NT shell
++if %ERRORLEVEL% equ 0 goto mainEnd
++
++:fail
++rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
++rem the _cmd.exe /c_ return code!
++set EXIT_CODE=%ERRORLEVEL%
++if %EXIT_CODE% equ 0 set EXIT_CODE=1
++if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
++exit /b %EXIT_CODE%
++
++:mainEnd
++if "%OS%"=="Windows_NT" endlocal
++
++:omega
 diff --git a/trade-service/openapi.yaml b/trade-service/openapi.yaml
 new file mode 100644
 index 0000000..34cff6d
@@ -21388,10 +20127,10 @@ index 0000000..52fe624
 +}
 diff --git a/trade-service/src/main/resources/application.properties b/trade-service/src/main/resources/application.properties
 new file mode 100644
-index 0000000..7b3d3f7
+index 0000000..34c50f4
 --- /dev/null
 +++ b/trade-service/src/main/resources/application.properties
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +server.port=${TRADING_SERVICE_PORT:18092}
 +server.forward-headers-strategy=framework
 +spring.threads.virtual.enabled=true
@@ -21404,7 +20143,6 @@ index 0000000..7b3d3f7
 +
 +# To avoid "Request header is too large" when application is backed by oidc proxy.
 +server.max-http-request-header-size=1000000
-+springdoc.swagger-ui.disable-swagger-default-url=true
 +
 +logging.level.root=info
 diff --git a/trade-service/src/main/test/java/finos/traderx/tradeservice/TradeServiceApplicationTests.java b/trade-service/src/main/test/java/finos/traderx/tradeservice/TradeServiceApplicationTests.java
@@ -21472,27 +20210,48 @@ index 0000000..4cc7b01
 \ No newline at end of file
 diff --git a/web-front-end/angular/Dockerfile.compose b/web-front-end/angular/Dockerfile.compose
 new file mode 100644
-index 0000000..7c68883
+index 0000000..0334f6b
 --- /dev/null
 +++ b/web-front-end/angular/Dockerfile.compose
-@@ -0,0 +1,14 @@
-+# syntax=docker/dockerfile:1.7
-+FROM node:20-alpine
+@@ -0,0 +1,35 @@
++# Production-optimized Angular with Nginx
++FROM node:22-alpine as builder
++
 +WORKDIR /app
-+COPY package*.json ./
-+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
-+    if [ -f package-lock.json ]; then \
-+      npm ci --no-audit --prefer-offline; \
-+    else \
-+      npm install --no-audit --prefer-offline; \
-+    fi
++
++# Copy package files and install all dependencies
++COPY package.json ./
++RUN npm install && npm cache clean --force
++
++# Copy source files and build for production
 +COPY . .
++RUN npm run build
++
++# Production stage with minimal nginx
++FROM nginx:alpine
++
++# Remove default nginx configuration
++RUN rm /etc/nginx/conf.d/default.conf
++
++# Copy built application (npm run build outputs to ./dist/browser/)
++COPY --from=builder /app/dist/browser /usr/share/nginx/html
++
++# Create simple nginx config for SPA
++RUN echo 'server { \
++    listen 18093; \
++    location / { \
++        root /usr/share/nginx/html; \
++        index index.html; \
++        try_files $uri $uri/ /index.html; \
++    } \
++}' > /etc/nginx/conf.d/default.conf
++
 +EXPOSE 18093
-+ENV WEB_SERVICE_PORT=18093
-+CMD ["npm", "run", "start"]
++
++CMD ["nginx", "-g", "daemon off;"]
 diff --git a/web-front-end/angular/Dockerfile.prod b/web-front-end/angular/Dockerfile.prod
 new file mode 100644
-index 0000000..a90f3fa
+index 0000000..0334f6b
 --- /dev/null
 +++ b/web-front-end/angular/Dockerfile.prod
 @@ -0,0 +1,35 @@
@@ -21502,8 +20261,8 @@ index 0000000..a90f3fa
 +WORKDIR /app
 +
 +# Copy package files and install all dependencies
-+COPY package.json package-lock.json ./
-+RUN npm ci && npm cache clean --force
++COPY package.json ./
++RUN npm install && npm cache clean --force
 +
 +# Copy source files and build for production
 +COPY . .
@@ -21576,13 +20335,13 @@ index 0000000..a4b147e
 +- `main/assets/img/FINOS_Icon_White.png`
 diff --git a/web-front-end/angular/SPEC.manifest.json b/web-front-end/angular/SPEC.manifest.json
 new file mode 100644
-index 0000000..ce9dae2
+index 0000000..23155c4
 --- /dev/null
 +++ b/web-front-end/angular/SPEC.manifest.json
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,33 @@
 +{
 +  "schemaVersion": "1.0.0",
-+  "generatedAtUtc": "2026-03-31T12:59:32Z",
++  "generatedAtUtc": "2026-07-22T12:27:30Z",
 +  "component": {
 +    "id": "web-front-end-angular",
 +    "kind": "ui",
@@ -21596,7 +20355,8 @@ index 0000000..ce9dae2
 +  "runtime": {
 +    "defaultPort": 18093,
 +    "dependsOn": ["account-service","trade-service","position-service","reference-data","people-service","trade-feed","trade-processor"],
-+    "requiredEnv": ["WEB_SERVICE_PORT"]
++    "requiredEnv": ["WEB_SERVICE_PORT"],
++    "healthHint": "http://<host>:18093/"
 +  },
 +  "contracts": {
 +    "primary": null
@@ -21815,6 +20575,152 @@ index 0000000..5ad43d5
 +        restartOnFileChange: true
 +    });
 +};
+diff --git a/web-front-end/angular/main/app/about/about.component.html b/web-front-end/angular/main/app/about/about.component.html
+new file mode 100644
+index 0000000..359aef6
+--- /dev/null
++++ b/web-front-end/angular/main/app/about/about.component.html
+@@ -0,0 +1,55 @@
++<div class="about-page" *ngIf="metadata$ | async as metadata">
++    <h2>About This TraderX State</h2>
++    <p class="about-lead">
++        State-aware metadata is generated at build time from repository state lineage contracts.
++    </p>
++
++    <section class="about-card">
++        <h3>Active State</h3>
++        <dl class="about-grid">
++            <dt>State ID</dt>
++            <dd>{{ metadata.stateId }}</dd>
++            <dt>State Title</dt>
++            <dd>{{ metadata.stateTitle }}</dd>
++            <dt>Track</dt>
++            <dd>{{ metadata.stateTrack }}</dd>
++            <dt>Generated</dt>
++            <dd>{{ formatGeneratedDate(metadata.generatedAtUtc) }}</dd>
++            <dt>Source Branch</dt>
++            <dd>
++                <a *ngIf="metadata.sourceBranchUrl; else sourceBranchText" [href]="metadata.sourceBranchUrl" target="_blank" rel="noopener noreferrer">
++                    {{ metadata.sourceBranch }}
++                </a>
++                <ng-template #sourceBranchText>{{ metadata.sourceBranch }}</ng-template>
++            </dd>
++        </dl>
++    </section>
++
++    <section class="about-card" *ngIf="metadata.previousStates.length > 0">
++        <h3>Lineage</h3>
++        <p class="about-lineage-link" *ngIf="metadata.lineageLinkUrl">
++            <a [href]="metadata.lineageLinkUrl" target="_blank" rel="noopener noreferrer">Open lineage map</a>
++        </p>
++        <ul class="lineage-list">
++            <li *ngFor="let entry of metadata.previousStates">
++                <strong>{{ entry.id }}</strong>
++                <span> - {{ entry.title }}</span>
++                <span class="lineage-summary">{{ entry.summary }}</span>
++                <span class="lineage-branch">
++                    (<a *ngIf="entry.sourceBranchUrl; else branchText" [href]="entry.sourceBranchUrl" target="_blank" rel="noopener noreferrer">{{ entry.sourceBranch }}</a>
++                    <ng-template #branchText>{{ entry.sourceBranch }}</ng-template>)
++                </span>
++            </li>
++        </ul>
++    </section>
++
++    <section class="about-card">
++        <h3>Tools</h3>
++        <p *ngIf="metadata.features.apiExplorer">
++            <a [href]="metadata.apiExplorerUrl">Open API explorer</a>
++        </p>
++        <p *ngIf="metadata.features.pubSubInspector">
++            <a [href]="metadata.pubSubInspectorUrl">Open Pub/Sub inspector</a>
++        </p>
++    </section>
++</div>
+diff --git a/web-front-end/angular/main/app/about/about.component.scss b/web-front-end/angular/main/app/about/about.component.scss
+new file mode 100644
+index 0000000..5af8668
+--- /dev/null
++++ b/web-front-end/angular/main/app/about/about.component.scss
+@@ -0,0 +1,45 @@
++.about-page {
++    padding: 1rem;
++}
++
++.about-lead {
++    margin-bottom: 1rem;
++}
++
++.about-card {
++    border: 1px solid #d4dbe5;
++    border-radius: 8px;
++    padding: 1rem;
++    margin-bottom: 1rem;
++    background: #fff;
++}
++
++.about-grid {
++    display: grid;
++    grid-template-columns: 160px 1fr;
++    gap: 0.5rem 1rem;
++    margin: 0;
++}
++
++.about-grid dt {
++    font-weight: 600;
++}
++
++.about-grid dd {
++    margin: 0;
++    word-break: break-word;
++}
++
++.lineage-list {
++    margin: 0;
++    padding-left: 1.2rem;
++}
++
++.lineage-list li {
++    margin-bottom: 0.6rem;
++}
++
++.lineage-summary {
++    display: block;
++    color: #2b3b52;
++}
+diff --git a/web-front-end/angular/main/app/about/about.component.ts b/web-front-end/angular/main/app/about/about.component.ts
+new file mode 100644
+index 0000000..8ecbcea
+--- /dev/null
++++ b/web-front-end/angular/main/app/about/about.component.ts
+@@ -0,0 +1,28 @@
++import { CommonModule } from '@angular/common';
++import { Component } from '@angular/core';
++import { Observable } from 'rxjs';
++import { StateUiMetadata } from '../model/state-ui-metadata.model';
++import { StateMetadataService } from '../service/state-metadata.service';
++
++@Component({
++    standalone: true,
++    selector: 'app-about',
++    imports: [CommonModule],
++    templateUrl: './about.component.html',
++    styleUrls: ['./about.component.scss']
++})
++export class AboutComponent {
++    readonly metadata$: Observable<StateUiMetadata>;
++
++    constructor(private readonly stateMetadataService: StateMetadataService) {
++        this.metadata$ = this.stateMetadataService.metadata$;
++    }
++
++    formatGeneratedDate(value: string): string {
++        if (!value) {
++            return 'Unavailable';
++        }
++        const parsed = new Date(value);
++        return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleString();
++    }
++}
 diff --git a/web-front-end/angular/main/app/accounts/account.component.html b/web-front-end/angular/main/app/accounts/account.component.html
 new file mode 100644
 index 0000000..6e0beca
@@ -22338,10 +21244,10 @@ index 0000000..c68e243
 \ No newline at end of file
 diff --git a/web-front-end/angular/main/app/accounts/user/assign-user.component.spec.ts b/web-front-end/angular/main/app/accounts/user/assign-user.component.spec.ts
 new file mode 100644
-index 0000000..576aaae
+index 0000000..8b0554b
 --- /dev/null
 +++ b/web-front-end/angular/main/app/accounts/user/assign-user.component.spec.ts
-@@ -0,0 +1,80 @@
+@@ -0,0 +1,79 @@
 +import { catchError } from 'rxjs/operators';
 +import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 +import { Account } from 'main/app/model/account.model';
@@ -22352,7 +21258,6 @@ index 0000000..576aaae
 +import { map, noop, Observable, Observer, of, switchMap, tap } from 'rxjs';
 +
 +@Component({
-+    standalone: false,
 +    selector: 'app-assign-user',
 +    templateUrl: 'assign-user.component.html'
 +})
@@ -22681,19 +21586,51 @@ index 0000000..cd6fd14
 \ No newline at end of file
 diff --git a/web-front-end/angular/main/app/header/header.component.html b/web-front-end/angular/main/app/header/header.component.html
 new file mode 100644
-index 0000000..f5543d2
+index 0000000..4a12b83
 --- /dev/null
 +++ b/web-front-end/angular/main/app/header/header.component.html
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,48 @@
 +<nav class="navbar navbar-expand-lg bg-body-tertiary text-bg-primary" data-bs-theme="dark">
-+    <div class="container-fluid">
-+        <img width="50px" src="assets/img/traderx-apple-touch-icon.png"/>
-+        <div style="font-size: 1.5em">FINOS | TraderX Sample Application</div>
-+        <img width="30px" src="assets/img/FINOS_Icon_White.png"/>
++    <div class="container-fluid top-bar-content">
++        <div class="brand-group">
++            <img width="50px" src="assets/img/traderx-apple-touch-icon.png"/>
++            <div class="app-title" *ngIf="metadata$ | async as metadata">{{ appTitle(metadata.stateId) }}</div>
++        </div>
++        <div class="system-group" *ngIf="metadata$ | async as metadata">
++            <div class="message-bus-indicator" [ngClass]="'message-bus-' + messageBusState" title="Message bus connection status">
++                <span class="message-bus-dot" aria-hidden="true"></span>
++                <span class="message-bus-label">Message Bus {{ messageBusStateLabel }}</span>
++            </div>
++            <small class="message-bus-notice" *ngIf="messageBusNotice">{{ messageBusNotice }}</small>
++            <div class="dropdown system-dropdown" [class.show]="isSystemMenuOpen" (click)="onSystemMenuInteraction($event)">
++                <button
++                    class="btn btn-sm btn-outline-light dropdown-toggle system-dropdown-toggle"
++                    type="button"
++                    [attr.aria-expanded]="isSystemMenuOpen"
++                    (click)="toggleSystemMenu($event)">
++                    System
++                </button>
++                <ul class="dropdown-menu dropdown-menu-end" [class.show]="isSystemMenuOpen">
++                    <li>
++                        <a class="dropdown-item" routerLink="/about" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" (click)="closeSystemMenu()">About</a>
++                    </li>
++                    <li *ngIf="metadata.features.statusPage">
++                        <a class="dropdown-item" routerLink="/status" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" (click)="closeSystemMenu()">Status</a>
++                    </li>
++                    <li *ngIf="metadata.features.apiExplorer">
++                        <a class="dropdown-item" [href]="metadata.apiExplorerUrl" (click)="closeSystemMenu()">API Explorer</a>
++                    </li>
++                    <li *ngIf="metadata.features.pubSubInspector">
++                        <a class="dropdown-item" [href]="metadata.pubSubInspectorUrl" (click)="closeSystemMenu()">Pub/Sub Inspector</a>
++                    </li>
++                </ul>
++            </div>
++            <img class="finos-logo" width="30px" src="assets/img/FINOS_Icon_White.png"/>
++        </div>
 +    </div>
 +</nav>
 +
-+<ul class="nav nav-tabs mt-3">
++<ul class="nav nav-tabs mt-3 functional-tabs">
 +    <li class="nav-item">
 +        <a class="nav-link" routerLink="/trade" routerLinkActive="active">Trade</a>
 +    </li>
@@ -22703,31 +21640,211 @@ index 0000000..f5543d2
 +</ul>
 diff --git a/web-front-end/angular/main/app/header/header.component.scss b/web-front-end/angular/main/app/header/header.component.scss
 new file mode 100644
-index 0000000..ecb8b3c
+index 0000000..89606da
 --- /dev/null
 +++ b/web-front-end/angular/main/app/header/header.component.scss
-@@ -0,0 +1,3 @@
+@@ -0,0 +1,139 @@
 +.navbar-brand {
 +    font-size: 15px;
 +}
-\ No newline at end of file
++
++.top-bar-content {
++    align-items: center;
++    display: flex;
++    flex-wrap: wrap;
++    gap: 0.75rem;
++    justify-content: space-between;
++}
++
++.brand-group {
++    align-items: center;
++    display: flex;
++    gap: 0.65rem;
++    min-width: 0;
++}
++
++.app-title {
++    font-size: 1.3rem;
++    font-weight: 600;
++}
++
++.system-group {
++    align-items: center;
++    display: flex;
++    flex-wrap: wrap;
++    gap: 0.6rem;
++    margin-left: auto;
++}
++
++.message-bus-indicator {
++    align-items: center;
++    border: 1px solid rgba(255, 255, 255, 0.32);
++    border-radius: 999px;
++    display: inline-flex;
++    font-size: 0.76rem;
++    font-weight: 600;
++    gap: 0.38rem;
++    line-height: 1;
++    padding: 0.24rem 0.62rem;
++}
++
++.message-bus-dot {
++    border-radius: 999px;
++    display: inline-block;
++    height: 0.55rem;
++    width: 0.55rem;
++}
++
++.message-bus-connected {
++    background: rgba(25, 135, 84, 0.18);
++    color: #dcfce7;
++}
++
++.message-bus-connected .message-bus-dot {
++    background: #22c55e;
++}
++
++.message-bus-connecting {
++    background: rgba(251, 191, 36, 0.2);
++    color: #fef3c7;
++}
++
++.message-bus-connecting .message-bus-dot {
++    background: #f59e0b;
++}
++
++.message-bus-disconnected {
++    background: rgba(239, 68, 68, 0.2);
++    color: #fee2e2;
++}
++
++.message-bus-disconnected .message-bus-dot {
++    background: #ef4444;
++}
++
++.message-bus-notice {
++    color: #d1fae5;
++    font-size: 0.7rem;
++    font-weight: 600;
++    line-height: 1;
++}
++
++.system-dropdown-toggle {
++    border-radius: 999px;
++    font-size: 0.9rem;
++    font-weight: 600;
++    min-width: 6.25rem;
++}
++
++.system-dropdown .dropdown-menu {
++    min-width: 12rem;
++}
++
++.system-dropdown .dropdown-item.active {
++    background-color: rgba(13, 110, 253, 0.15);
++    color: #0a58ca;
++}
++
++.finos-logo {
++    display: block;
++}
++
++.functional-tabs {
++    padding-inline: 0.75rem;
++}
++
++@media (max-width: 768px) {
++    .app-title {
++        font-size: 1.05rem;
++    }
++
++    .system-group {
++        justify-content: flex-end;
++        margin-left: 0;
++        width: 100%;
++    }
++
++    .message-bus-indicator {
++        order: 1;
++        width: 100%;
++    }
++
++    .message-bus-notice {
++        order: 2;
++        width: 100%;
++    }
++
++    .finos-logo {
++        margin-left: auto;
++        order: 4;
++    }
++
++    .system-dropdown {
++        order: 3;
++    }
++}
 diff --git a/web-front-end/angular/main/app/header/header.component.spec.ts b/web-front-end/angular/main/app/header/header.component.spec.ts
 new file mode 100644
-index 0000000..381e8e8
+index 0000000..539ee27
 --- /dev/null
 +++ b/web-front-end/angular/main/app/header/header.component.spec.ts
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,70 @@
 +import { ComponentFixture, TestBed } from '@angular/core/testing';
++import { HttpClientTestingModule } from '@angular/common/http/testing';
++import { RouterTestingModule } from '@angular/router/testing';
++import { BehaviorSubject } from 'rxjs';
 +
 +import { HeaderComponent } from './header.component';
++import { StateUiMetadata } from '../model/state-ui-metadata.model';
++import { StateMetadataService } from '../service/state-metadata.service';
++import { MessageBusConnectionState, TradeFeedService } from '../service/trade-feed.service';
++
++const DEFAULT_METADATA: StateUiMetadata = {
++  stateId: '001-baseline-uncontainerized-parity',
++  stateTitle: 'Simple App - Base Uncontainerized App',
++  stateTrack: 'prelude',
++  generatedAtUtc: '',
++  sourceBranch: 'code/generated-state-001-baseline-uncontainerized-parity',
++  sourceBranchUrl: '',
++  lineageLinkUrl: '',
++  apiExplorerUrl: '/api/docs',
++  pubSubInspectorUrl: '/api/docs/pubsub-inspector.html',
++  features: {
++    statusPage: false,
++    apiExplorer: false,
++    pubSubInspector: false
++  },
++  previousStates: [],
++  statusChecks: []
++};
 +
 +describe('HeaderComponent', () => {
 +  let component: HeaderComponent;
 +  let fixture: ComponentFixture<HeaderComponent>;
++  let metadata$: BehaviorSubject<StateUiMetadata>;
++  let connectionState$: BehaviorSubject<MessageBusConnectionState>;
 +
 +  beforeEach(async () => {
++    metadata$ = new BehaviorSubject<StateUiMetadata>(DEFAULT_METADATA);
++    connectionState$ = new BehaviorSubject<MessageBusConnectionState>('connected');
++
 +    await TestBed.configureTestingModule({
-+      declarations: [ HeaderComponent ]
++      declarations: [ HeaderComponent ],
++      imports: [HttpClientTestingModule, RouterTestingModule],
++      providers: [
++        {
++          provide: StateMetadataService,
++          useValue: {
++            metadata$: metadata$.asObservable()
++          }
++        },
++        {
++          provide: TradeFeedService,
++          useValue: {
++            connectionState$: connectionState$.asObservable()
++          }
++        }
++      ]
 +    })
 +    .compileComponents();
 +  });
@@ -22744,11 +21861,15 @@ index 0000000..381e8e8
 +});
 diff --git a/web-front-end/angular/main/app/header/header.component.ts b/web-front-end/angular/main/app/header/header.component.ts
 new file mode 100644
-index 0000000..3f06f2d
+index 0000000..f66dfeb
 --- /dev/null
 +++ b/web-front-end/angular/main/app/header/header.component.ts
-@@ -0,0 +1,16 @@
-+import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+@@ -0,0 +1,100 @@
++import { Component, HostListener, OnDestroy, OnInit, Output, EventEmitter } from '@angular/core';
++import { Observable, Subscription } from 'rxjs';
++import { StateUiMetadata } from '../model/state-ui-metadata.model';
++import { StateMetadataService } from '../service/state-metadata.service';
++import { MessageBusConnectionState, TradeFeedService } from '../service/trade-feed.service';
 +
 +@Component({
 +    standalone: false,
@@ -22756,13 +21877,93 @@ index 0000000..3f06f2d
 +  templateUrl: './header.component.html',
 +  styleUrls: ['./header.component.scss']
 +})
-+export class HeaderComponent implements OnInit {
++export class HeaderComponent implements OnInit, OnDestroy {
 +
 +  @Output() switchTheme = new EventEmitter();
++  metadata$: Observable<StateUiMetadata>;
++  isSystemMenuOpen = false;
++  messageBusState: MessageBusConnectionState = 'connecting';
++  messageBusStateLabel = 'Connecting';
++  messageBusNotice = '';
++  private connectionStateSubscription?: Subscription;
++  private reconnectNoticeTimer: ReturnType<typeof setTimeout> | null = null;
 +
-+  ngOnInit(): void {
++  constructor(
++    private readonly stateMetadataService: StateMetadataService,
++    private readonly tradeFeedService: TradeFeedService
++  ) {
++    this.metadata$ = this.stateMetadataService.metadata$;
 +  }
 +
++  ngOnInit(): void {
++    let previousState: MessageBusConnectionState = this.messageBusState;
++    this.connectionStateSubscription = this.tradeFeedService.connectionState$.subscribe((state) => {
++      this.messageBusState = state;
++      this.messageBusStateLabel = this.toStateLabel(state);
++      if (previousState === 'disconnected' && state === 'connected') {
++        this.messageBusNotice = 'message bus reconnected';
++        this.scheduleNoticeClear();
++      }
++      previousState = state;
++    });
++  }
++
++  ngOnDestroy(): void {
++    this.connectionStateSubscription?.unsubscribe();
++    this.clearNoticeTimer();
++  }
++
++  appTitle(stateId: string): string {
++    return `TraderX Sample Trading App (${stateId})`;
++  }
++
++  toggleSystemMenu(event: MouseEvent): void {
++    event.stopPropagation();
++    this.isSystemMenuOpen = !this.isSystemMenuOpen;
++  }
++
++  closeSystemMenu(): void {
++    this.isSystemMenuOpen = false;
++  }
++
++  onSystemMenuInteraction(event: MouseEvent): void {
++    event.stopPropagation();
++  }
++
++  @HostListener('document:click')
++  onDocumentClick(): void {
++    this.closeSystemMenu();
++  }
++
++  @HostListener('document:keydown.escape')
++  onEscapeKey(): void {
++    this.closeSystemMenu();
++  }
++
++  private toStateLabel(state: MessageBusConnectionState): string {
++    if (state === 'connected') {
++      return 'Connected';
++    }
++    if (state === 'disconnected') {
++      return 'Disconnected';
++    }
++    return 'Connecting';
++  }
++
++  private scheduleNoticeClear(): void {
++    this.clearNoticeTimer();
++    this.reconnectNoticeTimer = setTimeout(() => {
++      this.messageBusNotice = '';
++      this.reconnectNoticeTimer = null;
++    }, 2500);
++  }
++
++  private clearNoticeTimer(): void {
++    if (this.reconnectNoticeTimer !== null) {
++      clearTimeout(this.reconnectNoticeTimer);
++      this.reconnectNoticeTimer = null;
++    }
++  }
 +}
 diff --git a/web-front-end/angular/main/app/model/account.model.ts b/web-front-end/angular/main/app/model/account.model.ts
 new file mode 100644
@@ -22773,6 +21974,45 @@ index 0000000..1198026
 +export interface Account {
 +    id: number;
 +    displayName: string;
++}
+diff --git a/web-front-end/angular/main/app/model/state-ui-metadata.model.ts b/web-front-end/angular/main/app/model/state-ui-metadata.model.ts
+new file mode 100644
+index 0000000..88bb3be
+--- /dev/null
++++ b/web-front-end/angular/main/app/model/state-ui-metadata.model.ts
+@@ -0,0 +1,33 @@
++export interface LineageStateEntry {
++    id: string;
++    title: string;
++    sourceBranch: string;
++    sourceBranchUrl: string;
++    summary: string;
++}
++
++export interface StatusCheckDefinition {
++    id: string;
++    name: string;
++    url: string;
++    expectedStatuses: number[];
++}
++
++export interface StateUiMetadata {
++    stateId: string;
++    stateTitle: string;
++    stateTrack: string;
++    generatedAtUtc: string;
++    sourceBranch: string;
++    sourceBranchUrl: string;
++    lineageLinkUrl: string;
++    apiExplorerUrl: string;
++    pubSubInspectorUrl: string;
++    features: {
++        statusPage: boolean;
++        apiExplorer: boolean;
++        pubSubInspector: boolean;
++    };
++    previousStates: LineageStateEntry[];
++    statusChecks: StatusCheckDefinition[];
 +}
 diff --git a/web-front-end/angular/main/app/model/symbol.model.ts b/web-front-end/angular/main/app/model/symbol.model.ts
 new file mode 100644
@@ -22869,16 +22109,20 @@ index 0000000..718a2da
 +}
 diff --git a/web-front-end/angular/main/app/routing.ts b/web-front-end/angular/main/app/routing.ts
 new file mode 100644
-index 0000000..39d4aab
+index 0000000..905e132
 --- /dev/null
 +++ b/web-front-end/angular/main/app/routing.ts
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,15 @@
 +import { Routes } from '@angular/router';
++import { AboutComponent } from './about/about.component';
++import { StatusComponent } from './status/status.component';
 +import { AccountComponent } from './accounts/account.component';
 +import { PageNotFoundComponent } from './page-not-found.component';
 +import { TradeComponent } from './trade/trade.component';
 +
 +export const routes: Routes = [
++    { path: 'about', component: AboutComponent },
++    { path: 'status', component: StatusComponent },
 +    { path: 'trade', component: TradeComponent },
 +    { path: 'account', component: AccountComponent },
 +    { path: '', redirectTo: '/trade', pathMatch: 'full' }, // redirect to `first-component`
@@ -22948,6 +22192,153 @@ index 0000000..ed43057
 +    );
 +  }
 +}
+diff --git a/web-front-end/angular/main/app/service/fdc3-ticker-compatibility-bridge.service.spec.ts b/web-front-end/angular/main/app/service/fdc3-ticker-compatibility-bridge.service.spec.ts
+new file mode 100644
+index 0000000..f11f91d
+--- /dev/null
++++ b/web-front-end/angular/main/app/service/fdc3-ticker-compatibility-bridge.service.spec.ts
+@@ -0,0 +1,61 @@
++import { Fdc3TickerCompatibilityBridgeService } from './fdc3-ticker-compatibility-bridge.service';
++
++describe('Fdc3TickerCompatibilityBridgeService', () => {
++    let service: Fdc3TickerCompatibilityBridgeService;
++
++    beforeEach(() => {
++        service = new Fdc3TickerCompatibilityBridgeService();
++    });
++
++    it('should normalize outbound TraderX tickers without remapping symbols', () => {
++        expect(service.toInteropTicker(' ibm ')).toEqual('IBM');
++        expect(service.toInteropTicker('MS')).toEqual('MS');
++        expect(service.toInteropTicker('nvda')).toEqual('NVDA');
++    });
++
++    it('should normalize inbound interop tickers without remapping symbols', () => {
++        expect(service.fromInteropTicker('aapl')).toEqual('AAPL');
++        expect(service.fromInteropTicker('NASDAQ:msft')).toEqual('MSFT');
++        expect(service.fromInteropTicker('ORCL')).toEqual('ORCL');
++    });
++
++    it('should produce fdc3.instrument context from a TraderX ticker', () => {
++        expect(service.toInstrumentContext('c')).toEqual({
++            type: 'fdc3.instrument',
++            id: {
++                ticker: 'C'
++            }
++        });
++    });
++
++    it('should keep TradingView ticker payloads as bare canonical symbols', () => {
++        expect(service.toTradingViewTicker('c')).toEqual('C');
++        expect(service.toTradingViewTicker('msft')).toEqual('MSFT');
++        expect(service.toTradingViewTicker('ORCL')).toEqual('ORCL');
++    });
++
++    it('should use bare ticker for ViewInstrument intent context', () => {
++        expect(service.toViewInstrumentIntentContext('c')).toEqual({
++            type: 'fdc3.instrument',
++            id: {
++                ticker: 'C'
++            }
++        });
++    });
++
++    it('should extract a TraderX ticker from inbound instrument context', () => {
++        expect(service.fromInstrumentContext({
++            type: 'fdc3.instrument',
++            id: {
++                ticker: 'NASDAQ:AMZN'
++            }
++        })).toEqual('AMZN');
++    });
++
++    it('should return undefined for malformed context payloads', () => {
++        expect(service.fromInstrumentContext(undefined)).toBeUndefined();
++        expect(service.fromInstrumentContext(null)).toBeUndefined();
++        expect(service.fromInstrumentContext({ type: 'fdc3.contact', id: { ticker: 'AAPL' } })).toBeUndefined();
++        expect(service.fromInstrumentContext({ type: 'fdc3.instrument', id: {} })).toBeUndefined();
++    });
++});
+diff --git a/web-front-end/angular/main/app/service/fdc3-ticker-compatibility-bridge.service.ts b/web-front-end/angular/main/app/service/fdc3-ticker-compatibility-bridge.service.ts
+new file mode 100644
+index 0000000..9e39552
+--- /dev/null
++++ b/web-front-end/angular/main/app/service/fdc3-ticker-compatibility-bridge.service.ts
+@@ -0,0 +1,74 @@
++import { Injectable } from '@angular/core';
++
++export interface Fdc3InstrumentContext {
++    type: 'fdc3.instrument';
++    id: {
++        ticker: string;
++        [key: string]: string;
++    };
++}
++
++type InstrumentContextLike = {
++    type?: unknown;
++    id?: { [key: string]: unknown } | null;
++} | null | undefined;
++
++@Injectable({
++    providedIn: 'root'
++})
++export class Fdc3TickerCompatibilityBridgeService {
++    normalizeTicker(rawTicker: string | null | undefined): string | undefined {
++        if (typeof rawTicker !== 'string') {
++            return undefined;
++        }
++        let normalized = rawTicker.trim().toUpperCase();
++        if (!normalized) {
++            return undefined;
++        }
++        if (normalized.includes(':')) {
++            normalized = normalized.split(':').pop() ?? normalized;
++        }
++        normalized = normalized.replace(/\s+/g, '');
++        return normalized || undefined;
++    }
++
++    toInteropTicker(rawTraderxTicker: string | null | undefined): string | undefined {
++        return this.normalizeTicker(rawTraderxTicker);
++    }
++
++    fromInteropTicker(rawInteropTicker: string | null | undefined): string | undefined {
++        return this.normalizeTicker(rawInteropTicker);
++    }
++
++    toTradingViewTicker(rawTraderxTicker: string | null | undefined): string | undefined {
++        return this.normalizeTicker(rawTraderxTicker);
++    }
++
++    toInstrumentContext(rawTraderxTicker: string | null | undefined): Fdc3InstrumentContext | undefined {
++        const interopTicker = this.toInteropTicker(rawTraderxTicker);
++        if (!interopTicker) {
++            return undefined;
++        }
++        return {
++            type: 'fdc3.instrument',
++            id: {
++                ticker: interopTicker
++            }
++        };
++    }
++
++    toViewInstrumentIntentContext(rawTraderxTicker: string | null | undefined): Fdc3InstrumentContext | undefined {
++        return this.toInstrumentContext(rawTraderxTicker);
++    }
++
++    fromInstrumentContext(context: InstrumentContextLike): string | undefined {
++        if (!context || typeof context !== 'object') {
++            return undefined;
++        }
++        if (typeof context.type === 'string' && context.type !== 'fdc3.instrument') {
++            return undefined;
++        }
++        const ticker = context.id && typeof context.id.ticker === 'string' ? context.id.ticker : undefined;
++        return this.fromInteropTicker(ticker);
++    }
++}
 diff --git a/web-front-end/angular/main/app/service/position.service.ts b/web-front-end/angular/main/app/service/position.service.ts
 new file mode 100644
 index 0000000..83e673b
@@ -22996,6 +22387,118 @@ index 0000000..83e673b
 +    private handleError(error: HttpErrorResponse) {
 +        console.error(error);
 +        return throwError(() => error);
++    }
++}
+diff --git a/web-front-end/angular/main/app/service/state-metadata.service.ts b/web-front-end/angular/main/app/service/state-metadata.service.ts
+new file mode 100644
+index 0000000..cdc0ec5
+--- /dev/null
++++ b/web-front-end/angular/main/app/service/state-metadata.service.ts
+@@ -0,0 +1,106 @@
++import { HttpClient } from '@angular/common/http';
++import { Injectable } from '@angular/core';
++import { BehaviorSubject, Observable, of } from 'rxjs';
++import { catchError, map } from 'rxjs/operators';
++import { StateUiMetadata, StatusCheckDefinition } from '../model/state-ui-metadata.model';
++
++const DEFAULT_STATUS_CHECKS: StatusCheckDefinition[] = [
++    {
++        id: 'account-service',
++        name: 'Account Service',
++        url: `${window.location.protocol}//${window.location.hostname}:18088/account/22214`,
++        expectedStatuses: [200]
++    },
++    {
++        id: 'reference-data',
++        name: 'Reference Data',
++        url: `${window.location.protocol}//${window.location.hostname}:18085/stocks`,
++        expectedStatuses: [200]
++    },
++    {
++        id: 'position-service',
++        name: 'Position Service',
++        url: `${window.location.protocol}//${window.location.hostname}:18090/health/alive`,
++        expectedStatuses: [200]
++    },
++    {
++        id: 'trade-service',
++        name: 'Trade Service',
++        url: `${window.location.protocol}//${window.location.hostname}:18092/v3/api-docs`,
++        expectedStatuses: [200]
++    },
++    {
++        id: 'people-service',
++        name: 'People Service',
++        url: `${window.location.protocol}//${window.location.hostname}:18089/People/GetPerson?LogonId=user01`,
++        expectedStatuses: [200]
++    },
++    {
++        id: 'trade-feed',
++        name: 'Trade Feed',
++        url: `${window.location.protocol}//${window.location.hostname}:18086/socket.io/?EIO=4&transport=polling`,
++        expectedStatuses: [200]
++    }
++];
++
++const DEFAULT_METADATA: StateUiMetadata = {
++    stateId: '001-baseline-uncontainerized-parity',
++    stateTitle: 'Simple App - Base Uncontainerized App',
++    stateTrack: 'prelude',
++    generatedAtUtc: '',
++    sourceBranch: 'code/generated-state-001-baseline-uncontainerized-parity',
++    sourceBranchUrl: '',
++    lineageLinkUrl: '',
++    apiExplorerUrl: '/api/docs',
++    pubSubInspectorUrl: '/api/docs/pubsub-inspector.html',
++    features: {
++        statusPage: false,
++        apiExplorer: false,
++        pubSubInspector: false
++    },
++    previousStates: [],
++    statusChecks: DEFAULT_STATUS_CHECKS
++};
++
++@Injectable({
++    providedIn: 'root'
++})
++export class StateMetadataService {
++    private readonly metadataSubject = new BehaviorSubject<StateUiMetadata>(DEFAULT_METADATA);
++    readonly metadata$: Observable<StateUiMetadata> = this.metadataSubject.asObservable();
++
++    constructor(private readonly httpClient: HttpClient) {
++        this.refresh();
++    }
++
++    refresh(): void {
++        this.httpClient.get<StateUiMetadata>('assets/state-ui.json').pipe(
++            map((metadata) => this.normalize(metadata)),
++            catchError((error) => {
++                console.warn('[state-metadata] using defaults due to load error', error);
++                return of(DEFAULT_METADATA);
++            })
++        ).subscribe((metadata) => this.metadataSubject.next(metadata));
++    }
++
++    snapshot(): StateUiMetadata {
++        return this.metadataSubject.value;
++    }
++
++    private normalize(metadata: StateUiMetadata): StateUiMetadata {
++        const statusChecks = Array.isArray(metadata?.statusChecks) && metadata.statusChecks.length > 0
++            ? metadata.statusChecks
++            : DEFAULT_STATUS_CHECKS;
++
++        return {
++            ...DEFAULT_METADATA,
++            ...metadata,
++            features: {
++                ...DEFAULT_METADATA.features,
++                ...(metadata?.features ?? {})
++            },
++            previousStates: Array.isArray(metadata?.previousStates) ? metadata.previousStates : [],
++            statusChecks
++        };
 +    }
 +}
 diff --git a/web-front-end/angular/main/app/service/symbols.service.ts b/web-front-end/angular/main/app/service/symbols.service.ts
@@ -23069,19 +22572,24 @@ index 0000000..0b1350f
 +}
 diff --git a/web-front-end/angular/main/app/service/trade-feed.service.ts b/web-front-end/angular/main/app/service/trade-feed.service.ts
 new file mode 100644
-index 0000000..1ef4b81
+index 0000000..829fa19
 --- /dev/null
 +++ b/web-front-end/angular/main/app/service/trade-feed.service.ts
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,64 @@
 +import { Injectable } from '@angular/core';
 +import { environment } from 'main/environments/environment';
++import { BehaviorSubject } from 'rxjs';
 +import { io, Socket } from "socket.io-client";
++
++export type MessageBusConnectionState = 'connecting' | 'connected' | 'disconnected';
 +
 +@Injectable({
 +    providedIn: 'root'
 +})
 +export class TradeFeedService {
 +    private socket: Socket;
++    private readonly connectionStateSubject = new BehaviorSubject<MessageBusConnectionState>('connecting');
++    public readonly connectionState$ = this.connectionStateSubject.asObservable();
 +
 +    constructor() {
 +        this.connect();
@@ -23093,14 +22601,21 @@ index 0000000..1ef4b81
 +        
 +        this.socket.on("connect", this.onConnect);
 +        this.socket.on("disconnect", this.onDisconnect);
++        this.socket.on("reconnect_attempt", this.onReconnectAttempt);
 +    }
 +
 +    private onConnect = () => {
++        this.connectionStateSubject.next('connected');
 +        console.log('Trade feed is connected, connection id' + this.socket.id);
 +    }
 +
 +    private onDisconnect = () => {
++        this.connectionStateSubject.next('disconnected');
 +        console.log('Trade feed is disconnected, connection id was ' + this.socket.id);
++    }
++
++    private onReconnectAttempt = () => {
++        this.connectionStateSubject.next('connecting');
 +    }
 +
 +    public subscribe(topic: string, callback: (...args: any[]) => void) {
@@ -23125,6 +22640,447 @@ index 0000000..1ef4b81
 +        this.socket.off('publish', callback)
 +    }
 +}
+diff --git a/web-front-end/angular/main/app/service/tradingview-symbol-map.ts b/web-front-end/angular/main/app/service/tradingview-symbol-map.ts
+new file mode 100644
+index 0000000..c551876
+--- /dev/null
++++ b/web-front-end/angular/main/app/service/tradingview-symbol-map.ts
+@@ -0,0 +1,435 @@
++// AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
++// Generated by tools/generate-tradingview-symbol-map.py on 2026-04-16T23:37:29Z
++// Source: https://en.wikipedia.org/wiki/List_of_S%26P_500_companies
++
++export const TRADINGVIEW_QUALIFIED_TICKER_BY_TRADERX_SYMBOL: { [ticker: string]: string } = {
++    'A': 'NYSE:A',
++    'AAPL': 'NASDAQ:AAPL',
++    'ABBV': 'NYSE:ABBV',
++    'ABT': 'NYSE:ABT',
++    'ACN': 'NYSE:ACN',
++    'ADBE': 'NASDAQ:ADBE',
++    'ADI': 'NASDAQ:ADI',
++    'ADM': 'NYSE:ADM',
++    'ADP': 'NASDAQ:ADP',
++    'ADSK': 'NASDAQ:ADSK',
++    'AEE': 'NYSE:AEE',
++    'AEP': 'NASDAQ:AEP',
++    'AES': 'NYSE:AES',
++    'AFL': 'NYSE:AFL',
++    'AIG': 'NYSE:AIG',
++    'AIZ': 'NYSE:AIZ',
++    'AJG': 'NYSE:AJG',
++    'AKAM': 'NASDAQ:AKAM',
++    'ALB': 'NYSE:ALB',
++    'ALGN': 'NASDAQ:ALGN',
++    'ALL': 'NYSE:ALL',
++    'ALLE': 'NYSE:ALLE',
++    'AMAT': 'NASDAQ:AMAT',
++    'AMCR': 'NYSE:AMCR',
++    'AMD': 'NASDAQ:AMD',
++    'AME': 'NYSE:AME',
++    'AMGN': 'NASDAQ:AMGN',
++    'AMP': 'NYSE:AMP',
++    'AMT': 'NYSE:AMT',
++    'AMZN': 'NASDAQ:AMZN',
++    'ANET': 'NYSE:ANET',
++    'AON': 'NYSE:AON',
++    'AOS': 'NYSE:AOS',
++    'APA': 'NASDAQ:APA',
++    'APD': 'NYSE:APD',
++    'APH': 'NYSE:APH',
++    'APTV': 'NYSE:APTV',
++    'ARE': 'NYSE:ARE',
++    'ATO': 'NYSE:ATO',
++    'AVB': 'NYSE:AVB',
++    'AVGO': 'NASDAQ:AVGO',
++    'AVY': 'NYSE:AVY',
++    'AWK': 'NYSE:AWK',
++    'AXP': 'NYSE:AXP',
++    'AZO': 'NYSE:AZO',
++    'BA': 'NYSE:BA',
++    'BAC': 'NYSE:BAC',
++    'BAX': 'NYSE:BAX',
++    'BBY': 'NYSE:BBY',
++    'BDX': 'NYSE:BDX',
++    'BEN': 'NYSE:BEN',
++    'BF.B': 'NYSE:BF.B',
++    'BIIB': 'NASDAQ:BIIB',
++    'BK': 'NYSE:BK',
++    'BKNG': 'NASDAQ:BKNG',
++    'BKR': 'NASDAQ:BKR',
++    'BLK': 'NYSE:BLK',
++    'BMY': 'NYSE:BMY',
++    'BR': 'NYSE:BR',
++    'BRK.B': 'NYSE:BRK.B',
++    'BRO': 'NYSE:BRO',
++    'BSX': 'NYSE:BSX',
++    'BXP': 'NYSE:BXP',
++    'C': 'NYSE:C',
++    'CAG': 'NYSE:CAG',
++    'CAH': 'NYSE:CAH',
++    'CARR': 'NYSE:CARR',
++    'CAT': 'NYSE:CAT',
++    'CB': 'NYSE:CB',
++    'CBRE': 'NYSE:CBRE',
++    'CCI': 'NYSE:CCI',
++    'CCL': 'NYSE:CCL',
++    'CDNS': 'NASDAQ:CDNS',
++    'CDW': 'NASDAQ:CDW',
++    'CEG': 'NASDAQ:CEG',
++    'CF': 'NYSE:CF',
++    'CFG': 'NYSE:CFG',
++    'CHD': 'NYSE:CHD',
++    'CHRW': 'NASDAQ:CHRW',
++    'CHTR': 'NASDAQ:CHTR',
++    'CI': 'NYSE:CI',
++    'CINF': 'NASDAQ:CINF',
++    'CL': 'NYSE:CL',
++    'CLX': 'NYSE:CLX',
++    'CMCSA': 'NASDAQ:CMCSA',
++    'CME': 'NASDAQ:CME',
++    'CMG': 'NYSE:CMG',
++    'CMI': 'NYSE:CMI',
++    'CMS': 'NYSE:CMS',
++    'CNC': 'NYSE:CNC',
++    'CNP': 'NYSE:CNP',
++    'COF': 'NYSE:COF',
++    'COO': 'NASDAQ:COO',
++    'COP': 'NYSE:COP',
++    'COST': 'NASDAQ:COST',
++    'CPB': 'NYSE:CPB',
++    'CPRT': 'NASDAQ:CPRT',
++    'CRL': 'NYSE:CRL',
++    'CRM': 'NYSE:CRM',
++    'CSCO': 'NASDAQ:CSCO',
++    'CSX': 'NASDAQ:CSX',
++    'CTAS': 'NASDAQ:CTAS',
++    'CTRA': 'NYSE:CTRA',
++    'CTSH': 'NASDAQ:CTSH',
++    'CTVA': 'NYSE:CTVA',
++    'CVS': 'NYSE:CVS',
++    'CVX': 'NYSE:CVX',
++    'D': 'NYSE:D',
++    'DAL': 'NYSE:DAL',
++    'DB': 'NYSE:DB',
++    'DD': 'NYSE:DD',
++    'DE': 'NYSE:DE',
++    'DFS': 'NYSE:DFS',
++    'DG': 'NYSE:DG',
++    'DGX': 'NYSE:DGX',
++    'DHI': 'NYSE:DHI',
++    'DHR': 'NYSE:DHR',
++    'DIS': 'NYSE:DIS',
++    'DLR': 'NYSE:DLR',
++    'DLTR': 'NASDAQ:DLTR',
++    'DOV': 'NYSE:DOV',
++    'DOW': 'NYSE:DOW',
++    'DPZ': 'NYSE:DPZ',
++    'DRI': 'NYSE:DRI',
++    'DTE': 'NYSE:DTE',
++    'DUK': 'NYSE:DUK',
++    'DVA': 'NYSE:DVA',
++    'DVN': 'NYSE:DVN',
++    'DXCM': 'NASDAQ:DXCM',
++    'EA': 'NASDAQ:EA',
++    'EBAY': 'NASDAQ:EBAY',
++    'ECL': 'NYSE:ECL',
++    'ED': 'NYSE:ED',
++    'EFX': 'NYSE:EFX',
++    'EIX': 'NYSE:EIX',
++    'EL': 'NYSE:EL',
++    'EMR': 'NYSE:EMR',
++    'EOG': 'NYSE:EOG',
++    'EPAM': 'NYSE:EPAM',
++    'EQIX': 'NASDAQ:EQIX',
++    'EQR': 'NYSE:EQR',
++    'ES': 'NYSE:ES',
++    'ESS': 'NYSE:ESS',
++    'ETN': 'NYSE:ETN',
++    'ETR': 'NYSE:ETR',
++    'EVRG': 'NYSE:EVRG',
++    'EW': 'NYSE:EW',
++    'EXC': 'NASDAQ:EXC',
++    'EXPD': 'NASDAQ:EXPD',
++    'EXPE': 'NASDAQ:EXPE',
++    'EXR': 'NYSE:EXR',
++    'F': 'NYSE:F',
++    'FANG': 'NASDAQ:FANG',
++    'FAST': 'NASDAQ:FAST',
++    'FCX': 'NYSE:FCX',
++    'FDS': 'NYSE:FDS',
++    'FDX': 'NYSE:FDX',
++    'FE': 'NYSE:FE',
++    'FFIV': 'NASDAQ:FFIV',
++    'FIS': 'NYSE:FIS',
++    'FISV': 'NASDAQ:FISV',
++    'FITB': 'NASDAQ:FITB',
++    'FNF': 'NYSE:FNF',
++    'FNMA': 'OTCMKTS:FNMA',
++    'FOX': 'NASDAQ:FOX',
++    'FOXA': 'NASDAQ:FOXA',
++    'FRT': 'NYSE:FRT',
++    'FTNT': 'NASDAQ:FTNT',
++    'FTV': 'NYSE:FTV',
++    'GD': 'NYSE:GD',
++    'GE': 'NYSE:GE',
++    'GILD': 'NASDAQ:GILD',
++    'GIS': 'NYSE:GIS',
++    'GL': 'NYSE:GL',
++    'GLW': 'NYSE:GLW',
++    'GM': 'NYSE:GM',
++    'GNRC': 'NYSE:GNRC',
++    'GOOG': 'NASDAQ:GOOG',
++    'GOOGL': 'NASDAQ:GOOGL',
++    'GPC': 'NYSE:GPC',
++    'GPN': 'NYSE:GPN',
++    'GRMN': 'NYSE:GRMN',
++    'GS': 'NYSE:GS',
++    'GWW': 'NYSE:GWW',
++    'HAL': 'NYSE:HAL',
++    'HAS': 'NASDAQ:HAS',
++    'HBAN': 'NASDAQ:HBAN',
++    'HCA': 'NYSE:HCA',
++    'HD': 'NYSE:HD',
++    'HIG': 'NYSE:HIG',
++    'HII': 'NYSE:HII',
++    'HLT': 'NYSE:HLT',
++    'HON': 'NASDAQ:HON',
++    'HPE': 'NYSE:HPE',
++    'HPQ': 'NYSE:HPQ',
++    'HRL': 'NYSE:HRL',
++    'HSIC': 'NASDAQ:HSIC',
++    'HST': 'NASDAQ:HST',
++    'HSY': 'NYSE:HSY',
++    'HUM': 'NYSE:HUM',
++    'HWM': 'NYSE:HWM',
++    'IBM': 'NYSE:IBM',
++    'ICE': 'NYSE:ICE',
++    'IDXX': 'NASDAQ:IDXX',
++    'IEX': 'NYSE:IEX',
++    'IFF': 'NYSE:IFF',
++    'INCY': 'NASDAQ:INCY',
++    'INTC': 'NASDAQ:INTC',
++    'INTU': 'NASDAQ:INTU',
++    'IP': 'NYSE:IP',
++    'IQV': 'NYSE:IQV',
++    'IR': 'NYSE:IR',
++    'IRM': 'NYSE:IRM',
++    'ISRG': 'NASDAQ:ISRG',
++    'IT': 'NYSE:IT',
++    'ITW': 'NYSE:ITW',
++    'IVZ': 'NYSE:IVZ',
++    'J': 'NYSE:J',
++    'JBHT': 'NASDAQ:JBHT',
++    'JCI': 'NYSE:JCI',
++    'JKHY': 'NASDAQ:JKHY',
++    'JNJ': 'NYSE:JNJ',
++    'JPM': 'NYSE:JPM',
++    'KEY': 'NYSE:KEY',
++    'KEYS': 'NYSE:KEYS',
++    'KHC': 'NASDAQ:KHC',
++    'KIM': 'NYSE:KIM',
++    'KLAC': 'NASDAQ:KLAC',
++    'KMB': 'NASDAQ:KMB',
++    'KMI': 'NYSE:KMI',
++    'KO': 'NYSE:KO',
++    'KR': 'NYSE:KR',
++    'L': 'NYSE:L',
++    'LDOS': 'NYSE:LDOS',
++    'LEN': 'NYSE:LEN',
++    'LH': 'NYSE:LH',
++    'LHX': 'NYSE:LHX',
++    'LIN': 'NASDAQ:LIN',
++    'LLY': 'NYSE:LLY',
++    'LMT': 'NYSE:LMT',
++    'LNT': 'NASDAQ:LNT',
++    'LOW': 'NYSE:LOW',
++    'LRCX': 'NASDAQ:LRCX',
++    'LUV': 'NYSE:LUV',
++    'LVS': 'NYSE:LVS',
++    'LYB': 'NYSE:LYB',
++    'LYV': 'NYSE:LYV',
++    'MA': 'NYSE:MA',
++    'MAA': 'NYSE:MAA',
++    'MAR': 'NASDAQ:MAR',
++    'MAS': 'NYSE:MAS',
++    'MCD': 'NYSE:MCD',
++    'MCHP': 'NASDAQ:MCHP',
++    'MCK': 'NYSE:MCK',
++    'MCO': 'NYSE:MCO',
++    'MDLZ': 'NASDAQ:MDLZ',
++    'MDT': 'NYSE:MDT',
++    'MET': 'NYSE:MET',
++    'META': 'NASDAQ:META',
++    'MGM': 'NYSE:MGM',
++    'MKC': 'NYSE:MKC',
++    'MLM': 'NYSE:MLM',
++    'MMM': 'NYSE:MMM',
++    'MNST': 'NASDAQ:MNST',
++    'MO': 'NYSE:MO',
++    'MOS': 'NYSE:MOS',
++    'MPC': 'NYSE:MPC',
++    'MPWR': 'NASDAQ:MPWR',
++    'MRK': 'NYSE:MRK',
++    'MRNA': 'NASDAQ:MRNA',
++    'MS': 'NYSE:MS',
++    'MSCI': 'NYSE:MSCI',
++    'MSFT': 'NASDAQ:MSFT',
++    'MSI': 'NYSE:MSI',
++    'MTB': 'NYSE:MTB',
++    'MTD': 'NYSE:MTD',
++    'MU': 'NASDAQ:MU',
++    'NCLH': 'NYSE:NCLH',
++    'NDAQ': 'NASDAQ:NDAQ',
++    'NDSN': 'NASDAQ:NDSN',
++    'NEE': 'NYSE:NEE',
++    'NEM': 'NYSE:NEM',
++    'NFLX': 'NASDAQ:NFLX',
++    'NI': 'NYSE:NI',
++    'NKE': 'NYSE:NKE',
++    'NOC': 'NYSE:NOC',
++    'NOW': 'NYSE:NOW',
++    'NRG': 'NYSE:NRG',
++    'NSC': 'NYSE:NSC',
++    'NTAP': 'NASDAQ:NTAP',
++    'NTRS': 'NASDAQ:NTRS',
++    'NUE': 'NYSE:NUE',
++    'NVDA': 'NASDAQ:NVDA',
++    'NVR': 'NYSE:NVR',
++    'NWS': 'NASDAQ:NWS',
++    'NWSA': 'NASDAQ:NWSA',
++    'NXPI': 'NASDAQ:NXPI',
++    'O': 'NYSE:O',
++    'ODFL': 'NASDAQ:ODFL',
++    'OKE': 'NYSE:OKE',
++    'OMC': 'NYSE:OMC',
++    'ORCL': 'NYSE:ORCL',
++    'ORLY': 'NASDAQ:ORLY',
++    'OTIS': 'NYSE:OTIS',
++    'OXY': 'NYSE:OXY',
++    'PAYX': 'NASDAQ:PAYX',
++    'PCAR': 'NASDAQ:PCAR',
++    'PEG': 'NYSE:PEG',
++    'PEP': 'NASDAQ:PEP',
++    'PFE': 'NYSE:PFE',
++    'PFG': 'NASDAQ:PFG',
++    'PG': 'NYSE:PG',
++    'PGR': 'NYSE:PGR',
++    'PH': 'NYSE:PH',
++    'PHM': 'NYSE:PHM',
++    'PKG': 'NYSE:PKG',
++    'PLD': 'NYSE:PLD',
++    'PM': 'NYSE:PM',
++    'PNC': 'NYSE:PNC',
++    'PNR': 'NYSE:PNR',
++    'PNW': 'NYSE:PNW',
++    'POOL': 'NASDAQ:POOL',
++    'PPG': 'NYSE:PPG',
++    'PPL': 'NYSE:PPL',
++    'PRU': 'NYSE:PRU',
++    'PSA': 'NYSE:PSA',
++    'PSX': 'NYSE:PSX',
++    'PTC': 'NASDAQ:PTC',
++    'PWR': 'NYSE:PWR',
++    'PYPL': 'NASDAQ:PYPL',
++    'QCOM': 'NASDAQ:QCOM',
++    'RCL': 'NYSE:RCL',
++    'REG': 'NASDAQ:REG',
++    'REGN': 'NASDAQ:REGN',
++    'RF': 'NYSE:RF',
++    'RJF': 'NYSE:RJF',
++    'RL': 'NYSE:RL',
++    'RMD': 'NYSE:RMD',
++    'ROK': 'NYSE:ROK',
++    'ROL': 'NYSE:ROL',
++    'ROP': 'NASDAQ:ROP',
++    'ROST': 'NASDAQ:ROST',
++    'RSG': 'NYSE:RSG',
++    'RTX': 'NYSE:RTX',
++    'SBAC': 'NASDAQ:SBAC',
++    'SBUX': 'NASDAQ:SBUX',
++    'SCHW': 'NYSE:SCHW',
++    'SHW': 'NYSE:SHW',
++    'SJM': 'NYSE:SJM',
++    'SLB': 'NYSE:SLB',
++    'SNA': 'NYSE:SNA',
++    'SNPS': 'NASDAQ:SNPS',
++    'SO': 'NYSE:SO',
++    'SPG': 'NYSE:SPG',
++    'SPGI': 'NYSE:SPGI',
++    'SRE': 'NYSE:SRE',
++    'STE': 'NYSE:STE',
++    'STT': 'NYSE:STT',
++    'STX': 'NASDAQ:STX',
++    'STZ': 'NYSE:STZ',
++    'SWK': 'NYSE:SWK',
++    'SWKS': 'NASDAQ:SWKS',
++    'SYF': 'NYSE:SYF',
++    'SYK': 'NYSE:SYK',
++    'SYY': 'NYSE:SYY',
++    'T': 'NYSE:T',
++    'TAP': 'NYSE:TAP',
++    'TDG': 'NYSE:TDG',
++    'TDY': 'NYSE:TDY',
++    'TECH': 'NASDAQ:TECH',
++    'TEL': 'NYSE:TEL',
++    'TER': 'NASDAQ:TER',
++    'TFC': 'NYSE:TFC',
++    'TGT': 'NYSE:TGT',
++    'TJX': 'NYSE:TJX',
++    'TMO': 'NYSE:TMO',
++    'TMUS': 'NASDAQ:TMUS',
++    'TPR': 'NYSE:TPR',
++    'TRMB': 'NASDAQ:TRMB',
++    'TROW': 'NASDAQ:TROW',
++    'TRV': 'NYSE:TRV',
++    'TSCO': 'NASDAQ:TSCO',
++    'TSLA': 'NASDAQ:TSLA',
++    'TSN': 'NYSE:TSN',
++    'TT': 'NYSE:TT',
++    'TTWO': 'NASDAQ:TTWO',
++    'TXN': 'NASDAQ:TXN',
++    'TXT': 'NYSE:TXT',
++    'TYL': 'NYSE:TYL',
++    'UAL': 'NASDAQ:UAL',
++    'UBS': 'NYSE:UBS',
++    'UDR': 'NYSE:UDR',
++    'UHS': 'NYSE:UHS',
++    'ULTA': 'NASDAQ:ULTA',
++    'UNH': 'NYSE:UNH',
++    'UNP': 'NYSE:UNP',
++    'UPS': 'NYSE:UPS',
++    'URI': 'NYSE:URI',
++    'USB': 'NYSE:USB',
++    'V': 'NYSE:V',
++    'VLO': 'NYSE:VLO',
++    'VMC': 'NYSE:VMC',
++    'VRSK': 'NASDAQ:VRSK',
++    'VRSN': 'NASDAQ:VRSN',
++    'VRTX': 'NASDAQ:VRTX',
++    'VTR': 'NYSE:VTR',
++    'VTRS': 'NASDAQ:VTRS',
++    'VZ': 'NYSE:VZ',
++    'WAB': 'NYSE:WAB',
++    'WAT': 'NYSE:WAT',
++    'WDC': 'NASDAQ:WDC',
++    'WEC': 'NYSE:WEC',
++    'WELL': 'NYSE:WELL',
++    'WFC': 'NYSE:WFC',
++    'WM': 'NYSE:WM',
++    'WMB': 'NYSE:WMB',
++    'WMT': 'NASDAQ:WMT',
++    'WRB': 'NYSE:WRB',
++    'WST': 'NYSE:WST',
++    'WTW': 'NASDAQ:WTW',
++    'WY': 'NYSE:WY',
++    'WYNN': 'NASDAQ:WYNN',
++    'XEL': 'NASDAQ:XEL',
++    'XOM': 'NYSE:XOM',
++    'XYL': 'NYSE:XYL',
++    'YUM': 'NYSE:YUM',
++    'ZBH': 'NYSE:ZBH',
++    'ZBRA': 'NASDAQ:ZBRA',
++    'ZTS': 'NYSE:ZTS',
++};
 diff --git a/web-front-end/angular/main/app/service/user.service.ts b/web-front-end/angular/main/app/service/user.service.ts
 new file mode 100644
 index 0000000..2de8472
@@ -23176,6 +23132,265 @@ index 0000000..2de8472
 +        );
 +      }
 +    }
+diff --git a/web-front-end/angular/main/app/status/status.component.html b/web-front-end/angular/main/app/status/status.component.html
+new file mode 100644
+index 0000000..8e41857
+--- /dev/null
++++ b/web-front-end/angular/main/app/status/status.component.html
+@@ -0,0 +1,49 @@
++<div class="status-page">
++    <h2>Service Status</h2>
++
++    <ng-container *ngIf="metadata.features.statusPage; else statusUnavailable">
++        <p class="status-meta">
++            Last refresh: {{ lastRefreshUtc ? toRelativeTime(lastRefreshUtc) : 'never' }}
++        </p>
++        <button class="btn btn-sm btn-outline-primary mb-3" type="button" (click)="refreshAll()" [disabled]="checking">
++            {{ checking ? 'Checking...' : 'Refresh now' }}
++        </button>
++
++        <div class="table-responsive">
++            <table class="table table-sm table-striped align-middle">
++                <thead>
++                    <tr>
++                        <th>Service</th>
++                        <th>Status</th>
++                        <th>HTTP</th>
++                        <th>Latency</th>
++                        <th>Last Checked</th>
++                        <th>Uptime (page session)</th>
++                    </tr>
++                </thead>
++                <tbody>
++                    <tr *ngFor="let row of statusRows">
++                        <td>
++                            <div>{{ row.name }}</div>
++                            <small class="text-muted">{{ row.url }}</small>
++                        </td>
++                        <td>
++                            <span class="status-pill" [ngClass]="statusClass(row)">{{ row.available ? 'UP' : 'DOWN' }}</span>
++                            <small class="status-error" *ngIf="row.error">{{ row.error }}</small>
++                        </td>
++                        <td>{{ row.httpStatus ?? '-' }}</td>
++                        <td>{{ row.latencyMs != null ? row.latencyMs + ' ms' : '-' }}</td>
++                        <td>{{ row.lastCheckedUtc ? toRelativeTime(row.lastCheckedUtc) : '-' }}</td>
++                        <td>{{ row.upSinceUtc ? toRelativeTime(row.upSinceUtc) : '-' }}</td>
++                    </tr>
++                </tbody>
++            </table>
++        </div>
++    </ng-container>
++
++    <ng-template #statusUnavailable>
++        <div class="alert alert-info">
++            Status page is introduced in state <code>002-edge-proxy-uncontainerized</code> and later.
++        </div>
++    </ng-template>
++</div>
+diff --git a/web-front-end/angular/main/app/status/status.component.scss b/web-front-end/angular/main/app/status/status.component.scss
+new file mode 100644
+index 0000000..31afc81
+--- /dev/null
++++ b/web-front-end/angular/main/app/status/status.component.scss
+@@ -0,0 +1,32 @@
++.status-page {
++    padding: 1rem;
++}
++
++.status-meta {
++    color: #3c4f67;
++}
++
++.status-pill {
++    display: inline-block;
++    min-width: 52px;
++    text-align: center;
++    border-radius: 999px;
++    padding: 0.1rem 0.55rem;
++    font-size: 0.75rem;
++    font-weight: 700;
++}
++
++.status-up {
++    background: #d1fadf;
++    color: #085f2a;
++}
++
++.status-down {
++    background: #ffe1df;
++    color: #8a1212;
++}
++
++.status-error {
++    display: block;
++    color: #8a1212;
++}
+diff --git a/web-front-end/angular/main/app/status/status.component.ts b/web-front-end/angular/main/app/status/status.component.ts
+new file mode 100644
+index 0000000..55ae2f4
+--- /dev/null
++++ b/web-front-end/angular/main/app/status/status.component.ts
+@@ -0,0 +1,160 @@
++import { CommonModule } from '@angular/common';
++import { Component, OnDestroy, OnInit } from '@angular/core';
++import { Subscription } from 'rxjs';
++import { StateUiMetadata, StatusCheckDefinition } from '../model/state-ui-metadata.model';
++import { StateMetadataService } from '../service/state-metadata.service';
++
++interface ServiceStatusRow {
++    id: string;
++    name: string;
++    url: string;
++    expectedStatuses: number[];
++    lastCheckedUtc: string;
++    latencyMs: number | null;
++    httpStatus: number | null;
++    available: boolean;
++    upSinceUtc: string;
++    error: string;
++}
++
++@Component({
++    standalone: true,
++    selector: 'app-status',
++    imports: [CommonModule],
++    templateUrl: './status.component.html',
++    styleUrls: ['./status.component.scss']
++})
++export class StatusComponent implements OnInit, OnDestroy {
++    metadata: StateUiMetadata;
++    statusRows: ServiceStatusRow[] = [];
++    checking = false;
++    lastRefreshUtc = '';
++
++    private metadataSub: Subscription | null = null;
++    private intervalId: ReturnType<typeof setInterval> | null = null;
++
++    constructor(private readonly stateMetadataService: StateMetadataService) {
++        this.metadata = this.stateMetadataService.snapshot();
++    }
++
++    ngOnInit(): void {
++        this.metadataSub = this.stateMetadataService.metadata$.subscribe((metadata) => {
++            this.metadata = metadata;
++            this.statusRows = this.buildRows(metadata.statusChecks);
++            if (metadata.features.statusPage) {
++                this.refreshAll();
++            }
++            this.resetInterval();
++        });
++    }
++
++    ngOnDestroy(): void {
++        this.metadataSub?.unsubscribe();
++        if (this.intervalId) {
++            clearInterval(this.intervalId);
++        }
++    }
++
++    async refreshAll(): Promise<void> {
++        this.checking = true;
++        await Promise.all(this.statusRows.map((row) => this.refreshOne(row)));
++        this.lastRefreshUtc = new Date().toISOString();
++        this.checking = false;
++    }
++
++    statusClass(row: ServiceStatusRow): string {
++        return row.available ? 'status-up' : 'status-down';
++    }
++
++    toRelativeTime(value: string): string {
++        if (!value) {
++            return '-';
++        }
++        const ts = new Date(value);
++        if (Number.isNaN(ts.getTime())) {
++            return value;
++        }
++        const diffMs = Date.now() - ts.getTime();
++        const diffSec = Math.max(0, Math.floor(diffMs / 1000));
++        if (diffSec < 60) {
++            return `${diffSec}s ago`;
++        }
++        const diffMin = Math.floor(diffSec / 60);
++        if (diffMin < 60) {
++            return `${diffMin}m ago`;
++        }
++        const diffHr = Math.floor(diffMin / 60);
++        return `${diffHr}h ago`;
++    }
++
++    private resetInterval(): void {
++        if (this.intervalId) {
++            clearInterval(this.intervalId);
++            this.intervalId = null;
++        }
++        if (!this.metadata.features.statusPage) {
++            return;
++        }
++        this.intervalId = setInterval(() => {
++            this.refreshAll().catch((error) => {
++                console.warn('[status-page] refresh failed', error);
++            });
++        }, 30000);
++    }
++
++    private buildRows(statusChecks: StatusCheckDefinition[]): ServiceStatusRow[] {
++        return statusChecks.map((check) => ({
++            id: check.id,
++            name: check.name,
++            url: check.url,
++            expectedStatuses: check.expectedStatuses,
++            lastCheckedUtc: '',
++            latencyMs: null,
++            httpStatus: null,
++            available: false,
++            upSinceUtc: '',
++            error: ''
++        }));
++    }
++
++    private async refreshOne(row: ServiceStatusRow): Promise<void> {
++        const started = Date.now();
++        const timeoutMs = 6000;
++        const controller = new AbortController();
++        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
++
++        let httpStatus: number | null = null;
++        let available = false;
++        let error = '';
++
++        try {
++            const response = await fetch(row.url, {
++                method: 'GET',
++                cache: 'no-store',
++                signal: controller.signal
++            });
++            httpStatus = response.status;
++            available = row.expectedStatuses.includes(response.status);
++        } catch (requestError) {
++            error = requestError instanceof Error ? requestError.message : String(requestError);
++            available = false;
++        } finally {
++            clearTimeout(timeoutId);
++        }
++
++        const nowUtc = new Date().toISOString();
++        const latencyMs = Date.now() - started;
++        if (available && !row.upSinceUtc) {
++            row.upSinceUtc = nowUtc;
++        }
++        if (!available) {
++            row.upSinceUtc = '';
++        }
++
++        row.httpStatus = httpStatus;
++        row.available = available;
++        row.lastCheckedUtc = nowUtc;
++        row.latencyMs = latencyMs;
++        row.error = error;
++    }
++}
 diff --git a/web-front-end/angular/main/app/test-utils/mocks.service.ts b/web-front-end/angular/main/app/test-utils/mocks.service.ts
 new file mode 100644
 index 0000000..bf5e7ff
@@ -26006,17 +26221,17 @@ index 0000000..8728e48
 +</svg>
 diff --git a/web-front-end/angular/main/assets/state-ui.json b/web-front-end/angular/main/assets/state-ui.json
 new file mode 100644
-index 0000000..ce602a4
+index 0000000..a8333f4
 --- /dev/null
 +++ b/web-front-end/angular/main/assets/state-ui.json
-@@ -0,0 +1,97 @@
+@@ -0,0 +1,90 @@
 +{
-+  "stateId": "004-containerized-compose-runtime",
-+  "stateTitle": "Containerized Compose Runtime (NGINX Ingress)",
-+  "stateTrack": "baseline",
-+  "generatedAtUtc": "2026-05-20T09:44:50.615Z",
-+  "sourceBranch": "code/generated-state-004-containerized-compose-runtime",
-+  "sourceBranchUrl": "https://github.com/finos/traderX/tree/code/generated-state-004-containerized-compose-runtime",
++  "stateId": "003-agentic-harness-foundation",
++  "stateTitle": "Agentic Harness Foundation",
++  "stateTrack": "prelude",
++  "generatedAtUtc": "2026-07-22T12:53:24.689Z",
++  "sourceBranch": "code/generated-state-003-agentic-harness-foundation",
++  "sourceBranchUrl": "https://github.com/finos/traderX/tree/code/generated-state-003-agentic-harness-foundation",
 +  "lineageLinkUrl": "https://github.com/finos/traderX/blob/main/docs/learning-paths/index.md",
 +  "apiExplorerUrl": "/api/docs",
 +  "pubSubInspectorUrl": "/api/docs/pubsub-inspector.html",
@@ -26026,13 +26241,6 @@ index 0000000..ce602a4
 +    "pubSubInspector": false
 +  },
 +  "previousStates": [
-+    {
-+      "id": "003-agentic-harness-foundation",
-+      "title": "Agentic Harness Foundation",
-+      "sourceBranch": "code/generated-state-003-agentic-harness-foundation",
-+      "sourceBranchUrl": "https://github.com/finos/traderX/tree/code/generated-state-003-agentic-harness-foundation",
-+      "summary": "Introduces Agentic Harness Foundation on the prelude track."
-+    },
 +    {
 +      "id": "002-edge-proxy-uncontainerized",
 +      "title": "Edge Proxy Uncontainerized",
@@ -26107,14 +26315,42 @@ index 0000000..ce602a4
 +    }
 +  ]
 +}
+diff --git a/web-front-end/angular/main/environments/environment.interface.ts b/web-front-end/angular/main/environments/environment.interface.ts
+new file mode 100644
+index 0000000..0f76017
+--- /dev/null
++++ b/web-front-end/angular/main/environments/environment.interface.ts
+@@ -0,0 +1,20 @@
++/**
++ * Shared type contract for all Angular environment configurations.
++ *
++ * All three environment variants (environment.ts, environment.prod.ts,
++ * environment.local.ts) must implement this interface. TypeScript will
++ * produce a compile error if any variant is missing a required property,
++ * preventing silent runtime failures in production builds.
++ *
++ * When adding a new environment property, update this interface first,
++ * then add the property to all three variants.
++ */
++export interface Environment {
++    production:      boolean;
++    accountUrl:      string;
++    refrenceDataUrl: string;   // note: intentional typo matches existing key name
++    tradesUrl:       string;
++    positionsUrl:    string;
++    peopleUrl:       string;
++    tradeFeedUrl:    string;
++}
 diff --git a/web-front-end/angular/main/environments/environment.local.ts b/web-front-end/angular/main/environments/environment.local.ts
 new file mode 100644
-index 0000000..2c08cc2
+index 0000000..dfa1719
 --- /dev/null
 +++ b/web-front-end/angular/main/environments/environment.local.ts
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,12 @@
 +// State 002 overlay: route browser traffic through edge proxy endpoint.
-+export const environment = {
++import { Environment } from './environment.interface';
++
++export const environment: Environment = {
 +    production:         false,
 +    accountUrl:         `//${window.location.host}/account-service`,
 +    refrenceDataUrl:    `//${window.location.host}/reference-data`,
@@ -26125,11 +26361,13 @@ index 0000000..2c08cc2
 +};
 diff --git a/web-front-end/angular/main/environments/environment.prod.ts b/web-front-end/angular/main/environments/environment.prod.ts
 new file mode 100644
-index 0000000..9d15bb8
+index 0000000..1476013
 --- /dev/null
 +++ b/web-front-end/angular/main/environments/environment.prod.ts
-@@ -0,0 +1,9 @@
-+export const environment = {
+@@ -0,0 +1,11 @@
++import { Environment } from './environment.interface';
++
++export const environment: Environment = {
 +    production:         true,
 +    accountUrl:         `//${window.location.host}/account-service`,
 +    refrenceDataUrl:    `//${window.location.host}/reference-data`,
@@ -26140,12 +26378,17 @@ index 0000000..9d15bb8
 +};
 diff --git a/web-front-end/angular/main/environments/environment.ts b/web-front-end/angular/main/environments/environment.ts
 new file mode 100644
-index 0000000..2c08cc2
+index 0000000..dac53a6
 --- /dev/null
 +++ b/web-front-end/angular/main/environments/environment.ts
-@@ -0,0 +1,10 @@
-+// State 002 overlay: route browser traffic through edge proxy endpoint.
-+export const environment = {
+@@ -0,0 +1,24 @@
++// This file can be replaced during build by using the `fileReplacements` array.
++// `ng build` replaces `environment.ts` with `environment.prod.ts`.
++// The list of file replacements can be found in `angular.json`.
++
++import { Environment } from './environment.interface';
++
++export const environment: Environment = {
 +    production:         false,
 +    accountUrl:         `//${window.location.host}/account-service`,
 +    refrenceDataUrl:    `//${window.location.host}/reference-data`,
@@ -26154,6 +26397,15 @@ index 0000000..2c08cc2
 +    peopleUrl:          `//${window.location.host}/people-service`,
 +    tradeFeedUrl:       `//${window.location.host}`
 +};
++
++/*
++ * For easier debugging in development mode, you can import the following file
++ * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.
++ *
++ * This import should be commented out in production mode because it will have a negative impact
++ * on performance if an error is thrown.
++ */
++// import 'zone.js/plugins/zone-error';  // Included with Angular CLI.
 diff --git a/web-front-end/angular/main/index.html b/web-front-end/angular/main/index.html
 new file mode 100644
 index 0000000..3a63d18
@@ -26368,10 +26620,10 @@ index 0000000..52e2c1a
 +}
 diff --git a/web-front-end/angular/package-lock.json b/web-front-end/angular/package-lock.json
 new file mode 100644
-index 0000000..e97f889
+index 0000000..8704d8e
 --- /dev/null
 +++ b/web-front-end/angular/package-lock.json
-@@ -0,0 +1,17030 @@
+@@ -0,0 +1,16556 @@
 +{
 +  "name": "@finos/web-front-end",
 +  "version": "0.0.0",
@@ -26647,13 +26899,13 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@angular-devkit/architect": {
-+      "version": "0.2003.29",
-+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.29.tgz",
-+      "integrity": "sha512-+oASUJI/mSgNp9v7s/dEBZqVX7shXaUJFDO+2QOfJ0DNQuoItUDDEzKJtmpwULNLHvIQf4cV9fSXbuGgkbw2Jg==",
++      "version": "0.2003.32",
++      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.32.tgz",
++      "integrity": "sha512-V5d531w97LENARKdYk5Km0F2rt8NPEL3rXUQk7+gbo9r/jgLWn9GU3VHQ30oBWXnU7Vu00Hdp/8yFeYgpWqSow==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@angular-devkit/core": "20.3.29",
++        "@angular-devkit/core": "20.3.32",
 +        "rxjs": "7.8.2"
 +      },
 +      "engines": {
@@ -26663,18 +26915,18 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@angular-devkit/build-angular": {
-+      "version": "20.3.29",
-+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-20.3.29.tgz",
-+      "integrity": "sha512-7x1W8sa6lxV60kWNrKxRZl7kgFnPwZO0N8oaGf32NP9bnd+BKT7XaDtkz6nrJ18vQE/uSamuE8s8WuCZznA8+A==",
++      "version": "20.3.32",
++      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-20.3.32.tgz",
++      "integrity": "sha512-1prN/HmTkL2TTd4zoNz/fFOds9eUc78winkjvBRxTL+OuUQMIeWIjpUui53mk2qdeW9ImiITcqCQVpZL95fLvQ==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
 +        "@ampproject/remapping": "2.3.0",
-+        "@angular-devkit/architect": "0.2003.29",
-+        "@angular-devkit/build-webpack": "0.2003.29",
-+        "@angular-devkit/core": "20.3.29",
-+        "@angular/build": "20.3.29",
-+        "@babel/core": "7.28.3",
++        "@angular-devkit/architect": "0.2003.32",
++        "@angular-devkit/build-webpack": "0.2003.32",
++        "@angular-devkit/core": "20.3.32",
++        "@angular/build": "20.3.32",
++        "@babel/core": "7.29.7",
 +        "@babel/generator": "7.28.3",
 +        "@babel/helper-annotate-as-pure": "7.27.3",
 +        "@babel/helper-split-export-declaration": "7.24.7",
@@ -26684,16 +26936,16 @@ index 0000000..e97f889
 +        "@babel/preset-env": "7.28.3",
 +        "@babel/runtime": "7.28.3",
 +        "@discoveryjs/json-ext": "0.6.3",
-+        "@ngtools/webpack": "20.3.29",
++        "@ngtools/webpack": "20.3.32",
 +        "ansi-colors": "4.1.3",
 +        "autoprefixer": "10.4.21",
 +        "babel-loader": "10.0.0",
 +        "browserslist": "^4.21.5",
 +        "copy-webpack-plugin": "14.0.0",
 +        "css-loader": "7.1.2",
-+        "esbuild-wasm": "0.28.0",
++        "esbuild-wasm": "0.28.1",
 +        "fast-glob": "3.3.3",
-+        "http-proxy-middleware": "3.0.5",
++        "http-proxy-middleware": "3.0.7",
 +        "istanbul-lib-instrument": "6.0.3",
 +        "jsonc-parser": "3.3.1",
 +        "karma-source-map-support": "1.4.0",
@@ -26705,7 +26957,7 @@ index 0000000..e97f889
 +        "open": "10.2.0",
 +        "ora": "8.2.0",
 +        "picomatch": "4.0.4",
-+        "piscina": "5.1.3",
++        "piscina": "5.2.0",
 +        "postcss": "8.5.12",
 +        "postcss-loader": "8.1.1",
 +        "resolve-url-loader": "5.0.0",
@@ -26730,7 +26982,7 @@ index 0000000..e97f889
 +        "yarn": ">= 1.13.0"
 +      },
 +      "optionalDependencies": {
-+        "esbuild": "0.28.0"
++        "esbuild": "0.28.1"
 +      },
 +      "peerDependencies": {
 +        "@angular/compiler-cli": "^20.0.0",
@@ -26739,7 +26991,7 @@ index 0000000..e97f889
 +        "@angular/platform-browser": "^20.0.0",
 +        "@angular/platform-server": "^20.0.0",
 +        "@angular/service-worker": "^20.0.0",
-+        "@angular/ssr": "^20.3.29",
++        "@angular/ssr": "^20.3.32",
 +        "@web/test-runner": "^0.20.0",
 +        "browser-sync": "^3.0.2",
 +        "jest": "^29.5.0 || ^30.2.0",
@@ -26796,13 +27048,13 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@angular-devkit/build-webpack": {
-+      "version": "0.2003.29",
-+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2003.29.tgz",
-+      "integrity": "sha512-VrlO2o8DuBJL500RvZ/rrYxlo3UiDrAyr+Q1DbwQ1vITd85Mp513JqaPDl/fyppnkHCuLzlC0UvkR6OZ/TInEg==",
++      "version": "0.2003.32",
++      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2003.32.tgz",
++      "integrity": "sha512-dFyM5Qkgl6wgSb8EJF8uZCt9K+VUsDP8APS5siCNHyhjzjACqDevk5RwqWCfPU/QjzlgCp11MbkKr/Y2sgaDcw==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@angular-devkit/architect": "0.2003.29",
++        "@angular-devkit/architect": "0.2003.32",
 +        "rxjs": "7.8.2"
 +      },
 +      "engines": {
@@ -26816,9 +27068,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@angular-devkit/core": {
-+      "version": "20.3.29",
-+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.29.tgz",
-+      "integrity": "sha512-mITFI5HUh/yC8i8kKNwJlKtID/3HTaOKqovgMu0pu+ujIN5swA8VntQODw4+sf3tzeDONy7lviVfskzQrL+BTg==",
++      "version": "20.3.32",
++      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.32.tgz",
++      "integrity": "sha512-pXipSsYP/XTEAljmwqgy1u3GR/ZzSMg1FERINekGT61Th1pGhzjs02rPgbyftqz2e5/tfQ6XgTP7xYzm3+S35Q==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -26844,13 +27096,13 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@angular-devkit/schematics": {
-+      "version": "20.3.29",
-+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.29.tgz",
-+      "integrity": "sha512-IZM5XRtHw/HmK4DVDyFseXwdkswR8li2j7L4qODb9QowaWT11nw6XkhTnSBUslMtqrt4o4ObHjjzun2UojI3mw==",
++      "version": "20.3.32",
++      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.32.tgz",
++      "integrity": "sha512-UxWncmJTcYMDEaAKRi3QHU3qXivIcIOulFOKozW8svfs/A43Oq1GG4kvDZ+WVf/w2UWTmMaSlfFa4KIQciSIDA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@angular-devkit/core": "20.3.29",
++        "@angular-devkit/core": "20.3.32",
 +        "jsonc-parser": "3.3.1",
 +        "magic-string": "0.30.17",
 +        "ora": "8.2.0",
@@ -26863,9 +27115,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@angular/animations": {
-+      "version": "20.3.25",
-+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.25.tgz",
-+      "integrity": "sha512-lQmti3tI85D525TjUVGqCNLzFxSUoZg+vgIyvuGJZPY0UU/o2S6KAxW6ObmcRotZZHNfenLHIxWgzamBDjIjuw==",
++      "version": "20.3.26",
++      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.26.tgz",
++      "integrity": "sha512-hfNrX19v8xs/usNkELSqc6q5IwBfS2GGW8sQ4OMpxAmLZDJwaLUxkj48t8VYhUFezsIfzR+sDEi6ZQBOaMIYug==",
 +      "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
 +      "license": "MIT",
 +      "dependencies": {
@@ -26875,26 +27127,26 @@ index 0000000..e97f889
 +        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 +      },
 +      "peerDependencies": {
-+        "@angular/core": "20.3.25"
++        "@angular/core": "20.3.26"
 +      }
 +    },
 +    "node_modules/@angular/build": {
-+      "version": "20.3.29",
-+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.29.tgz",
-+      "integrity": "sha512-AWPK8AMDgqDFTldicU2hX6xyqlJAwcovzC1NyNQhBxOXItAQ6VrHQyprexFiX5/9/ApakEp6nO31oXb4tEdYqA==",
++      "version": "20.3.32",
++      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.32.tgz",
++      "integrity": "sha512-ph/qcT6C7RYriU5dxXfNrYBEvCwU4acxTNoxkdGQHYxM7iOKT0K1YO6v5JBNRZ1S4LOJhWmGaWzJ+sRei0iGsQ==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
 +        "@ampproject/remapping": "2.3.0",
-+        "@angular-devkit/architect": "0.2003.29",
-+        "@babel/core": "7.28.3",
++        "@angular-devkit/architect": "0.2003.32",
++        "@babel/core": "7.29.7",
 +        "@babel/helper-annotate-as-pure": "7.27.3",
 +        "@babel/helper-split-export-declaration": "7.24.7",
 +        "@inquirer/confirm": "5.1.14",
 +        "@vitejs/plugin-basic-ssl": "2.1.0",
 +        "beasties": "0.3.5",
 +        "browserslist": "^4.23.0",
-+        "esbuild": "0.28.0",
++        "esbuild": "0.28.1",
 +        "https-proxy-agent": "7.0.6",
 +        "istanbul-lib-instrument": "6.0.3",
 +        "jsonc-parser": "3.3.1",
@@ -26903,13 +27155,13 @@ index 0000000..e97f889
 +        "mrmime": "2.0.1",
 +        "parse5-html-rewriting-stream": "8.0.0",
 +        "picomatch": "4.0.4",
-+        "piscina": "5.1.3",
++        "piscina": "5.2.0",
 +        "rollup": "4.59.0",
 +        "sass": "1.90.0",
 +        "semver": "7.7.2",
 +        "source-map-support": "0.5.21",
 +        "tinyglobby": "0.2.14",
-+        "vite": "7.3.2",
++        "vite": "7.3.6",
 +        "watchpack": "2.4.4"
 +      },
 +      "engines": {
@@ -26928,7 +27180,7 @@ index 0000000..e97f889
 +        "@angular/platform-browser": "^20.0.0",
 +        "@angular/platform-server": "^20.0.0",
 +        "@angular/service-worker": "^20.0.0",
-+        "@angular/ssr": "^20.3.29",
++        "@angular/ssr": "^20.3.32",
 +        "karma": "^6.4.0",
 +        "less": "^4.2.0",
 +        "ng-packagr": "^20.0.0",
@@ -26978,19 +27230,19 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@angular/cli": {
-+      "version": "20.3.29",
-+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.29.tgz",
-+      "integrity": "sha512-3PjdwM/K0XnqoIY0qlK1Won9ZnE2vlCc0vJP/0U4oVCORdfq89NC+731llYB9T/zUXJbQ6ImxY4z1kRJuEoLfg==",
++      "version": "20.3.32",
++      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.32.tgz",
++      "integrity": "sha512-WIMbTrEJYVVz4Phs8nn6yK/bzCSt1dDlxtAEnS2melTWXKGF6WK/OqVaH0+Cox0SNagA81dvvSbGlFYCxncYfQ==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@angular-devkit/architect": "0.2003.29",
-+        "@angular-devkit/core": "20.3.29",
-+        "@angular-devkit/schematics": "20.3.29",
++        "@angular-devkit/architect": "0.2003.32",
++        "@angular-devkit/core": "20.3.32",
++        "@angular-devkit/schematics": "20.3.32",
 +        "@inquirer/prompts": "7.8.2",
 +        "@listr2/prompt-adapter-inquirer": "3.0.1",
 +        "@modelcontextprotocol/sdk": "1.26.0",
-+        "@schematics/angular": "20.3.29",
++        "@schematics/angular": "20.3.32",
 +        "@yarnpkg/lockfile": "1.1.0",
 +        "algoliasearch": "5.35.0",
 +        "ini": "5.0.0",
@@ -27013,9 +27265,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@angular/common": {
-+      "version": "20.3.25",
-+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.25.tgz",
-+      "integrity": "sha512-rnRGcXbjet0DHgkRL4Dqxk21G2T4UypVfiTV/fay58H8w9U89PJ1L6gRmk8B/uyfpii/9r23cBwnpcguQykxYw==",
++      "version": "20.3.26",
++      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.26.tgz",
++      "integrity": "sha512-35+aHaCmldFZ2qFiH83+cHcDXwUqSEuUR5DVApcd+Ku8PfIIGo8uMiD5++Qq7QIUTbZCD2glAiE9jLroGrf1Cw==",
 +      "license": "MIT",
 +      "dependencies": {
 +        "tslib": "^2.3.0"
@@ -27024,14 +27276,14 @@ index 0000000..e97f889
 +        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 +      },
 +      "peerDependencies": {
-+        "@angular/core": "20.3.25",
++        "@angular/core": "20.3.26",
 +        "rxjs": "^6.5.3 || ^7.4.0"
 +      }
 +    },
 +    "node_modules/@angular/compiler": {
-+      "version": "20.3.25",
-+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.25.tgz",
-+      "integrity": "sha512-TSh6gVoQqlLPqWwsYMK0lfVEQYENQO+USzS+BHFXEHFfgBRap6qDpIUGnRdj0Y2PlaVJUVFbeq1855EZUPUEoA==",
++      "version": "20.3.26",
++      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.26.tgz",
++      "integrity": "sha512-H4DVTBCiyM4dGytFi2C8sMGflxXzPnoQ6Ajfs4hJ/Dekg6ypfvW5Ze7BDh4TaMQvaX2joM5LhBYW5jTxBx66hA==",
 +      "license": "MIT",
 +      "dependencies": {
 +        "tslib": "^2.3.0"
@@ -27041,13 +27293,13 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@angular/compiler-cli": {
-+      "version": "20.3.25",
-+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.25.tgz",
-+      "integrity": "sha512-iqxwVo5Pgzt3EfT49OZ6plxA6KKxwv7ixx1XNH7QRvaOJC9gmsPScWpx+LO7ZsVZdo/NkA+rnXDl0PauUgGciw==",
++      "version": "20.3.26",
++      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.26.tgz",
++      "integrity": "sha512-3rHtC87ecldvaiFHwQEZ6Wx3QaZ/Q7b0Gb7XORDOjn/M+5CYZ4rQsvbxE5TUjwreg07oQ4Y2h8ADESXTJEUYOQ==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@babel/core": "7.28.3",
++        "@babel/core": "7.29.7",
 +        "@jridgewell/sourcemap-codec": "^1.4.14",
 +        "chokidar": "^4.0.0",
 +        "convert-source-map": "^1.5.1",
@@ -27064,7 +27316,7 @@ index 0000000..e97f889
 +        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 +      },
 +      "peerDependencies": {
-+        "@angular/compiler": "20.3.25",
++        "@angular/compiler": "20.3.26",
 +        "typescript": ">=5.8 <6.0"
 +      },
 +      "peerDependenciesMeta": {
@@ -27074,9 +27326,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@angular/core": {
-+      "version": "20.3.25",
-+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.25.tgz",
-+      "integrity": "sha512-B4XnnR5jzikZDvZ4PjwjAWZMT14dxrKrmJdwa/n0yp7rMPkIJTKF6ZJMg4d1pLWLLSsc2oWHioN3UrWlGqIKnA==",
++      "version": "20.3.26",
++      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.26.tgz",
++      "integrity": "sha512-v+YtZ9eQVDb6v3V1TbUUBHU63FEp8Hqqqb3UhM4MLAOm0chyyh9jah7FiHr3HbCKrV1f4long1coftFK/KThog==",
 +      "license": "MIT",
 +      "dependencies": {
 +        "tslib": "^2.3.0"
@@ -27085,7 +27337,7 @@ index 0000000..e97f889
 +        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 +      },
 +      "peerDependencies": {
-+        "@angular/compiler": "20.3.25",
++        "@angular/compiler": "20.3.26",
 +        "rxjs": "^6.5.3 || ^7.4.0",
 +        "zone.js": "~0.15.0"
 +      },
@@ -27099,9 +27351,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@angular/forms": {
-+      "version": "20.3.25",
-+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.25.tgz",
-+      "integrity": "sha512-vGRo1LVPFo2Cu0k+QyDTlsBv5UbN0c3Et2YMS+43oyi1c4keocntBccOjLyM5C0kpMz4+pP81MqqYpAWu2k+TQ==",
++      "version": "20.3.26",
++      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.26.tgz",
++      "integrity": "sha512-ia0YaPVjlG2oBFKCfaAgqQ0jGRrhGTAcrbZG3tVeFDpi7LQ6WdP3Syw2H+0D3GPyzpl/5UqU10Fum5Wr1br4QQ==",
 +      "license": "MIT",
 +      "dependencies": {
 +        "tslib": "^2.3.0"
@@ -27110,16 +27362,16 @@ index 0000000..e97f889
 +        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 +      },
 +      "peerDependencies": {
-+        "@angular/common": "20.3.25",
-+        "@angular/core": "20.3.25",
-+        "@angular/platform-browser": "20.3.25",
++        "@angular/common": "20.3.26",
++        "@angular/core": "20.3.26",
++        "@angular/platform-browser": "20.3.26",
 +        "rxjs": "^6.5.3 || ^7.4.0"
 +      }
 +    },
 +    "node_modules/@angular/language-service": {
-+      "version": "20.3.25",
-+      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-20.3.25.tgz",
-+      "integrity": "sha512-3PZUwbDUVQXk9BLSiNUpDxTnRXGR3szwK9QFQaGDt8lhmLYaQLh3VJsY0FHDRghHZYIGR2P2MbVxGQHytF+IPw==",
++      "version": "20.3.26",
++      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-20.3.26.tgz",
++      "integrity": "sha512-8w6T4upVRwW2X1kT3i7OFpGJQihx/liU1utFapfy4gee4Qy6wuuwjGk+Z2M3F5W9waucXlBHfjXs2tWJ+pCozQ==",
 +      "dev": true,
 +      "license": "MIT",
 +      "engines": {
@@ -27127,9 +27379,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@angular/platform-browser": {
-+      "version": "20.3.25",
-+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.25.tgz",
-+      "integrity": "sha512-0k06U/AJRQifGMLkcU3R9uEHWbuKEzkKMuKcGagXTrkeFvCG2Ub4JdsbcjFNWB2bspWgaxIMSceuj7c83U5wOA==",
++      "version": "20.3.26",
++      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.26.tgz",
++      "integrity": "sha512-In4wUiLUUT9LqyV9Rjz78k/dsnKAwec4AtDmwZoX8/ZmeJOSH7g5X1gTM+hxTxmifmZkrapQjXR299IcfIkzrw==",
 +      "license": "MIT",
 +      "dependencies": {
 +        "tslib": "^2.3.0"
@@ -27138,9 +27390,9 @@ index 0000000..e97f889
 +        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 +      },
 +      "peerDependencies": {
-+        "@angular/animations": "20.3.25",
-+        "@angular/common": "20.3.25",
-+        "@angular/core": "20.3.25"
++        "@angular/animations": "20.3.26",
++        "@angular/common": "20.3.26",
++        "@angular/core": "20.3.26"
 +      },
 +      "peerDependenciesMeta": {
 +        "@angular/animations": {
@@ -27149,9 +27401,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@angular/platform-browser-dynamic": {
-+      "version": "20.3.25",
-+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.3.25.tgz",
-+      "integrity": "sha512-3Ku+IsN4tQPVBsw75SoLbLf7TsXAGL0rGPHSsyNYFhG2ZZeQuYNIAi8mc4cwz/qMDnuassHFrCxuLDgN6Yab5w==",
++      "version": "20.3.26",
++      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.3.26.tgz",
++      "integrity": "sha512-/9eq0GGmtMoBV5UvcjvhnV4ZDcgZr15h+dzoxkZodUncb2z7fxybSyha7wWD9aTeabZ/q/KYVUSnoYqVyBhbVQ==",
 +      "deprecated": "@angular/platform-browser-dynamic is deprecated. Use `@angular/platform-browser` instead.",
 +      "license": "MIT",
 +      "dependencies": {
@@ -27161,16 +27413,16 @@ index 0000000..e97f889
 +        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 +      },
 +      "peerDependencies": {
-+        "@angular/common": "20.3.25",
-+        "@angular/compiler": "20.3.25",
-+        "@angular/core": "20.3.25",
-+        "@angular/platform-browser": "20.3.25"
++        "@angular/common": "20.3.26",
++        "@angular/compiler": "20.3.26",
++        "@angular/core": "20.3.26",
++        "@angular/platform-browser": "20.3.26"
 +      }
 +    },
 +    "node_modules/@angular/router": {
-+      "version": "20.3.25",
-+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.25.tgz",
-+      "integrity": "sha512-YIjLHWAufTaukNj15hEoys29e7XNhnCRsS1/95h/OqR69R3adbB8hV7ut7gO6XdXokriYqb4gtoUjoESxR+xFQ==",
++      "version": "20.3.26",
++      "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.26.tgz",
++      "integrity": "sha512-q0k0b5uuQx93Trk4qEMYe8LoPOozheRBIjze51q+LUTlLXWik4W0ughXLiTJL346KRudR/vB5ksfZP8b6WlQyA==",
 +      "license": "MIT",
 +      "dependencies": {
 +        "tslib": "^2.3.0"
@@ -27179,9 +27431,9 @@ index 0000000..e97f889
 +        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 +      },
 +      "peerDependencies": {
-+        "@angular/common": "20.3.25",
-+        "@angular/core": "20.3.25",
-+        "@angular/platform-browser": "20.3.25",
++        "@angular/common": "20.3.26",
++        "@angular/core": "20.3.26",
++        "@angular/platform-browser": "20.3.26",
 +        "rxjs": "^6.5.3 || ^7.4.0"
 +      }
 +    },
@@ -27211,22 +27463,22 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@babel/core": {
-+      "version": "7.28.3",
-+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
-+      "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
++      "version": "7.29.7",
++      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
++      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@ampproject/remapping": "^2.2.0",
-+        "@babel/code-frame": "^7.27.1",
-+        "@babel/generator": "^7.28.3",
-+        "@babel/helper-compilation-targets": "^7.27.2",
-+        "@babel/helper-module-transforms": "^7.28.3",
-+        "@babel/helpers": "^7.28.3",
-+        "@babel/parser": "^7.28.3",
-+        "@babel/template": "^7.27.2",
-+        "@babel/traverse": "^7.28.3",
-+        "@babel/types": "^7.28.2",
++        "@babel/code-frame": "^7.29.7",
++        "@babel/generator": "^7.29.7",
++        "@babel/helper-compilation-targets": "^7.29.7",
++        "@babel/helper-module-transforms": "^7.29.7",
++        "@babel/helpers": "^7.29.7",
++        "@babel/parser": "^7.29.7",
++        "@babel/template": "^7.29.7",
++        "@babel/traverse": "^7.29.7",
++        "@babel/types": "^7.29.7",
++        "@jridgewell/remapping": "^2.3.5",
 +        "convert-source-map": "^2.0.0",
 +        "debug": "^4.1.0",
 +        "gensync": "^1.0.0-beta.2",
@@ -27239,6 +27491,23 @@ index 0000000..e97f889
 +      "funding": {
 +        "type": "opencollective",
 +        "url": "https://opencollective.com/babel"
++      }
++    },
++    "node_modules/@babel/core/node_modules/@babel/generator": {
++      "version": "7.29.7",
++      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
++      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
++      "dev": true,
++      "license": "MIT",
++      "dependencies": {
++        "@babel/parser": "^7.29.7",
++        "@babel/types": "^7.29.7",
++        "@jridgewell/gen-mapping": "^0.3.12",
++        "@jridgewell/trace-mapping": "^0.3.28",
++        "jsesc": "^3.0.2"
++      },
++      "engines": {
++        "node": ">=6.9.0"
 +      }
 +    },
 +    "node_modules/@babel/core/node_modules/convert-source-map": {
@@ -28959,9 +29228,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/aix-ppc64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
++      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
 +      "cpu": [
 +        "ppc64"
 +      ],
@@ -28976,9 +29245,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/android-arm": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
++      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
 +      "cpu": [
 +        "arm"
 +      ],
@@ -28993,9 +29262,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/android-arm64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
++      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -29010,9 +29279,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/android-x64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
++      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -29027,9 +29296,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/darwin-arm64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
++      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -29044,9 +29313,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/darwin-x64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
++      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -29061,9 +29330,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/freebsd-arm64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
++      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -29078,9 +29347,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/freebsd-x64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
++      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -29095,9 +29364,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/linux-arm": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
++      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
 +      "cpu": [
 +        "arm"
 +      ],
@@ -29112,9 +29381,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/linux-arm64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
++      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -29129,9 +29398,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/linux-ia32": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
++      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
 +      "cpu": [
 +        "ia32"
 +      ],
@@ -29146,9 +29415,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/linux-loong64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
++      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
 +      "cpu": [
 +        "loong64"
 +      ],
@@ -29163,9 +29432,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/linux-mips64el": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
++      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
 +      "cpu": [
 +        "mips64el"
 +      ],
@@ -29180,9 +29449,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/linux-ppc64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
++      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
 +      "cpu": [
 +        "ppc64"
 +      ],
@@ -29197,9 +29466,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/linux-riscv64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
++      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
 +      "cpu": [
 +        "riscv64"
 +      ],
@@ -29214,9 +29483,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/linux-s390x": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
++      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
 +      "cpu": [
 +        "s390x"
 +      ],
@@ -29231,9 +29500,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/linux-x64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
++      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -29248,9 +29517,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/netbsd-arm64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
++      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -29265,9 +29534,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/netbsd-x64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
++      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -29282,9 +29551,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/openbsd-arm64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
++      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -29299,9 +29568,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/openbsd-x64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
++      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -29316,9 +29585,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/openharmony-arm64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
++      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -29333,9 +29602,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/sunos-x64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
++      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -29350,9 +29619,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/win32-arm64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
++      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -29367,9 +29636,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/win32-ia32": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
++      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
 +      "cpu": [
 +        "ia32"
 +      ],
@@ -29384,9 +29653,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@esbuild/win32-x64": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
++      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -29824,6 +30093,17 @@ index 0000000..e97f889
 +        "@jridgewell/trace-mapping": "^0.3.24"
 +      }
 +    },
++    "node_modules/@jridgewell/remapping": {
++      "version": "2.3.5",
++      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
++      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
++      "dev": true,
++      "license": "MIT",
++      "dependencies": {
++        "@jridgewell/gen-mapping": "^0.3.5",
++        "@jridgewell/trace-mapping": "^0.3.24"
++      }
++    },
 +    "node_modules/@jridgewell/resolve-uri": {
 +      "version": "3.1.2",
 +      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -29915,14 +30195,14 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@jsonjoy.com/fs-core": {
-+      "version": "4.57.8",
-+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.8.tgz",
-+      "integrity": "sha512-YzVbwggV9452VCeHgo0bjsTaUt1O7JE0XpEsPar93nn/+RAwXk0mb1Y+f5EDJ3TRtRCFe+Ck5RuojdfB4jeHVw==",
++      "version": "4.64.0",
++      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.64.0.tgz",
++      "integrity": "sha512-zs2TAq7Six5jgMuoMNjpspAvOP3mhtgq/k1UyQodEzCtQi/N83y2/y+zcvnZSGp/Rxq96DBN+bValOBQAyn/ew==",
 +      "dev": true,
 +      "license": "Apache-2.0",
 +      "dependencies": {
-+        "@jsonjoy.com/fs-node-builtins": "4.57.8",
-+        "@jsonjoy.com/fs-node-utils": "4.57.8",
++        "@jsonjoy.com/fs-node-builtins": "4.64.0",
++        "@jsonjoy.com/fs-node-utils": "4.64.0",
 +        "thingies": "^2.5.0"
 +      },
 +      "engines": {
@@ -29937,15 +30217,15 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@jsonjoy.com/fs-fsa": {
-+      "version": "4.57.8",
-+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.8.tgz",
-+      "integrity": "sha512-vmClyvCQMxgqz7uamDiGtRfp4MjzOznk3pcQjCxlIwJcw7TWeyr+bF30hI0x8NxdtNOGMg1pHM74VDIXOeyjuw==",
++      "version": "4.64.0",
++      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.64.0.tgz",
++      "integrity": "sha512-nMWOVbkLFyEgmXZih3wyvxA9XpgyyqyfrINMHvEFqhi7uqfRl7c9ERJt6yX7vgMPrB9Uo+OJO+Spa0cFzPD01w==",
 +      "dev": true,
 +      "license": "Apache-2.0",
 +      "dependencies": {
-+        "@jsonjoy.com/fs-core": "4.57.8",
-+        "@jsonjoy.com/fs-node-builtins": "4.57.8",
-+        "@jsonjoy.com/fs-node-utils": "4.57.8",
++        "@jsonjoy.com/fs-core": "4.64.0",
++        "@jsonjoy.com/fs-node-builtins": "4.64.0",
++        "@jsonjoy.com/fs-node-utils": "4.64.0",
 +        "thingies": "^2.5.0"
 +      },
 +      "engines": {
@@ -29960,17 +30240,17 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@jsonjoy.com/fs-node": {
-+      "version": "4.57.8",
-+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.8.tgz",
-+      "integrity": "sha512-IPEOlDYSnTDYpjQlQg2F8h+eqxKQN3sdbroI0WrteRiQZ462HzVpBo9ZZX485njz4nAacoe3fd4iDiIhk+k5Hg==",
++      "version": "4.64.0",
++      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.64.0.tgz",
++      "integrity": "sha512-dO+NNkODbUli4uV42bcNrrLvq5rE7SNpdZ5TNd0dtbLsAaNK3MDiIC9lUi+brboGoIjW6vd2fB1qao60nrk5xA==",
 +      "dev": true,
 +      "license": "Apache-2.0",
 +      "dependencies": {
-+        "@jsonjoy.com/fs-core": "4.57.8",
-+        "@jsonjoy.com/fs-node-builtins": "4.57.8",
-+        "@jsonjoy.com/fs-node-utils": "4.57.8",
-+        "@jsonjoy.com/fs-print": "4.57.8",
-+        "@jsonjoy.com/fs-snapshot": "4.57.8",
++        "@jsonjoy.com/fs-core": "4.64.0",
++        "@jsonjoy.com/fs-node-builtins": "4.64.0",
++        "@jsonjoy.com/fs-node-utils": "4.64.0",
++        "@jsonjoy.com/fs-print": "4.64.0",
++        "@jsonjoy.com/fs-snapshot": "4.64.0",
 +        "glob-to-regex.js": "^1.0.0",
 +        "thingies": "^2.5.0"
 +      },
@@ -29986,9 +30266,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@jsonjoy.com/fs-node-builtins": {
-+      "version": "4.57.8",
-+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.8.tgz",
-+      "integrity": "sha512-mxXSXw8zZwRVakcjLqR2I/psy4gURFSASZS10kKJ2kJw05GC2nXGroGrWVHxwgkxXgQLsFQnB74QaLzsxzdL/w==",
++      "version": "4.64.0",
++      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.64.0.tgz",
++      "integrity": "sha512-/o7WRFhUWaM/fOrslwLZGnzn4RmRILykn+lAL+mNObqqRNw+CQSiij6hpCeZ+C7buhdoVo7go/OYqzaSUfDYmA==",
 +      "dev": true,
 +      "license": "Apache-2.0",
 +      "engines": {
@@ -30003,15 +30283,15 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-+      "version": "4.57.8",
-+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.8.tgz",
-+      "integrity": "sha512-AWZcT/4+H+iDl4XCukbXrarvwEgOrf/prFI5/7eg4ix9FxqVsZysIDJd1Kjd+AjlCeHKHJOaRqjLd5HiGSCJEw==",
++      "version": "4.64.0",
++      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.64.0.tgz",
++      "integrity": "sha512-WDD9WVs0hb7UAEKTgZW2f66WDrbj7gIIWwpP3spbLyXa0rghtUaFTB8L4gdR3ZCWwiKIsj38/CNijpVmpnuPUw==",
 +      "dev": true,
 +      "license": "Apache-2.0",
 +      "dependencies": {
-+        "@jsonjoy.com/fs-fsa": "4.57.8",
-+        "@jsonjoy.com/fs-node-builtins": "4.57.8",
-+        "@jsonjoy.com/fs-node-utils": "4.57.8"
++        "@jsonjoy.com/fs-fsa": "4.64.0",
++        "@jsonjoy.com/fs-node-builtins": "4.64.0",
++        "@jsonjoy.com/fs-node-utils": "4.64.0"
 +      },
 +      "engines": {
 +        "node": ">=10.0"
@@ -30025,13 +30305,14 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@jsonjoy.com/fs-node-utils": {
-+      "version": "4.57.8",
-+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.8.tgz",
-+      "integrity": "sha512-E/bJ7sQAb4pu9nbeJhbULU3WnqWrswte4N9Js/oHt7aHB746S8/XBqKlcbrqIgnD3095XluovNEZuu5ONT230g==",
++      "version": "4.64.0",
++      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.64.0.tgz",
++      "integrity": "sha512-k5Indsx9hWW9xSF7Y6oSKKwtCUNhzZxadub3owhIlitc+iMRVlPPdX2duTKQWBL3qNWpXya8jykgaaWpheeS4w==",
 +      "dev": true,
 +      "license": "Apache-2.0",
 +      "dependencies": {
-+        "@jsonjoy.com/fs-node-builtins": "4.57.8"
++        "@jsonjoy.com/fs-node-builtins": "4.64.0",
++        "glob-to-regex.js": "^1.0.1"
 +      },
 +      "engines": {
 +        "node": ">=10.0"
@@ -30045,13 +30326,13 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@jsonjoy.com/fs-print": {
-+      "version": "4.57.8",
-+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.8.tgz",
-+      "integrity": "sha512-DfzhOBpmvNu5P/KSe4NNQaOnvNliTdcf0qrh/4EReErF/XUQXYkd0vZl/OiJCm/qjEEo8DWRstliw2/JNS84dA==",
++      "version": "4.64.0",
++      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.64.0.tgz",
++      "integrity": "sha512-PHZFccchvkhWrwPWHjmVAhbC3vSHCtyZvlZfJJ3ho2bnzl450hXri6/8e6pbkWdH+SkmLXNml0sV8e5HDAfxKw==",
 +      "dev": true,
 +      "license": "Apache-2.0",
 +      "dependencies": {
-+        "@jsonjoy.com/fs-node-utils": "4.57.8",
++        "@jsonjoy.com/fs-node-utils": "4.64.0",
 +        "tree-dump": "^1.1.0"
 +      },
 +      "engines": {
@@ -30066,14 +30347,14 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@jsonjoy.com/fs-snapshot": {
-+      "version": "4.57.8",
-+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.8.tgz",
-+      "integrity": "sha512-L+eqKaWOHLDaiMv1dh/EWQ4hA+o6xAhWSumTo3Teg7OM18jU/KE13/e8Mfal+eAZ/pSl4wIhKHcDiwapJzC8Wg==",
++      "version": "4.64.0",
++      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.64.0.tgz",
++      "integrity": "sha512-oM7UDeL83q6NBzzsfKAsYKXKVXlykKFqqOLh4xZZKAzzROTlInkPbc6LTDGThEOnPiFiUzA7tYziHG9xavd76Q==",
 +      "dev": true,
 +      "license": "Apache-2.0",
 +      "dependencies": {
 +        "@jsonjoy.com/buffers": "^17.65.0",
-+        "@jsonjoy.com/fs-node-utils": "4.57.8",
++        "@jsonjoy.com/fs-node-utils": "4.64.0",
 +        "@jsonjoy.com/json-pack": "^17.65.0",
 +        "@jsonjoy.com/util": "^17.65.0"
 +      },
@@ -30885,9 +31166,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@ngtools/webpack": {
-+      "version": "20.3.29",
-+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-20.3.29.tgz",
-+      "integrity": "sha512-FqThqRsu+h/8bSCCMeoLBxCrWfuTfGZrqDG944Sxzdhaz7pRa87NPAB7XPiO+P3qFjNFg6lWxl1PwxN1xxfEbw==",
++      "version": "20.3.32",
++      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-20.3.32.tgz",
++      "integrity": "sha512-a3KWNfv3NEyNHdGusIP/+lfLtjH7L5rcqgouBm6v3t1vHQ4zg2sNgoYIQIJCAJnFI2b080YrP9jh2FqKTCJlug==",
 +      "dev": true,
 +      "license": "MIT",
 +      "engines": {
@@ -30970,9 +31251,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@npmcli/agent/node_modules/lru-cache": {
-+      "version": "11.5.1",
-+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
++      "version": "11.5.2",
++      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
++      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
 +      "dev": true,
 +      "license": "BlueOak-1.0.0",
 +      "engines": {
@@ -31033,9 +31314,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@npmcli/git/node_modules/lru-cache": {
-+      "version": "11.5.1",
-+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
++      "version": "11.5.2",
++      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
++      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
 +      "dev": true,
 +      "license": "BlueOak-1.0.0",
 +      "engines": {
@@ -31125,9 +31406,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-+      "version": "5.0.6",
-+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
++      "version": "5.0.7",
++      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
++      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -31258,9 +31539,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@parcel/watcher": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
-+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
++      "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
 +      "dev": true,
 +      "hasInstallScript": true,
 +      "license": "MIT",
@@ -31269,7 +31550,7 @@ index 0000000..e97f889
 +        "detect-libc": "^2.0.3",
 +        "is-glob": "^4.0.3",
 +        "node-addon-api": "^7.0.0",
-+        "picomatch": "^4.0.3"
++        "picomatch": "^4.0.4"
 +      },
 +      "engines": {
 +        "node": ">= 10.0.0"
@@ -31279,25 +31560,24 @@ index 0000000..e97f889
 +        "url": "https://opencollective.com/parcel"
 +      },
 +      "optionalDependencies": {
-+        "@parcel/watcher-android-arm64": "2.5.6",
-+        "@parcel/watcher-darwin-arm64": "2.5.6",
-+        "@parcel/watcher-darwin-x64": "2.5.6",
-+        "@parcel/watcher-freebsd-x64": "2.5.6",
-+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
-+        "@parcel/watcher-linux-arm-musl": "2.5.6",
-+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
-+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
-+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
-+        "@parcel/watcher-linux-x64-musl": "2.5.6",
-+        "@parcel/watcher-win32-arm64": "2.5.6",
-+        "@parcel/watcher-win32-ia32": "2.5.6",
-+        "@parcel/watcher-win32-x64": "2.5.6"
++        "@parcel/watcher-android-arm64": "2.6.0",
++        "@parcel/watcher-darwin-arm64": "2.6.0",
++        "@parcel/watcher-darwin-x64": "2.6.0",
++        "@parcel/watcher-freebsd-x64": "2.6.0",
++        "@parcel/watcher-linux-arm-glibc": "2.6.0",
++        "@parcel/watcher-linux-arm-musl": "2.6.0",
++        "@parcel/watcher-linux-arm64-glibc": "2.6.0",
++        "@parcel/watcher-linux-arm64-musl": "2.6.0",
++        "@parcel/watcher-linux-x64-glibc": "2.6.0",
++        "@parcel/watcher-linux-x64-musl": "2.6.0",
++        "@parcel/watcher-win32-arm64": "2.6.0",
++        "@parcel/watcher-win32-x64": "2.6.0"
 +      }
 +    },
 +    "node_modules/@parcel/watcher-android-arm64": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
++      "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -31316,9 +31596,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@parcel/watcher-darwin-arm64": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
++      "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -31337,9 +31617,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@parcel/watcher-darwin-x64": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
++      "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -31358,9 +31638,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@parcel/watcher-freebsd-x64": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
++      "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -31379,9 +31659,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@parcel/watcher-linux-arm-glibc": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
++      "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
 +      "cpu": [
 +        "arm"
 +      ],
@@ -31403,9 +31683,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@parcel/watcher-linux-arm-musl": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
++      "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
 +      "cpu": [
 +        "arm"
 +      ],
@@ -31427,9 +31707,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@parcel/watcher-linux-arm64-glibc": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
++      "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -31451,9 +31731,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@parcel/watcher-linux-arm64-musl": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
++      "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -31475,9 +31755,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@parcel/watcher-linux-x64-glibc": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
++      "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -31499,9 +31779,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@parcel/watcher-linux-x64-musl": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
++      "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -31523,9 +31803,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@parcel/watcher-win32-arm64": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
++      "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
 +      "cpu": [
 +        "arm64"
 +      ],
@@ -31543,31 +31823,10 @@ index 0000000..e97f889
 +        "url": "https://opencollective.com/parcel"
 +      }
 +    },
-+    "node_modules/@parcel/watcher-win32-ia32": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
-+      "cpu": [
-+        "ia32"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "win32"
-+      ],
-+      "engines": {
-+        "node": ">= 10.0.0"
-+      },
-+      "funding": {
-+        "type": "opencollective",
-+        "url": "https://opencollective.com/parcel"
-+      }
-+    },
 +    "node_modules/@parcel/watcher-win32-x64": {
-+      "version": "2.5.6",
-+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
-+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
++      "version": "2.6.0",
++      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
++      "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
 +      "cpu": [
 +        "x64"
 +      ],
@@ -32319,14 +32578,14 @@ index 0000000..e97f889
 +      ]
 +    },
 +    "node_modules/@schematics/angular": {
-+      "version": "20.3.29",
-+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.29.tgz",
-+      "integrity": "sha512-mzUvgz8YAZTZypIPfz70P+7XEKaE9H88P1EkQ3x5HcIBobwTZysJimmdXPjmJ5+mWBoONfLp72L/9j59U/D1/A==",
++      "version": "20.3.32",
++      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.32.tgz",
++      "integrity": "sha512-asporFGNP/U4p/A6jHqRmC8zGBxsSbjA/17I0p1tIW4HLbDTwJ0Z1gTSGpkHGRGTeowPZZSCj7s0IWVoaBCjnA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "@angular-devkit/core": "20.3.29",
-+        "@angular-devkit/schematics": "20.3.29",
++        "@angular-devkit/core": "20.3.32",
++        "@angular-devkit/schematics": "20.3.32",
 +        "jsonc-parser": "3.3.1"
 +      },
 +      "engines": {
@@ -32501,9 +32760,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@tufjs/models/node_modules/brace-expansion": {
-+      "version": "5.0.6",
-+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
++      "version": "5.0.7",
++      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
++      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -32624,9 +32883,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/@types/express-serve-static-core": {
-+      "version": "4.19.8",
-+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
-+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
++      "version": "4.19.9",
++      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
++      "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -32675,9 +32934,9 @@ index 0000000..e97f889
 +      "license": "MIT"
 +    },
 +    "node_modules/@types/node": {
-+      "version": "22.20.0",
-+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
-+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
++      "version": "22.20.1",
++      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
++      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -33465,9 +33724,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/bare-fs": {
-+      "version": "4.7.2",
-+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
-+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
++      "version": "4.7.4",
++      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
++      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
 +      "dev": true,
 +      "license": "Apache-2.0",
 +      "dependencies": {
@@ -33489,25 +33748,12 @@ index 0000000..e97f889
 +        }
 +      }
 +    },
-+    "node_modules/bare-os": {
-+      "version": "3.9.1",
-+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-+      "dev": true,
-+      "license": "Apache-2.0",
-+      "engines": {
-+        "bare": ">=1.14.0"
-+      }
-+    },
 +    "node_modules/bare-path": {
-+      "version": "3.0.1",
-+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
-+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
++      "version": "3.1.1",
++      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
++      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
 +      "dev": true,
-+      "license": "Apache-2.0",
-+      "dependencies": {
-+        "bare-os": "^3.0.1"
-+      }
++      "license": "Apache-2.0"
 +    },
 +    "node_modules/bare-stream": {
 +      "version": "2.13.3",
@@ -33538,9 +33784,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/bare-url": {
-+      "version": "2.4.5",
-+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
-+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
++      "version": "2.4.6",
++      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
++      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
 +      "dev": true,
 +      "license": "Apache-2.0",
 +      "dependencies": {
@@ -33579,9 +33825,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/baseline-browser-mapping": {
-+      "version": "2.10.38",
-+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
++      "version": "2.11.0",
++      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz",
++      "integrity": "sha512-oCu2wfipvX3AePSgmOuKkIywOu+8n9psz7hXYmk56ghpu3+7KzNIBopaOs4c9BrtdnTtW30unG9GTfHo7EwERQ==",
 +      "dev": true,
 +      "license": "Apache-2.0",
 +      "bin": {
@@ -33691,9 +33937,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/bonjour-service": {
-+      "version": "1.4.1",
-+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.1.tgz",
-+      "integrity": "sha512-9KM4QMPKnaJqaja1v7gYO/+TXZGLtzPA05NmUTqDAJjcsWeVoOXKMvU9g0gfuuoYTQqJZ924hivICd5R/bCJbA==",
++      "version": "1.4.3",
++      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.3.tgz",
++      "integrity": "sha512-2Kd5UYlFUVgAKMTyuBLl6w49wqfOnbxHqmuH0oCl/n7TfAikR0zoowNOP5BU4dfXmm+Vr9JyEN370auSMx+CNg==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -33728,9 +33974,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/brace-expansion": {
-+      "version": "1.1.15",
-+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
++      "version": "1.1.16",
++      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
++      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -33752,9 +33998,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/browserslist": {
-+      "version": "4.28.2",
-+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
++      "version": "4.28.7",
++      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
++      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
 +      "dev": true,
 +      "funding": [
 +        {
@@ -33772,10 +34018,10 @@ index 0000000..e97f889
 +      ],
 +      "license": "MIT",
 +      "dependencies": {
-+        "baseline-browser-mapping": "^2.10.12",
-+        "caniuse-lite": "^1.0.30001782",
-+        "electron-to-chromium": "^1.5.328",
-+        "node-releases": "^2.0.36",
++        "baseline-browser-mapping": "^2.10.44",
++        "caniuse-lite": "^1.0.30001806",
++        "electron-to-chromium": "^1.5.393",
++        "node-releases": "^2.0.51",
 +        "update-browserslist-db": "^1.2.3"
 +      },
 +      "bin": {
@@ -33896,9 +34142,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/cacache/node_modules/brace-expansion": {
-+      "version": "5.0.6",
-+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
++      "version": "5.0.7",
++      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
++      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -33927,9 +34173,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/cacache/node_modules/lru-cache": {
-+      "version": "11.5.1",
-+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
++      "version": "11.5.2",
++      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
++      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
 +      "dev": true,
 +      "license": "BlueOak-1.0.0",
 +      "engines": {
@@ -33994,9 +34240,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/caniuse-lite": {
-+      "version": "1.0.30001799",
-+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
++      "version": "1.0.30001806",
++      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
++      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
 +      "dev": true,
 +      "funding": [
 +        {
@@ -34963,9 +35209,9 @@ index 0000000..e97f889
 +      "license": "MIT"
 +    },
 +    "node_modules/electron-to-chromium": {
-+      "version": "1.5.376",
-+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
-+      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
++      "version": "1.5.395",
++      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.395.tgz",
++      "integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
 +      "dev": true,
 +      "license": "ISC"
 +    },
@@ -35098,9 +35344,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/enhanced-resolve": {
-+      "version": "5.24.0",
-+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
-+      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
++      "version": "5.24.3",
++      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
++      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -35208,9 +35454,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/es-module-lexer": {
-+      "version": "2.1.0",
-+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
++      "version": "2.3.1",
++      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
++      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
 +      "dev": true,
 +      "license": "MIT"
 +    },
@@ -35228,9 +35474,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/esbuild": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
++      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
 +      "dev": true,
 +      "hasInstallScript": true,
 +      "license": "MIT",
@@ -35241,38 +35487,38 @@ index 0000000..e97f889
 +        "node": ">=18"
 +      },
 +      "optionalDependencies": {
-+        "@esbuild/aix-ppc64": "0.28.0",
-+        "@esbuild/android-arm": "0.28.0",
-+        "@esbuild/android-arm64": "0.28.0",
-+        "@esbuild/android-x64": "0.28.0",
-+        "@esbuild/darwin-arm64": "0.28.0",
-+        "@esbuild/darwin-x64": "0.28.0",
-+        "@esbuild/freebsd-arm64": "0.28.0",
-+        "@esbuild/freebsd-x64": "0.28.0",
-+        "@esbuild/linux-arm": "0.28.0",
-+        "@esbuild/linux-arm64": "0.28.0",
-+        "@esbuild/linux-ia32": "0.28.0",
-+        "@esbuild/linux-loong64": "0.28.0",
-+        "@esbuild/linux-mips64el": "0.28.0",
-+        "@esbuild/linux-ppc64": "0.28.0",
-+        "@esbuild/linux-riscv64": "0.28.0",
-+        "@esbuild/linux-s390x": "0.28.0",
-+        "@esbuild/linux-x64": "0.28.0",
-+        "@esbuild/netbsd-arm64": "0.28.0",
-+        "@esbuild/netbsd-x64": "0.28.0",
-+        "@esbuild/openbsd-arm64": "0.28.0",
-+        "@esbuild/openbsd-x64": "0.28.0",
-+        "@esbuild/openharmony-arm64": "0.28.0",
-+        "@esbuild/sunos-x64": "0.28.0",
-+        "@esbuild/win32-arm64": "0.28.0",
-+        "@esbuild/win32-ia32": "0.28.0",
-+        "@esbuild/win32-x64": "0.28.0"
++        "@esbuild/aix-ppc64": "0.28.1",
++        "@esbuild/android-arm": "0.28.1",
++        "@esbuild/android-arm64": "0.28.1",
++        "@esbuild/android-x64": "0.28.1",
++        "@esbuild/darwin-arm64": "0.28.1",
++        "@esbuild/darwin-x64": "0.28.1",
++        "@esbuild/freebsd-arm64": "0.28.1",
++        "@esbuild/freebsd-x64": "0.28.1",
++        "@esbuild/linux-arm": "0.28.1",
++        "@esbuild/linux-arm64": "0.28.1",
++        "@esbuild/linux-ia32": "0.28.1",
++        "@esbuild/linux-loong64": "0.28.1",
++        "@esbuild/linux-mips64el": "0.28.1",
++        "@esbuild/linux-ppc64": "0.28.1",
++        "@esbuild/linux-riscv64": "0.28.1",
++        "@esbuild/linux-s390x": "0.28.1",
++        "@esbuild/linux-x64": "0.28.1",
++        "@esbuild/netbsd-arm64": "0.28.1",
++        "@esbuild/netbsd-x64": "0.28.1",
++        "@esbuild/openbsd-arm64": "0.28.1",
++        "@esbuild/openbsd-x64": "0.28.1",
++        "@esbuild/openharmony-arm64": "0.28.1",
++        "@esbuild/sunos-x64": "0.28.1",
++        "@esbuild/win32-arm64": "0.28.1",
++        "@esbuild/win32-ia32": "0.28.1",
++        "@esbuild/win32-x64": "0.28.1"
 +      }
 +    },
 +    "node_modules/esbuild-wasm": {
-+      "version": "0.28.0",
-+      "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.28.0.tgz",
-+      "integrity": "sha512-5TRVKExcEmeMkccIZMzUq+Az6X2RoMAJyfl6SMMO1dMVhmvt0I2mx7gAb6zYi42n4d1ETcatFXazGKzA+aW7fg==",
++      "version": "0.28.1",
++      "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.28.1.tgz",
++      "integrity": "sha512-p/GD4E8oYRjg3kjdKrnMb0s4PzXgJF42e0MF4H0+ACyK/kIlFRp3e0fzOleIG+wBBm6MM3XQrbpe7soEA+vJIA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "bin": {
@@ -35515,12 +35761,13 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/express-rate-limit": {
-+      "version": "8.5.2",
-+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
++      "version": "8.6.0",
++      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
++      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
++        "debug": "^4.4.3",
 +        "ip-address": "^10.2.0"
 +      },
 +      "engines": {
@@ -35606,9 +35853,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/fast-uri": {
-+      "version": "3.1.2",
-+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
++      "version": "3.1.4",
++      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
++      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 +      "dev": true,
 +      "funding": [
 +        {
@@ -36099,9 +36346,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/hono": {
-+      "version": "4.12.26",
-+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
-+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
++      "version": "4.12.31",
++      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
++      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
 +      "dev": true,
 +      "license": "MIT",
 +      "engines": {
@@ -36122,9 +36369,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/hosted-git-info/node_modules/lru-cache": {
-+      "version": "11.5.1",
-+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
++      "version": "11.5.2",
++      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
++      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
 +      "dev": true,
 +      "license": "BlueOak-1.0.0",
 +      "engines": {
@@ -36289,9 +36536,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/http-proxy-middleware": {
-+      "version": "3.0.5",
-+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-+      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
++      "version": "3.0.7",
++      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
++      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -36303,7 +36550,7 @@ index 0000000..e97f889
 +        "micromatch": "^4.0.8"
 +      },
 +      "engines": {
-+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
++        "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
 +      }
 +    },
 +    "node_modules/https-proxy-agent": {
@@ -36331,9 +36578,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/iconv-lite": {
-+      "version": "0.7.2",
-+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
++      "version": "0.7.3",
++      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
++      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -36405,9 +36652,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/ignore-walk/node_modules/brace-expansion": {
-+      "version": "5.0.6",
-+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
++      "version": "5.0.7",
++      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
++      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -36448,9 +36695,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/immutable": {
-+      "version": "5.1.6",
-+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
-+      "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
++      "version": "5.1.9",
++      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
++      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
 +      "dev": true,
 +      "license": "MIT"
 +    },
@@ -36925,9 +37172,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/jose": {
-+      "version": "6.2.3",
-+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
++      "version": "6.2.4",
++      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
++      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "funding": {
@@ -36942,9 +37189,9 @@ index 0000000..e97f889
 +      "license": "MIT"
 +    },
 +    "node_modules/js-yaml": {
-+      "version": "4.2.0",
-+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
++      "version": "4.3.0",
++      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
++      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 +      "dev": true,
 +      "funding": [
 +        {
@@ -37237,9 +37484,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/karma/node_modules/body-parser": {
-+      "version": "1.20.5",
-+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
++      "version": "1.20.6",
++      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
++      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -38024,20 +38271,20 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/memfs": {
-+      "version": "4.57.8",
-+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.8.tgz",
-+      "integrity": "sha512-bApYhn8BLpFAnAQmFfEl/NPN+8qx5Ar3V4Qt3ek23mVwBEElzV7c6XoPkb/PCG8ZFpowCEpHcPwMFTwHS7tSMA==",
++      "version": "4.64.0",
++      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.64.0.tgz",
++      "integrity": "sha512-Kw72fgY7Wn+sD8KmtNWSafl1dz0UvAsE/PHs3YVfLiaZuA3HxNm9sRLqAu0ATiBGJvME1PxZXbBZPv5GycDeAw==",
 +      "dev": true,
 +      "license": "Apache-2.0",
 +      "dependencies": {
-+        "@jsonjoy.com/fs-core": "4.57.8",
-+        "@jsonjoy.com/fs-fsa": "4.57.8",
-+        "@jsonjoy.com/fs-node": "4.57.8",
-+        "@jsonjoy.com/fs-node-builtins": "4.57.8",
-+        "@jsonjoy.com/fs-node-to-fsa": "4.57.8",
-+        "@jsonjoy.com/fs-node-utils": "4.57.8",
-+        "@jsonjoy.com/fs-print": "4.57.8",
-+        "@jsonjoy.com/fs-snapshot": "4.57.8",
++        "@jsonjoy.com/fs-core": "4.64.0",
++        "@jsonjoy.com/fs-fsa": "4.64.0",
++        "@jsonjoy.com/fs-node": "4.64.0",
++        "@jsonjoy.com/fs-node-builtins": "4.64.0",
++        "@jsonjoy.com/fs-node-to-fsa": "4.64.0",
++        "@jsonjoy.com/fs-node-utils": "4.64.0",
++        "@jsonjoy.com/fs-print": "4.64.0",
++        "@jsonjoy.com/fs-snapshot": "4.64.0",
 +        "@jsonjoy.com/json-pack": "^1.11.0",
 +        "@jsonjoy.com/util": "^1.9.0",
 +        "glob-to-regex.js": "^1.0.1",
@@ -38452,9 +38699,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/nanoid": {
-+      "version": "3.3.14",
-+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.14.tgz",
-+      "integrity": "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==",
++      "version": "3.3.16",
++      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
++      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 +      "dev": true,
 +      "funding": [
 +        {
@@ -38631,9 +38878,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/node-releases": {
-+      "version": "2.0.48",
-+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
++      "version": "2.0.51",
++      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
++      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
 +      "dev": true,
 +      "license": "MIT",
 +      "engines": {
@@ -38974,9 +39221,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/p-map": {
-+      "version": "7.0.4",
-+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
++      "version": "7.0.6",
++      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
++      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
 +      "dev": true,
 +      "license": "MIT",
 +      "engines": {
@@ -39268,9 +39515,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/path-scurry/node_modules/lru-cache": {
-+      "version": "11.5.1",
-+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
++      "version": "11.5.2",
++      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
++      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
 +      "dev": true,
 +      "license": "BlueOak-1.0.0",
 +      "engines": {
@@ -39327,9 +39574,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/piscina": {
-+      "version": "5.1.3",
-+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.3.tgz",
-+      "integrity": "sha512-0u3N7H4+hbr40KjuVn2uNhOcthu/9usKhnw5vT3J7ply79v3D3M8naI00el9Klcy16x557VsEkkUQaHCWFXC/g==",
++      "version": "5.2.0",
++      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.2.0.tgz",
++      "integrity": "sha512-DszUCKeVN/5G5QKo6jAVHL8fmKnkJvQ0ACiVgY7YGCq3TUB2oznAOayvZPIAdEThvhczkXR+qm3IHsNXpFCYfA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "engines": {
@@ -39368,9 +39615,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/postcss": {
-+      "version": "8.5.15",
-+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
++      "version": "8.5.22",
++      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
++      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
 +      "dev": true,
 +      "funding": [
 +        {
@@ -39388,7 +39635,7 @@ index 0000000..e97f889
 +      ],
 +      "license": "MIT",
 +      "dependencies": {
-+        "nanoid": "^3.3.12",
++        "nanoid": "^3.3.16",
 +        "picocolors": "^1.1.1",
 +        "source-map-js": "^1.2.1"
 +      },
@@ -39732,13 +39979,17 @@ index 0000000..e97f889
 +      "license": "MIT"
 +    },
 +    "node_modules/range-parser": {
-+      "version": "1.2.1",
-+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
++      "version": "1.3.0",
++      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
++      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
 +      "dev": true,
 +      "license": "MIT",
 +      "engines": {
 +        "node": ">= 0.6"
++      },
++      "funding": {
++        "type": "opencollective",
++        "url": "https://opencollective.com/express"
 +      }
 +    },
 +    "node_modules/raw-body": {
@@ -40347,9 +40598,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/serialize-javascript": {
-+      "version": "7.0.6",
-+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
-+      "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
++      "version": "7.0.7",
++      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
++      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
 +      "dev": true,
 +      "license": "BSD-3-Clause",
 +      "engines": {
@@ -40620,9 +40871,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/shell-quote": {
-+      "version": "1.8.4",
-+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
++      "version": "1.10.0",
++      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
++      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
 +      "dev": true,
 +      "license": "MIT",
 +      "engines": {
@@ -40813,9 +41064,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/socket.io-parser": {
-+      "version": "4.2.6",
-+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
++      "version": "4.2.7",
++      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
++      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
 +      "license": "MIT",
 +      "dependencies": {
 +        "@socket.io/component-emitter": "~3.1.0",
@@ -41194,9 +41445,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/tar": {
-+      "version": "7.5.16",
-+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
++      "version": "7.5.21",
++      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
++      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
 +      "dev": true,
 +      "license": "BlueOak-1.0.0",
 +      "dependencies": {
@@ -41211,9 +41462,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/tar-fs": {
-+      "version": "3.1.2",
-+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
-+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
++      "version": "3.1.3",
++      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
++      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -41811,13 +42062,13 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/vite": {
-+      "version": "7.3.2",
-+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
++      "version": "7.3.6",
++      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
++      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
-+        "esbuild": "^0.27.0",
++        "esbuild": "^0.27.0 || ^0.28.0",
 +        "fdir": "^6.5.0",
 +        "picomatch": "^4.0.3",
 +        "postcss": "^8.5.6",
@@ -41883,490 +42134,6 @@ index 0000000..e97f889
 +        "yaml": {
 +          "optional": true
 +        }
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-+      "cpu": [
-+        "ppc64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "aix"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/android-arm": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-+      "cpu": [
-+        "arm"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "android"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "android"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/android-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "android"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "darwin"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "darwin"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "freebsd"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "freebsd"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-+      "cpu": [
-+        "arm"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-+      "cpu": [
-+        "ia32"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-+      "cpu": [
-+        "loong64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-+      "cpu": [
-+        "mips64el"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-+      "cpu": [
-+        "ppc64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-+      "cpu": [
-+        "riscv64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-+      "cpu": [
-+        "s390x"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "linux"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "netbsd"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "netbsd"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "openbsd"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "openbsd"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "openharmony"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "sunos"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-+      "cpu": [
-+        "arm64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "win32"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-+      "cpu": [
-+        "ia32"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "win32"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-+      "cpu": [
-+        "x64"
-+      ],
-+      "dev": true,
-+      "license": "MIT",
-+      "optional": true,
-+      "os": [
-+        "win32"
-+      ],
-+      "engines": {
-+        "node": ">=18"
-+      }
-+    },
-+    "node_modules/vite/node_modules/esbuild": {
-+      "version": "0.27.7",
-+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-+      "dev": true,
-+      "hasInstallScript": true,
-+      "license": "MIT",
-+      "bin": {
-+        "esbuild": "bin/esbuild"
-+      },
-+      "engines": {
-+        "node": ">=18"
-+      },
-+      "optionalDependencies": {
-+        "@esbuild/aix-ppc64": "0.27.7",
-+        "@esbuild/android-arm": "0.27.7",
-+        "@esbuild/android-arm64": "0.27.7",
-+        "@esbuild/android-x64": "0.27.7",
-+        "@esbuild/darwin-arm64": "0.27.7",
-+        "@esbuild/darwin-x64": "0.27.7",
-+        "@esbuild/freebsd-arm64": "0.27.7",
-+        "@esbuild/freebsd-x64": "0.27.7",
-+        "@esbuild/linux-arm": "0.27.7",
-+        "@esbuild/linux-arm64": "0.27.7",
-+        "@esbuild/linux-ia32": "0.27.7",
-+        "@esbuild/linux-loong64": "0.27.7",
-+        "@esbuild/linux-mips64el": "0.27.7",
-+        "@esbuild/linux-ppc64": "0.27.7",
-+        "@esbuild/linux-riscv64": "0.27.7",
-+        "@esbuild/linux-s390x": "0.27.7",
-+        "@esbuild/linux-x64": "0.27.7",
-+        "@esbuild/netbsd-arm64": "0.27.7",
-+        "@esbuild/netbsd-x64": "0.27.7",
-+        "@esbuild/openbsd-arm64": "0.27.7",
-+        "@esbuild/openbsd-x64": "0.27.7",
-+        "@esbuild/openharmony-arm64": "0.27.7",
-+        "@esbuild/sunos-x64": "0.27.7",
-+        "@esbuild/win32-arm64": "0.27.7",
-+        "@esbuild/win32-ia32": "0.27.7",
-+        "@esbuild/win32-x64": "0.27.7"
 +      }
 +    },
 +    "node_modules/vite/node_modules/tinyglobby": {
@@ -42603,9 +42370,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/webpack-dev-server/node_modules/body-parser": {
-+      "version": "1.20.5",
-+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
++      "version": "1.20.6",
++      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
++      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
 +      "dev": true,
 +      "license": "MIT",
 +      "dependencies": {
@@ -42912,6 +42679,16 @@ index 0000000..e97f889
 +        "url": "https://github.com/sponsors/jonschlinkert"
 +      }
 +    },
++    "node_modules/webpack-dev-server/node_modules/range-parser": {
++      "version": "1.2.1",
++      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
++      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
++      "dev": true,
++      "license": "MIT",
++      "engines": {
++        "node": ">= 0.6"
++      }
++    },
 +    "node_modules/webpack-dev-server/node_modules/raw-body": {
 +      "version": "2.5.3",
 +      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
@@ -43012,9 +42789,9 @@ index 0000000..e97f889
 +      }
 +    },
 +    "node_modules/webpack-sources": {
-+      "version": "3.5.0",
-+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
-+      "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
++      "version": "3.5.1",
++      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
++      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
 +      "dev": true,
 +      "license": "MIT",
 +      "engines": {
@@ -43400,26 +43177,29 @@ index 0000000..e97f889
 +      "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
 +      "license": "MIT"
 +    }
-+  }
++  },
++  "traderxPackageJsonSha256": "babdbdb4f1b1b202b07c842687dc15314b6b02ff8ae010940af9b8d818082b96"
 +}
 diff --git a/web-front-end/angular/package.json b/web-front-end/angular/package.json
 new file mode 100644
-index 0000000..f89c654
+index 0000000..3e9bc3e
 --- /dev/null
 +++ b/web-front-end/angular/package.json
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,67 @@
 +{
 +  "name": "@finos/web-front-end",
 +  "version": "0.0.0",
 +  "scripts": {
 +    "ng": "ng",
 +    "lint": "ng lint",
-+    "start-prod": "ng serve --host 0.0.0.0 --disable-host-check --configuration=production --port ${WEB_SERVICE_PORT:-18093}",
-+    "start": "ng serve --host 0.0.0.0 --disable-host-check --port ${WEB_SERVICE_PORT:-18093}",
++    "start-dev": "cross-env NODE_ENV=development node serve-angular-dev.js",
++    "start": "ng build --base-href=. --configuration production --output-path=./dist --aot --output-hashing=all && node serve-angular-dist.js",
 +    "build": "cross-env NG_CLI_ANALYTICS=ci ng build --base-href=. --configuration production --output-path=./dist --aot --output-hashing=all",
 +    "buildlocal": "cross-env NG_CLI_ANALYTICS=ci ng build --base-href=. --configuration local --output-path=./dist --aot --output-hashing=all",
 +    "test": "ng test --code-coverage --watch=true",
-+    "test:ci": "ng test --code-coverage --watch=false --browsers=ChromeHeadlessNoSandbox"
++    "test:ci": "ng test --code-coverage --watch=false --browsers=ChromeHeadlessNoSandbox",
++    "sbom": "cyclonedx-npm --output-file build/reports/sbom.json --output-format JSON",
++    "sbom:xml": "cyclonedx-npm --output-file build/reports/sbom.xml --output-format XML"
 +  },
 +  "private": true,
 +  "license": "Apache-2.0",
@@ -43440,6 +43220,15 @@ index 0000000..f89c654
 +    "socket.io-client": "^4.8.3",
 +    "tslib": "^2.7.0",
 +    "zone.js": "^0.15.0"
++  },
++  "overrides": {
++    "ws": "8.21.0",
++    "postcss": "^8.5.13",
++    "serialize-javascript": "^7.0.5",
++    "tar": "^7.5.13",
++    "uuid": "^14.0.0",
++    "qs": "6.15.2",
++    "engine.io": "6.6.9"
 +  },
 +  "devDependencies": {
 +    "@angular-devkit/build-angular": "^20.3.25",
@@ -43462,14 +43251,6 @@ index 0000000..f89c654
 +    "serve-handler": "^6.1.5",
 +    "ts-node": "^10.9.2",
 +    "typescript": "~5.8.2"
-+  },
-+  "overrides": {
-+    "postcss": "^8.5.13",
-+    "qs": "6.15.2",
-+    "serialize-javascript": "^7.0.5",
-+    "tar": "^7.5.13",
-+    "uuid": "^14.0.0",
-+    "ws": "8.21.0"
 +  }
 +}
 diff --git a/web-front-end/angular/prettier.config.js b/web-front-end/angular/prettier.config.js
@@ -43493,6 +43274,73 @@ index 0000000..b50a96c
 +        }
 +    ]
 +};
+diff --git a/web-front-end/angular/serve-angular-dev.js b/web-front-end/angular/serve-angular-dev.js
+new file mode 100644
+index 0000000..a1df5e0
+--- /dev/null
++++ b/web-front-end/angular/serve-angular-dev.js
+@@ -0,0 +1,25 @@
++'use strict';
++
++const { spawn } = require('child_process');
++
++const port = Number.parseInt(process.env.WEB_SERVICE_PORT || '18093', 10);
++const ngBinary = process.platform === 'win32' ? 'npx.cmd' : 'npx';
++
++const child = spawn(
++  ngBinary,
++  ['ng', 'serve', '--host', '0.0.0.0', '--disable-host-check', '--port', String(port)],
++  { stdio: 'inherit', env: process.env }
++);
++
++child.on('exit', (code, signal) => {
++  if (signal) {
++    process.kill(process.pid, signal);
++    return;
++  }
++  process.exit(code ?? 1);
++});
++
++child.on('error', (err) => {
++  console.error('[angular-dev] failed to start ng serve', err);
++  process.exit(1);
++});
+diff --git a/web-front-end/angular/serve-angular-dist.js b/web-front-end/angular/serve-angular-dist.js
+new file mode 100644
+index 0000000..1a64f0b
+--- /dev/null
++++ b/web-front-end/angular/serve-angular-dist.js
+@@ -0,0 +1,30 @@
++'use strict';
++
++const http = require('http');
++const handler = require('serve-handler');
++const path = require('path');
++const fs = require('fs');
++
++const port = Number.parseInt(process.env.WEB_SERVICE_PORT || '18093', 10);
++
++const distBase = path.join(__dirname, 'dist');
++const distBrowser = path.join(distBase, 'browser');
++const publicDir = fs.existsSync(distBrowser) ? distBrowser : distBase;
++
++const server = http.createServer((req, res) =>
++  handler(req, res, {
++    public: publicDir,
++    rewrites: [{ source: '**', destination: '/index.html' }],
++    headers: [
++      {
++        source: '**',
++        headers: [{ key: 'Cache-Control', value: 'no-cache' }]
++      }
++    ]
++  })
++);
++
++server.listen(port, '0.0.0.0', () => {
++  console.log(`[angular-static] serving ${publicDir}`);
++  console.log(`[angular-static] listening on :${port}`);
++});
 diff --git a/web-front-end/angular/tsconfig.app.json b/web-front-end/angular/tsconfig.app.json
 new file mode 100644
 index 0000000..5ff1945


### PR DESCRIPTION
## Summary
- refresh the state 004 overlay patch against the current state 003 generated output
- preserve 004 compose/ingress/runtime assets while using current generated component dependency targets
- remove stale inherited runtime/CI patch hunks that no longer belong to the 004 overlay

## Validation
- PATH="/opt/homebrew/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.10/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/git/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/dovkatz/.codex/tmp/arg0/codex-arg0lXilV5:/Applications/ChatGPT.app/Contents/Resources" TRADERX_GENERATED_ROOT="/var/folders/y2/79lf532j6l5f3r6vpwfz0t380000gn/T/tmp.CeCRgdxuC4/generated" bash pipeline/generate-state.sh 004-containerized-compose-runtime
- PATH="/opt/homebrew/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Library/Frameworks/Python.framework/Versions/3.10/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/git/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/dovkatz/.codex/tmp/arg0/codex-arg0lXilV5:/Applications/ChatGPT.app/Contents/Resources" bash pipeline/generate-state.sh 004-containerized-compose-runtime
- bash pipeline/validate-generated-dependency-targets.sh generated/code/components generated/code/target-generated