### PR TITLE
Refresh state 006 generated overlay patch

### DIFF
--- a/specs/006-messaging-nats-replacement/generation/patches/0001-state-overlay.patch
+++ b/specs/006-messaging-nats-replacement/generation/patches/0001-state-overlay.patch
@@ -25,7 +25,7 @@ index 91e5754..f43eb9f 100644
      steps:
        - uses: actions/checkout@v4
 diff --git a/.github/workflows/security.yml b/.github/workflows/security.yml
-index c9594c9..3eb407b 100644
+index d4f367f..9a2af66 100644
 --- a/.github/workflows/security.yml
 +++ b/.github/workflows/security.yml
 @@ -23,7 +23,6 @@ jobs:
@@ -36,7 +36,7 @@ index c9594c9..3eb407b 100644
            - web-front-end/angular
      steps:
        - name: Checkout
-@@ -177,9 +176,6 @@ jobs:
+@@ -178,9 +177,6 @@ jobs:
            - directory: reference-data
              dockerfile: Dockerfile.compose
              image_name: reference-data
@@ -71,7 +71,7 @@ index 0e81a6c..45d73a8 100644
  - Service/runtime topology is defined by the source state pack in the upstream repository.
  - This generated directory contains runnable artifacts, not the authoritative architecture source.
 diff --git a/ci/state-metadata.json b/ci/state-metadata.json
-index 0835b4c..1175300 100644
+index cea98d5..68c6941 100644
 --- a/ci/state-metadata.json
 +++ b/ci/state-metadata.json
 @@ -1,12 +1,11 @@
@@ -123,7 +123,7 @@ index ea0a7f0..0000000
 -
 -- `http://localhost:8080`
 diff --git a/ingress/nginx.traderx.conf.template b/ingress/nginx.traderx.conf.template
-index fbe8473..f881206 100644
+index 565d298..a1894c3 100644
 --- a/ingress/nginx.traderx.conf.template
 +++ b/ingress/nginx.traderx.conf.template
 @@ -16,28 +16,18 @@ server {
@@ -158,7 +158,7 @@ index fbe8473..f881206 100644
      }
  
      location /people-service/ {
-@@ -62,5 +52,8 @@ server {
+@@ -97,5 +87,8 @@ server {
  
      location / {
          proxy_pass ${WEB_FRONTEND_URL};
@@ -191,10 +191,10 @@ index 0000000..d9896f5
 +- NATS monitor: `http://localhost:8222/varz`
 +- NATS websocket (ingress proxied): `ws://localhost:8080/nats-ws`
 diff --git a/containerized-compose/docker-compose.yml b/messaging-nats-replacement/docker-compose.yml
-similarity index 63%
+similarity index 64%
 rename from containerized-compose/docker-compose.yml
 rename to messaging-nats-replacement/docker-compose.yml
-index 97b46a6..ba4a919 100644
+index 568e078..34f0057 100644
 --- a/containerized-compose/docker-compose.yml
 +++ b/messaging-nats-replacement/docker-compose.yml
 @@ -1,19 +1,22 @@
@@ -400,13 +400,13 @@ index 8a93957..e807587 100644
  - Scripts in this folder are local-runtime wrappers for the generated codebase.
  - They are designed to run without invoking root pipeline generation.
 diff --git a/scripts/start-state-005-postgres-database-replacement-generated.sh b/scripts/start-state-006-messaging-nats-replacement-generated.sh
-similarity index 87%
+similarity index 89%
 rename from scripts/start-state-005-postgres-database-replacement-generated.sh
 rename to scripts/start-state-006-messaging-nats-replacement-generated.sh
-index d0d6062..16a2718 100755
+index 01b9c60..c49e816 100755
 --- a/scripts/start-state-005-postgres-database-replacement-generated.sh
 +++ b/scripts/start-state-006-messaging-nats-replacement-generated.sh
-@@ -17,10 +17,10 @@ if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
+@@ -17,9 +17,9 @@ if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
      exec "${LOCAL_RUNTIME_SCRIPT}" "$@"
    fi
  fi
@@ -419,7 +419,6 @@ index d0d6062..16a2718 100755
  COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
  DRY_RUN=0
  SKIP_BUILD=0
- 
 @@ -116,12 +116,13 @@ wait_for_http() {
  
  wait_for_postgres || exit 1
@@ -440,7 +439,7 @@ diff --git a/scripts/status-state-005-postgres-database-replacement-generated.sh
 similarity index 73%
 rename from scripts/status-state-005-postgres-database-replacement-generated.sh
 rename to scripts/status-state-006-messaging-nats-replacement-generated.sh
-index 340ee63..9676d35 100755
+index 268bda4..cd3ab4b 100755
 --- a/scripts/status-state-005-postgres-database-replacement-generated.sh
 +++ b/scripts/status-state-006-messaging-nats-replacement-generated.sh
 @@ -17,8 +17,8 @@ if [[ "${TRADERX_LOCAL_RUNTIME_SCRIPT:-0}" != "1" ]]; then
@@ -549,13 +548,13 @@ index 187e687..0000000
 -- Commands: `subscribe`, `unsubscribe`, `unusbscribe` (legacy compatibility), `publish`
 diff --git a/trade-feed/SPEC.manifest.json b/trade-feed/SPEC.manifest.json
 deleted file mode 100644
-index b0ff5e7..0000000
+index 4fa2a49..0000000
 --- a/trade-feed/SPEC.manifest.json
 +++ /dev/null
-@@ -1,32 +0,0 @@
+@@ -1,33 +0,0 @@
 -{
 -  "schemaVersion": "1.0.0",
--  "generatedAtUtc": "2026-03-31T12:59:32Z",
+-  "generatedAtUtc": "2026-07-22T12:27:30Z",
 -  "component": {
 -    "id": "trade-feed",
 -    "kind": "service",
@@ -569,7 +568,8 @@ index b0ff5e7..0000000
 -  "runtime": {
 -    "defaultPort": 18086,
 -    "dependsOn": [],
--    "requiredEnv": ["TRADE_FEED_PORT","CORS_ALLOWED_ORIGINS"]
+-    "requiredEnv": ["TRADE_FEED_PORT","CORS_ALLOWED_ORIGINS"],
+-    "healthHint": "tcp://<host>:18086 (TCP reachability)"
 -  },
 -  "contracts": {
 -    "primary": null
@@ -762,10 +762,10 @@ index ea23c90..0000000
 -});
 diff --git a/trade-feed/package.json b/trade-feed/package.json
 deleted file mode 100644
-index d9ef000..0000000
+index 136e009..0000000
 --- a/trade-feed/package.json
 +++ /dev/null
-@@ -1,18 +0,0 @@
+@@ -1,20 +0,0 @@
 -{
 -  "name": "@traderspec/trade-feed-specfirst",
 -  "version": "0.1.0",
@@ -781,21 +781,23 @@ index d9ef000..0000000
 -    "winston": "^3.17.0"
 -  },
 -  "overrides": {
+-    "engine.io": "6.6.9",
+-    "qs": "6.15.2",
 -    "ws": "8.21.0"
 -  }
 -}
 diff --git a/trade-processor/build.gradle b/trade-processor/build.gradle
-index b3a7648..48ea8b4 100644
+index 728c800..d587e02 100644
 --- a/trade-processor/build.gradle
 +++ b/trade-processor/build.gradle
-@@ -20,6 +20,7 @@ dependencies {
+@@ -23,6 +23,7 @@ dependencies {
    implementation 'org.springframework.boot:spring-boot-starter-web'
    implementation 'org.postgresql:postgresql:42.7.12'
    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.17'
 +  implementation 'io.nats:jnats:2.20.5'
+   implementation 'org.apache.logging.log4j:log4j-api:2.26.1'
+   implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.26.1'
  
-   implementation('org.json:json:20240303') {
-     because 'previous versions are affected by multiple CVE'
 diff --git a/trade-processor/src/main/java/finos/traderx/messaging/nats/NatsEnvelope.java b/trade-processor/src/main/java/finos/traderx/messaging/nats/NatsEnvelope.java
 new file mode 100644
 index 0000000..770ea68
@@ -1161,10 +1163,10 @@ index ec32e32..1dc48f4 100644
  
    public TradeFeedHandler() {
 diff --git a/trade-processor/src/main/resources/application.properties b/trade-processor/src/main/resources/application.properties
-index b56e35a..a11e2e7 100644
+index c83a4d5..e3e1021 100644
 --- a/trade-processor/src/main/resources/application.properties
 +++ b/trade-processor/src/main/resources/application.properties
-@@ -10,7 +10,7 @@ spring.jpa.hibernate.ddl-auto=none
+@@ -11,7 +11,7 @@ spring.jpa.hibernate.ddl-auto=none
  spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
  spring.threads.virtual.enabled=true
  
@@ -1174,17 +1176,17 @@ index b56e35a..a11e2e7 100644
  # To avoid "Request header is too large" when application is backed by oidc proxy.
  server.max-http-request-header-size=1000000
 diff --git a/trade-service/build.gradle b/trade-service/build.gradle
-index 5693071..d7a9ae1 100644
+index 434cc4d..7bd0742 100644
 --- a/trade-service/build.gradle
 +++ b/trade-service/build.gradle
-@@ -24,6 +24,7 @@ dependencies {
+@@ -27,6 +27,7 @@ dependencies {
    implementation 'org.springframework.boot:spring-boot-starter-web'
    implementation 'com.h2database:h2:2.4.240'
    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.17'
 +  implementation 'io.nats:jnats:2.20.5'
+   implementation 'org.apache.logging.log4j:log4j-api:2.26.1'
+   implementation 'org.apache.logging.log4j:log4j-to-slf4j:2.26.1'
  
-   implementation('org.json:json:20240303') {
-     because 'previous versions are affected by multiple CVE'
 diff --git a/trade-service/src/main/java/finos/traderx/messaging/nats/NatsEnvelope.java b/trade-service/src/main/java/finos/traderx/messaging/nats/NatsEnvelope.java
 new file mode 100644
 index 0000000..770ea68
@@ -1389,10 +1391,10 @@ index 2224b99..7f8dc0d 100644
    }
  }
 diff --git a/trade-service/src/main/resources/application.properties b/trade-service/src/main/resources/application.properties
-index 2640da4..3dfc1e9 100644
+index 34c50f4..fccb4ce 100644
 --- a/trade-service/src/main/resources/application.properties
 +++ b/trade-service/src/main/resources/application.properties
-@@ -5,7 +5,7 @@ people.service.url=${PEOPLE_SERVICE_URL:http://${PEOPLE_SERVICE_HOST:localhost}:
+@@ -6,7 +6,7 @@ people.service.url=${PEOPLE_SERVICE_URL:http://${PEOPLE_SERVICE_HOST:localhost}:
  account.service.url=${ACCOUNT_SERVICE_URL:http://${ACCOUNT_SERVICE_HOST:localhost}:18088}
  reference.data.service.url=${REFERENCE_DATA_SERVICE_URL:http://${REFERENCE_DATA_HOST:localhost}:18085}
  
@@ -1402,14 +1404,17 @@ index 2640da4..3dfc1e9 100644
  # To avoid "Request header is too large" when application is backed by oidc proxy.
  server.max-http-request-header-size=1000000
 diff --git a/web-front-end/angular/main/app/service/trade-feed.service.ts b/web-front-end/angular/main/app/service/trade-feed.service.ts
-index 1ef4b81..f15d8f2 100644
+index 829fa19..58917cc 100644
 --- a/web-front-end/angular/main/app/service/trade-feed.service.ts
 +++ b/web-front-end/angular/main/app/service/trade-feed.service.ts
-@@ -1,52 +1,203 @@
+@@ -1,15 +1,32 @@
  import { Injectable } from '@angular/core';
  import { environment } from 'main/environments/environment';
+ import { BehaviorSubject } from 'rxjs';
 -import { io, Socket } from "socket.io-client";
-+
+ 
+ export type MessageBusConnectionState = 'connecting' | 'connected' | 'disconnected';
+ 
 +type SubscriptionRecord = {
 +    sid: number;
 +    topic: string;
@@ -1421,7 +1426,7 @@ index 1ef4b81..f15d8f2 100644
 +    sid: number;
 +    bytes: number;
 +};
- 
++
  @Injectable({
      providedIn: 'root'
  })
@@ -1434,9 +1439,10 @@ index 1ef4b81..f15d8f2 100644
 +    private pendingData = '';
 +    private pendingMsg: PendingMsg | null = null;
 +    private readonly subscriptions = new Map<number, SubscriptionRecord>();
+     private readonly connectionStateSubject = new BehaviorSubject<MessageBusConnectionState>('connecting');
+     public readonly connectionState$ = this.connectionStateSubject.asObservable();
  
-     constructor() {
-         this.connect();
+@@ -18,47 +35,191 @@ export class TradeFeedService {
      }
  
      private connect() {
@@ -1445,20 +1451,24 @@ index 1ef4b81..f15d8f2 100644
 -        
 -        this.socket.on("connect", this.onConnect);
 -        this.socket.on("disconnect", this.onDisconnect);
+-        this.socket.on("reconnect_attempt", this.onReconnectAttempt);
 +        if (this.socket && (this.socket.readyState === WebSocket.OPEN || this.socket.readyState === WebSocket.CONNECTING)) {
 +            return;
 +        }
-+        const ws = new WebSocket(environment.tradeFeedUrl);
++        this.connectionStateSubject.next('connecting');
++        const wsUrl = this.resolveWebSocketUrl(environment.tradeFeedUrl);
++        const ws = new WebSocket(wsUrl);
 +        this.socket = ws;
 +
 +        ws.onopen = () => {
 +            this.connected = true;
++            this.connectionStateSubject.next('connected');
 +            this.pendingData = '';
 +            this.pendingMsg = null;
 +            this.sendRaw('CONNECT {"protocol":1,"verbose":false,"pedantic":false,"echo":false}\r\n');
 +            this.sendRaw('PING\r\n');
 +            this.resubscribeAll();
-+            console.log(`Trade feed (NATS websocket) connected: ${environment.tradeFeedUrl}`);
++            console.log(`Trade feed (NATS websocket) connected: ${wsUrl}`);
 +        };
 +
 +        ws.onmessage = (event) => {
@@ -1471,6 +1481,7 @@ index 1ef4b81..f15d8f2 100644
 +
 +        ws.onclose = () => {
 +            this.connected = false;
++            this.connectionStateSubject.next('disconnected');
 +            this.pendingData = '';
 +            this.pendingMsg = null;
 +            this.scheduleReconnect();
@@ -1479,7 +1490,24 @@ index 1ef4b81..f15d8f2 100644
      }
  
 -    private onConnect = () => {
+-        this.connectionStateSubject.next('connected');
 -        console.log('Trade feed is connected, connection id' + this.socket.id);
++    private resolveWebSocketUrl(configuredUrl: string): string {
++        const targetProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
++        const fallback = `${targetProtocol}//${window.location.host}/nats-ws`;
++
++        try {
++            const parsed = new URL(configuredUrl, window.location.href);
++            parsed.protocol = targetProtocol;
++            return parsed.toString();
++        } catch (_error) {
++            return fallback;
++        }
+     }
+ 
+-    private onDisconnect = () => {
+-        this.connectionStateSubject.next('disconnected');
+-        console.log('Trade feed is disconnected, connection id was ' + this.socket.id);
 +    private scheduleReconnect() {
 +        if (this.reconnectTimer !== null) {
 +            window.clearTimeout(this.reconnectTimer);
@@ -1490,8 +1518,8 @@ index 1ef4b81..f15d8f2 100644
 +        }, 1000);
      }
  
--    private onDisconnect = () => {
--        console.log('Trade feed is disconnected, connection id was ' + this.socket.id);
+-    private onReconnectAttempt = () => {
+-        this.connectionStateSubject.next('connecting');
 +    private sendRaw(payload: string) {
 +        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
 +            return;
@@ -1635,15 +1663,10 @@ index 1ef4b81..f15d8f2 100644
      }
  }
 diff --git a/web-front-end/angular/main/environments/environment.local.ts b/web-front-end/angular/main/environments/environment.local.ts
-index 2c08cc2..9b2052e 100644
+index dfa1719..78bc857 100644
 --- a/web-front-end/angular/main/environments/environment.local.ts
 +++ b/web-front-end/angular/main/environments/environment.local.ts
-@@ -1,4 +1,3 @@
--// State 002 overlay: route browser traffic through edge proxy endpoint.
- export const environment = {
-     production:         false,
-     accountUrl:         `//${window.location.host}/account-service`,
-@@ -6,5 +5,5 @@ export const environment = {
+@@ -8,5 +8,5 @@ export const environment: Environment = {
      tradesUrl:          `//${window.location.host}/trade-service/trade/`,
      positionsUrl:       `//${window.location.host}/position-service`,
      peopleUrl:          `//${window.location.host}/people-service`,
@@ -1651,10 +1674,10 @@ index 2c08cc2..9b2052e 100644
 +    tradeFeedUrl:       `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}/nats-ws`
  };
 diff --git a/web-front-end/angular/main/environments/environment.prod.ts b/web-front-end/angular/main/environments/environment.prod.ts
-index 9d15bb8..b884df5 100644
+index 1476013..08b7774 100644
 --- a/web-front-end/angular/main/environments/environment.prod.ts
 +++ b/web-front-end/angular/main/environments/environment.prod.ts
-@@ -5,5 +5,5 @@ export const environment = {
+@@ -7,5 +7,5 @@ export const environment: Environment = {
      tradesUrl:          `//${window.location.host}/trade-service/trade/`,
      positionsUrl:       `//${window.location.host}/position-service`,
      peopleUrl:          `//${window.location.host}/people-service`,
@@ -1662,18 +1685,15 @@ index 9d15bb8..b884df5 100644
 +    tradeFeedUrl:       `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}/nats-ws`
  };
 diff --git a/web-front-end/angular/main/environments/environment.ts b/web-front-end/angular/main/environments/environment.ts
-index 2c08cc2..9b2052e 100644
+index dac53a6..6b880f2 100644
 --- a/web-front-end/angular/main/environments/environment.ts
 +++ b/web-front-end/angular/main/environments/environment.ts
-@@ -1,4 +1,3 @@
--// State 002 overlay: route browser traffic through edge proxy endpoint.
- export const environment = {
-     production:         false,
-     accountUrl:         `//${window.location.host}/account-service`,
-@@ -6,5 +5,5 @@ export const environment = {
+@@ -11,7 +11,7 @@ export const environment: Environment = {
      tradesUrl:          `//${window.location.host}/trade-service/trade/`,
      positionsUrl:       `//${window.location.host}/position-service`,
      peopleUrl:          `//${window.location.host}/people-service`,
 -    tradeFeedUrl:       `//${window.location.host}`
 +    tradeFeedUrl:       `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}/nats-ws`
  };
+ 
+ /*


### PR DESCRIPTION
## Summary
- refreshes the state 006 NATS overlay patch against the current state 005 generated output
- keeps the inherited frontend message-bus connection-state contract while switching the transport to NATS websocket
- preserves current dependency targets, including Spring Boot/Log4j/pgJDBC drift fixed by earlier generator PRs

## Validation
- `bash pipeline/generate-state.sh 006-messaging-nats-replacement`
- `bash pipeline/validate-generated-dependency-targets.sh generated/code/components generated/code/target-generated`
