### PR TITLE
Keep demo compose stacks alive across reboot + SSH redeploy workflow

### DIFF
--- a/.github/workflows/redeploy-live-demo.yml
+++ b/.github/workflows/redeploy-live-demo.yml
@@ -1,0 +1,56 @@
+name: Redeploy Live Demo
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Demo host to redeploy
+        required: true
+        type: choice
+        options:
+          - demo.traderx.finos.org
+          - demo-advanced.traderx.finos.org
+
+# Requires repository secret DEMO_EC2_SSH_PRIVATE_KEY (PEM private key for ec2-user).
+permissions:
+  contents: read
+
+concurrency:
+  group: redeploy-live-demo-${{ inputs.target }}
+  cancel-in-progress: false
+
+jobs:
+  redeploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Write SSH private key
+        env:
+          DEMO_EC2_SSH_PRIVATE_KEY: ${{ secrets.DEMO_EC2_SSH_PRIVATE_KEY }}
+        run: |
+          if [[ -z "${DEMO_EC2_SSH_PRIVATE_KEY}" ]]; then
+            echo "[fail] repository secret DEMO_EC2_SSH_PRIVATE_KEY is not set"
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${DEMO_EC2_SSH_PRIVATE_KEY}" > ~/.ssh/demo_ec2.pem
+          chmod 600 ~/.ssh/demo_ec2.pem
+
+      - name: Trust host key
+        run: |
+          ssh-keyscan -H "${{ inputs.target }}" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Run ~/redeploy.sh over SSH
+        run: |
+          ssh -i ~/.ssh/demo_ec2.pem \
+            -o IdentitiesOnly=yes \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=yes \
+            "ec2-user@${{ inputs.target }}" \
+            'bash -lc "~/redeploy.sh"'
+
+      - name: Remove SSH private key
+        if: always()
+        run: rm -f ~/.ssh/demo_ec2.pem

--- a/pipeline/install-generated-ci-assets.sh
+++ b/pipeline/install-generated-ci-assets.sh
@@ -899,6 +899,9 @@ write_compose_ghcr_bundle() {
       echo "    extends:"
       echo "      file: ${compose_extends_rel}"
       echo "      service: ${service}"
+      # Keep GHCR demo stacks alive across host reboot even if the extended
+      # compose file is temporarily unavailable on disk.
+      echo "    restart: unless-stopped"
 
       service_has_build="$(
         awk -v svc="${service}" '

--- a/specs/004-containerized-compose-runtime/system/docker-compose.spec.yaml
+++ b/specs/004-containerized-compose-runtime/system/docker-compose.spec.yaml
@@ -2,6 +2,7 @@ name: traderx-state-003
 
 services:
   database:
+    restart: unless-stopped
     build:
       context: ../database
       dockerfile: Dockerfile.compose
@@ -16,6 +17,7 @@ services:
       - "18084:18084"
 
   reference-data:
+    restart: unless-stopped
     build:
       context: ../reference-data
       dockerfile: Dockerfile.compose
@@ -28,6 +30,7 @@ services:
       - database
 
   trade-feed:
+    restart: unless-stopped
     build:
       context: ../trade-feed
       dockerfile: Dockerfile.compose
@@ -38,6 +41,7 @@ services:
       - "18086:18086"
 
   people-service:
+    restart: unless-stopped
     build:
       context: ../people-service
       dockerfile: Dockerfile.compose
@@ -48,6 +52,7 @@ services:
       - "18089:18089"
 
   account-service:
+    restart: unless-stopped
     build:
       context: ../account-service
       dockerfile: Dockerfile.compose
@@ -64,6 +69,7 @@ services:
       - people-service
 
   position-service:
+    restart: unless-stopped
     build:
       context: ../position-service
       dockerfile: Dockerfile.compose
@@ -78,6 +84,7 @@ services:
       - database
 
   trade-processor:
+    restart: unless-stopped
     build:
       context: ../trade-processor
       dockerfile: Dockerfile.compose
@@ -94,6 +101,7 @@ services:
       - trade-feed
 
   trade-service:
+    restart: unless-stopped
     build:
       context: ../trade-service
       dockerfile: Dockerfile.compose
@@ -114,6 +122,7 @@ services:
       - trade-processor
 
   web-front-end-angular:
+    restart: unless-stopped
     build:
       context: ../web-front-end/angular
       dockerfile: Dockerfile.compose
@@ -130,6 +139,7 @@ services:
       - trade-feed
 
   ingress:
+    restart: unless-stopped
     build:
       context: ../ingress
       dockerfile: Dockerfile.compose

--- a/specs/005-postgres-database-replacement/system/docker-compose.postgres.snippet.yaml
+++ b/specs/005-postgres-database-replacement/system/docker-compose.postgres.snippet.yaml
@@ -1,5 +1,6 @@
 services:
   database:
+    restart: unless-stopped
     image: postgres:16-alpine
     environment:
       POSTGRES_DB: "traderx"


### PR DESCRIPTION
- Set `restart: unless-stopped` on generated GHCR compose services so live demos (`demo` / `demo-advanced`) come back after host reboot.
- Align compose specs (004 + postgres snippet) with the same restart policy.
- Add a manual GitHub Action that SSHs as `ec2-user` to a chosen demo host and runs `~/redeploy.sh`.

Repo secret `DEMO_EC2_SSH_PRIVATE_KEY` is already set.

Github action needs testing.