### PR TITLE
Fix prepublish state id numeric comparison

### DIFF
--- a/pipeline/prepublish-generated-state-gate.sh
+++ b/pipeline/prepublish-generated-state-gate.sh
@@ -300,7 +300,7 @@ run_cve_scan() {
     echo "[warn] skipping CVE dependency scan (--skip-cve-scan)"
     return 0
   fi
-  if [[ "${state_num}" -lt 2 ]]; then
+  if [[ "${state_num_decimal}" -lt 2 ]]; then
     echo "[info] CVE dependency scan not required for pre-CI states"
     return 0
   fi


### PR DESCRIPTION
## Summary
- fixes a prepublish gate arithmetic comparison that used zero-padded state IDs directly
- makes the CVE-scan pre-CI check use the already-normalized decimal state number
- prevents Bash from reporting invalid octal values for states such as `008` and `009`

## Validation
- `bash -n pipeline/prepublish-generated-state-gate.sh`
- `bash -c 'state_num=008; state_num_decimal=$((10#${state_num})); [[ "${state_num_decimal}" -lt 2 ]]; test $? -eq 1'`
