### PR TITLE
Import Jackson BOM in state 009 order matcher

### DIFF
--- a/specs/009-order-management-matcher/generation/patches/0001-state-overlay.patch
+++ b/specs/009-order-management-matcher/generation/patches/0001-state-overlay.patch
@@ -2213,6 +2213,7 @@ index 0000000..ac3802f
 +  id 'io.spring.dependency-management' version '1.1.7'
 +}
 +
++ext['jackson-bom.version'] = '2.22.1'
 +ext['tomcat.version'] = '10.1.57'
 +
 +group = 'finos.traderx.order-matcher-specfirst'


### PR DESCRIPTION
## Summary
- import the repo-wide Jackson BOM target in the generated state 009 `order-matcher` module
- resolves generated `jackson-databind` from vulnerable `2.21.4` to `2.22.1`
- fixes the Dependency-Check failure found during generated-state publish

## Validation
- `bash pipeline/generate-state.sh 009-order-management-matcher`
- `./gradlew --no-daemon dependencyInsight --dependency jackson-databind --configuration runtimeClasspath` in generated `order-matcher`
- targeted generated `order-matcher` build plus Dependency-Check Gradle scan with cached `--noupdate`
