### PR TITLE
Fix generated API explorer context publishing

### DIFF
--- a/pipeline/install-generated-ci-assets.sh
+++ b/pipeline/install-generated-ci-assets.sh
@@ -172,16 +172,16 @@ case "${STATE_ID}" in
     state_allowed_roots=("${ORDER_COMPONENT_DIRS[@]}" "ingress" "order-management-matcher" "postgres-database-replacement")
     ;;
   010-kubernetes-runtime)
-    state_allowed_roots=("${C2_COMPONENT_DIRS[@]}" "kubernetes-runtime")
+    state_allowed_roots=("${C2_COMPONENT_DIRS[@]}" "api-explorer" "kubernetes-runtime")
     ;;
   011-tilt-kubernetes-dev-loop|012-platform-convergence-c3)
-    state_allowed_roots=("${C2_COMPONENT_DIRS[@]}" "kubernetes-runtime" "tilt-kubernetes-dev-loop")
+    state_allowed_roots=("${C2_COMPONENT_DIRS[@]}" "api-explorer" "kubernetes-runtime" "tilt-kubernetes-dev-loop")
     ;;
   013-radius-kubernetes-platform)
-    state_allowed_roots=("${C2_COMPONENT_DIRS[@]}" "kubernetes-runtime" "radius-kubernetes-platform")
+    state_allowed_roots=("${C2_COMPONENT_DIRS[@]}" "api-explorer" "kubernetes-runtime" "radius-kubernetes-platform")
     ;;
   014-fdc3-intent-interoperability)
-    state_allowed_roots=("${C2_COMPONENT_DIRS[@]}" "kubernetes-runtime" "tilt-kubernetes-dev-loop" "fdc3-intent-interoperability")
+    state_allowed_roots=("${C2_COMPONENT_DIRS[@]}" "api-explorer" "kubernetes-runtime" "tilt-kubernetes-dev-loop" "fdc3-intent-interoperability")
     ;;
 esac
 

--- a/pipeline/publish-generated-state-branch.sh
+++ b/pipeline/publish-generated-state-branch.sh
@@ -39,6 +39,8 @@ SKIP_PREPUBLISH_GATE="${TRADERX_SKIP_PREPUBLISH_GATE:-0}"
 SKIP_RUNTIME_PREFLIGHT="${TRADERX_SKIP_RUNTIME_PREFLIGHT:-0}"
 SKIP_CONTRACT_VALIDATION="${TRADERX_SKIP_CONTRACT_VALIDATION:-0}"
 SKIP_LINEAGE_VALIDATION="${TRADERX_SKIP_LINEAGE_VALIDATION:-0}"
+PUBLISH_SNAPSHOT_FIXTURE_ROOT="${TRADERX_PUBLISH_SNAPSHOT_FIXTURE_ROOT:-}"
+PUBLISH_VALIDATE_SNAPSHOT_ONLY="${TRADERX_PUBLISH_VALIDATE_SNAPSHOT_ONLY:-0}"
 
 while (( "$#" )); do
   case "$1" in
@@ -145,125 +147,139 @@ if [[ "${GEN_MODE}" != "implemented" ]]; then
   exit 1
 fi
 
-if [[ -n "$(git -C "${ROOT}" status --porcelain)" ]]; then
+if [[ -n "${PUBLISH_SNAPSHOT_FIXTURE_ROOT}" && ! -d "${PUBLISH_SNAPSHOT_FIXTURE_ROOT}" ]]; then
+  echo "[fail] snapshot fixture root does not exist: ${PUBLISH_SNAPSHOT_FIXTURE_ROOT}"
+  exit 1
+fi
+
+if [[ -n "${PUBLISH_SNAPSHOT_FIXTURE_ROOT}" && "${PUBLISH_VALIDATE_SNAPSHOT_ONLY}" != "1" ]]; then
+  echo "[fail] snapshot fixture root is only supported with TRADERX_PUBLISH_VALIDATE_SNAPSHOT_ONLY=1"
+  exit 1
+fi
+
+if [[ -z "${PUBLISH_SNAPSHOT_FIXTURE_ROOT}" && -n "$(git -C "${ROOT}" status --porcelain)" ]]; then
   echo "[fail] working tree must be clean before publishing generated-state branch."
   echo "[hint] commit or stash current changes and retry."
   exit 1
 fi
 
-echo "[info] generating state ${STATE_ID} (${STATE_TITLE})"
-case "${STATE_ID}" in
-  001-baseline-uncontainerized-parity)
-    bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
-    if [[ "${SKIP_RUNTIME_PREFLIGHT}" == "1" ]]; then
-      echo "[warn] skipping runtime preflight (--skip-runtime-preflight)"
-    else
-      "${ROOT}/scripts/start-base-uncontainerized-generated.sh" --build-only
-      "${ROOT}/scripts/start-base-uncontainerized-generated.sh" --dry-run
-    fi
-    ;;
-  002-edge-proxy-uncontainerized)
-    bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
-    if [[ "${SKIP_RUNTIME_PREFLIGHT}" == "1" ]]; then
-      echo "[warn] skipping runtime preflight (--skip-runtime-preflight)"
-    else
-      "${ROOT}/scripts/start-state-002-edge-proxy-generated.sh" --build-only
-      "${ROOT}/scripts/start-state-002-edge-proxy-generated.sh" --dry-run
-    fi
-    ;;
-  003-agentic-harness-foundation)
-    bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
-    if [[ "${SKIP_RUNTIME_PREFLIGHT}" == "1" ]]; then
-      echo "[warn] skipping runtime preflight (--skip-runtime-preflight)"
-    else
-      "${ROOT}/scripts/start-state-003-agentic-harness-foundation-generated.sh" --build-only
-      "${ROOT}/scripts/start-state-003-agentic-harness-foundation-generated.sh" --dry-run
-    fi
-    ;;
-  004-containerized-compose-runtime)
-    bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
-    [[ -f "${GENERATED_ROOT}/code/target-generated/containerized-compose/docker-compose.yml" ]] || {
-      echo "[fail] missing generated compose file for state 004"
-      exit 1
-    }
-    ;;
-  010-kubernetes-runtime)
-    bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
-    [[ -f "${GENERATED_ROOT}/code/target-generated/kubernetes-runtime/build-plan.json" ]] || {
-      echo "[fail] missing generated kubernetes build-plan for state 010"
-      exit 1
-    }
-    if [[ "${SKIP_RUNTIME_PREFLIGHT}" == "1" ]]; then
-      echo "[warn] skipping runtime preflight (--skip-runtime-preflight)"
-    else
-      "${ROOT}/scripts/start-state-010-kubernetes-runtime-generated.sh" --dry-run
-    fi
-    ;;
-  013-radius-kubernetes-platform)
-    bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
-    [[ -f "${GENERATED_ROOT}/code/target-generated/radius-kubernetes-platform/radius/app.bicep" ]] || {
-      echo "[fail] missing generated radius app model for state 013"
-      exit 1
-    }
-    ;;
-  011-tilt-kubernetes-dev-loop)
-    bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
-    [[ -f "${GENERATED_ROOT}/code/target-generated/tilt-kubernetes-dev-loop/tilt/Tiltfile" ]] || {
-      echo "[fail] missing generated tilt assets for state 011"
-      exit 1
-    }
-    ;;
-  *)
-    bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
-    RUNTIME_START_SCRIPT="${ROOT}/scripts/start-state-${STATE_ID}-generated.sh"
-    if [[ "${SKIP_RUNTIME_PREFLIGHT}" == "1" ]]; then
-      echo "[warn] skipping runtime preflight (--skip-runtime-preflight)"
-    elif [[ -x "${RUNTIME_START_SCRIPT}" ]]; then
-      "${RUNTIME_START_SCRIPT}" --dry-run || true
-    else
-      echo "[info] no state-specific start script found at ${RUNTIME_START_SCRIPT}; skipping runtime dry-run"
-    fi
-    ;;
-esac
-
-# Recompute CI assets after runtime dry-run because some states (notably
-# uncontainerized 002/003 lineage) materialize runnable component layout into
-# target-generated during dry-run. Without this refresh, workflow target
-# discovery may emit "no targets" stubs.
-bash "${ROOT}/pipeline/install-generated-ci-assets.sh" "${STATE_ID}" "${GENERATED_ROOT}/code/target-generated"
-
-if [[ "${SKIP_PREPUBLISH_GATE}" == "1" ]]; then
-  echo "[warn] skipping prepublish generated-state gate (--skip-prepublish-gate)"
-  if [[ "${SKIP_CONTRACT_VALIDATION}" == "1" ]]; then
-    echo "[warn] skipping generated-state contract validation (--skip-contract-validation)"
-  else
-    bash "${ROOT}/pipeline/validate-generated-state-contracts.sh" "${GENERATED_ROOT}/code/target-generated"
-  fi
-  if [[ "${SKIP_COMPILE_PREFLIGHT}" == "1" ]]; then
-    echo "[warn] skipping generated compile preflight (--skip-compile-preflight)"
-  else
-    CI_METADATA="${GENERATED_ROOT}/code/target-generated/ci/state-metadata.json"
-    if [[ -f "${CI_METADATA}" ]]; then
-      echo "[step] run generated compile preflight"
-      bash "${ROOT}/pipeline/preflight-generated-ci.sh" "${GENERATED_ROOT}/code/target-generated"
-    elif [[ "${state_num}" -lt 2 ]]; then
-      echo "[info] compile preflight metadata unavailable for ${STATE_ID}; skipping for legacy pre-CI state"
-    else
-      echo "[fail] missing compile preflight metadata: ${CI_METADATA}"
-      echo "[hint] ensure CI assets were installed during state generation"
-      exit 1
-    fi
-  fi
+if [[ -n "${PUBLISH_SNAPSHOT_FIXTURE_ROOT}" ]]; then
+  echo "[info] using snapshot fixture root for ${STATE_ID}: ${PUBLISH_SNAPSHOT_FIXTURE_ROOT}"
 else
-  prepublish_args=("${STATE_ID}" "--target-root" "${GENERATED_ROOT}/code/target-generated" "--components-root" "${GENERATED_ROOT}/code/components")
-  if [[ "${SKIP_COMPILE_PREFLIGHT}" == "1" ]]; then
-    prepublish_args+=("--skip-compile-preflight")
+  echo "[info] generating state ${STATE_ID} (${STATE_TITLE})"
+  case "${STATE_ID}" in
+    001-baseline-uncontainerized-parity)
+      bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
+      if [[ "${SKIP_RUNTIME_PREFLIGHT}" == "1" ]]; then
+        echo "[warn] skipping runtime preflight (--skip-runtime-preflight)"
+      else
+        "${ROOT}/scripts/start-base-uncontainerized-generated.sh" --build-only
+        "${ROOT}/scripts/start-base-uncontainerized-generated.sh" --dry-run
+      fi
+      ;;
+    002-edge-proxy-uncontainerized)
+      bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
+      if [[ "${SKIP_RUNTIME_PREFLIGHT}" == "1" ]]; then
+        echo "[warn] skipping runtime preflight (--skip-runtime-preflight)"
+      else
+        "${ROOT}/scripts/start-state-002-edge-proxy-generated.sh" --build-only
+        "${ROOT}/scripts/start-state-002-edge-proxy-generated.sh" --dry-run
+      fi
+      ;;
+    003-agentic-harness-foundation)
+      bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
+      if [[ "${SKIP_RUNTIME_PREFLIGHT}" == "1" ]]; then
+        echo "[warn] skipping runtime preflight (--skip-runtime-preflight)"
+      else
+        "${ROOT}/scripts/start-state-003-agentic-harness-foundation-generated.sh" --build-only
+        "${ROOT}/scripts/start-state-003-agentic-harness-foundation-generated.sh" --dry-run
+      fi
+      ;;
+    004-containerized-compose-runtime)
+      bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
+      [[ -f "${GENERATED_ROOT}/code/target-generated/containerized-compose/docker-compose.yml" ]] || {
+        echo "[fail] missing generated compose file for state 004"
+        exit 1
+      }
+      ;;
+    010-kubernetes-runtime)
+      bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
+      [[ -f "${GENERATED_ROOT}/code/target-generated/kubernetes-runtime/build-plan.json" ]] || {
+        echo "[fail] missing generated kubernetes build-plan for state 010"
+        exit 1
+      }
+      if [[ "${SKIP_RUNTIME_PREFLIGHT}" == "1" ]]; then
+        echo "[warn] skipping runtime preflight (--skip-runtime-preflight)"
+      else
+        "${ROOT}/scripts/start-state-010-kubernetes-runtime-generated.sh" --dry-run
+      fi
+      ;;
+    013-radius-kubernetes-platform)
+      bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
+      [[ -f "${GENERATED_ROOT}/code/target-generated/radius-kubernetes-platform/radius/app.bicep" ]] || {
+        echo "[fail] missing generated radius app model for state 013"
+        exit 1
+      }
+      ;;
+    011-tilt-kubernetes-dev-loop)
+      bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
+      [[ -f "${GENERATED_ROOT}/code/target-generated/tilt-kubernetes-dev-loop/tilt/Tiltfile" ]] || {
+        echo "[fail] missing generated tilt assets for state 011"
+        exit 1
+      }
+      ;;
+    *)
+      bash "${ROOT}/pipeline/generate-state.sh" "${STATE_ID}"
+      RUNTIME_START_SCRIPT="${ROOT}/scripts/start-state-${STATE_ID}-generated.sh"
+      if [[ "${SKIP_RUNTIME_PREFLIGHT}" == "1" ]]; then
+        echo "[warn] skipping runtime preflight (--skip-runtime-preflight)"
+      elif [[ -x "${RUNTIME_START_SCRIPT}" ]]; then
+        "${RUNTIME_START_SCRIPT}" --dry-run || true
+      else
+        echo "[info] no state-specific start script found at ${RUNTIME_START_SCRIPT}; skipping runtime dry-run"
+      fi
+      ;;
+  esac
+
+  # Recompute CI assets after runtime dry-run because some states (notably
+  # uncontainerized 002/003 lineage) materialize runnable component layout into
+  # target-generated during dry-run. Without this refresh, workflow target
+  # discovery may emit "no targets" stubs.
+  bash "${ROOT}/pipeline/install-generated-ci-assets.sh" "${STATE_ID}" "${GENERATED_ROOT}/code/target-generated"
+
+  if [[ "${SKIP_PREPUBLISH_GATE}" == "1" ]]; then
+    echo "[warn] skipping prepublish generated-state gate (--skip-prepublish-gate)"
+    if [[ "${SKIP_CONTRACT_VALIDATION}" == "1" ]]; then
+      echo "[warn] skipping generated-state contract validation (--skip-contract-validation)"
+    else
+      bash "${ROOT}/pipeline/validate-generated-state-contracts.sh" "${GENERATED_ROOT}/code/target-generated"
+    fi
+    if [[ "${SKIP_COMPILE_PREFLIGHT}" == "1" ]]; then
+      echo "[warn] skipping generated compile preflight (--skip-compile-preflight)"
+    else
+      CI_METADATA="${GENERATED_ROOT}/code/target-generated/ci/state-metadata.json"
+      if [[ -f "${CI_METADATA}" ]]; then
+        echo "[step] run generated compile preflight"
+        bash "${ROOT}/pipeline/preflight-generated-ci.sh" "${GENERATED_ROOT}/code/target-generated"
+      elif [[ "${state_num}" -lt 2 ]]; then
+        echo "[info] compile preflight metadata unavailable for ${STATE_ID}; skipping for legacy pre-CI state"
+      else
+        echo "[fail] missing compile preflight metadata: ${CI_METADATA}"
+        echo "[hint] ensure CI assets were installed during state generation"
+        exit 1
+      fi
+    fi
+  else
+    prepublish_args=("${STATE_ID}" "--target-root" "${GENERATED_ROOT}/code/target-generated" "--components-root" "${GENERATED_ROOT}/code/components")
+    if [[ "${SKIP_COMPILE_PREFLIGHT}" == "1" ]]; then
+      prepublish_args+=("--skip-compile-preflight")
+    fi
+    echo "[step] run prepublish generated-state gate"
+    bash "${ROOT}/pipeline/prepublish-generated-state-gate.sh" "${prepublish_args[@]}"
   fi
-  echo "[step] run prepublish generated-state gate"
-  bash "${ROOT}/pipeline/prepublish-generated-state-gate.sh" "${prepublish_args[@]}"
 fi
 
-SNAPSHOT_ROOT="${GENERATED_ROOT}/code/target-generated"
+SNAPSHOT_ROOT="${PUBLISH_SNAPSHOT_FIXTURE_ROOT:-${GENERATED_ROOT}/code/target-generated}"
 if [[ ! -d "${SNAPSHOT_ROOT}" ]]; then
   echo "[fail] missing generated target directory: ${SNAPSHOT_ROOT}"
   exit 1
@@ -310,19 +326,21 @@ ensure_generated_root_branch() {
   echo "[ok] created generated root branch ${root_branch}"
 }
 
-ensure_generated_root_branch "${GENERATED_ROOT_BRANCH}"
-
 BASE_BRANCH="${GENERATED_ROOT_BRANCH}"
 if [[ -n "${PRIMARY_PREVIOUS_BRANCH}" ]]; then
   BASE_BRANCH="${PRIMARY_PREVIOUS_BRANCH}"
 fi
 
-if ! ensure_local_branch_ref "${BASE_BRANCH}"; then
-  echo "[fail] base branch ${BASE_BRANCH} not found locally or on origin"
-  if [[ -n "${PRIMARY_PREVIOUS_STATE_ID}" ]]; then
-    echo "[hint] publish parent state first: ${PRIMARY_PREVIOUS_STATE_ID}"
+if [[ "${PUBLISH_VALIDATE_SNAPSHOT_ONLY}" != "1" ]]; then
+  ensure_generated_root_branch "${GENERATED_ROOT_BRANCH}"
+
+  if ! ensure_local_branch_ref "${BASE_BRANCH}"; then
+    echo "[fail] base branch ${BASE_BRANCH} not found locally or on origin"
+    if [[ -n "${PRIMARY_PREVIOUS_STATE_ID}" ]]; then
+      echo "[hint] publish parent state first: ${PRIMARY_PREVIOUS_STATE_ID}"
+    fi
+    exit 1
   fi
-  exit 1
 fi
 
 cp -R "${SNAPSHOT_ROOT}/." "${SNAPSHOT_DIR}/"
@@ -432,19 +450,19 @@ snapshot_keep_paths_for_state() {
     printf '%s\n' "${ORDER_COMPONENT_DIRS[@]}" "ingress" "order-management-matcher" "postgres-database-replacement" ".github" "runtime"
     ;;
     010-kubernetes-runtime)
-      printf '%s\n' "${C2_COMPONENT_DIRS[@]}" "kubernetes-runtime" ".github"
+      printf '%s\n' "${C2_COMPONENT_DIRS[@]}" "api-explorer" "kubernetes-runtime" ".github"
       ;;
     011-tilt-kubernetes-dev-loop)
-      printf '%s\n' "${C2_COMPONENT_DIRS[@]}" "kubernetes-runtime" "tilt-kubernetes-dev-loop" ".github"
+      printf '%s\n' "${C2_COMPONENT_DIRS[@]}" "api-explorer" "kubernetes-runtime" "tilt-kubernetes-dev-loop" ".github"
       ;;
     012-platform-convergence-c3)
-      printf '%s\n' "${C2_COMPONENT_DIRS[@]}" "kubernetes-runtime" "tilt-kubernetes-dev-loop" ".github" "runtime"
+      printf '%s\n' "${C2_COMPONENT_DIRS[@]}" "api-explorer" "kubernetes-runtime" "tilt-kubernetes-dev-loop" ".github" "runtime"
       ;;
   013-radius-kubernetes-platform)
-      printf '%s\n' "${C2_COMPONENT_DIRS[@]}" "kubernetes-runtime" "radius-kubernetes-platform" ".github"
+      printf '%s\n' "${C2_COMPONENT_DIRS[@]}" "api-explorer" "kubernetes-runtime" "radius-kubernetes-platform" ".github"
       ;;
     014-fdc3-intent-interoperability)
-      printf '%s\n' "${C2_COMPONENT_DIRS[@]}" "kubernetes-runtime" "tilt-kubernetes-dev-loop" "fdc3-intent-interoperability" ".github" "runtime"
+      printf '%s\n' "${C2_COMPONENT_DIRS[@]}" "api-explorer" "kubernetes-runtime" "tilt-kubernetes-dev-loop" "fdc3-intent-interoperability" ".github" "runtime"
       ;;
     *)
       echo "[fail] missing explicit snapshot keep-path policy for ${STATE_ID}"
@@ -547,8 +565,66 @@ assert_snapshot_size_guardrails() {
   fi
 }
 
+validate_snapshot_build_plan_contexts() {
+  local build_plan="${SNAPSHOT_DIR}/kubernetes-runtime/build-plan.json"
+  if [[ ! -f "${build_plan}" ]]; then
+    return 0
+  fi
+
+  if ! jq -e '
+    (.images | type == "array")
+    and all(.images[]; (
+      type == "object"
+      and (.name | type == "string" and length > 0)
+      and (.context | type == "string" and length > 0)
+      and (.dockerfile | type == "string" and length > 0)
+    ))
+  ' "${build_plan}" >/dev/null; then
+    echo "[fail] kubernetes build plan must contain images[] entries with non-empty string name, context, and dockerfile fields: ${build_plan}"
+    exit 1
+  fi
+
+  local item name context_rel dockerfile_rel context_abs dockerfile_abs
+  while IFS= read -r item; do
+    name="$(jq -r '.name' <<<"${item}")"
+    context_rel="$(jq -r '.context' <<<"${item}")"
+    dockerfile_rel="$(jq -r '.dockerfile' <<<"${item}")"
+    case "${context_rel}" in
+      /*|*../*)
+        echo "[fail] kubernetes build plan context for ${name} must stay inside snapshot root: ${context_rel}"
+        exit 1
+        ;;
+    esac
+    case "${dockerfile_rel}" in
+      /*|*../*)
+        echo "[fail] kubernetes build plan dockerfile for ${name} must stay inside its context: ${dockerfile_rel}"
+        exit 1
+        ;;
+    esac
+    context_abs="${SNAPSHOT_DIR}/${context_rel}"
+    dockerfile_abs="${context_abs}/${dockerfile_rel}"
+
+    [[ -d "${context_abs}" ]] || {
+      echo "[fail] kubernetes build plan references missing context for ${name}: ${context_rel}"
+      echo "[hint] update snapshot keep-path policy or build-plan context before publishing ${STATE_ID}"
+      exit 1
+    }
+    [[ -f "${dockerfile_abs}" ]] || {
+      echo "[fail] kubernetes build plan references missing dockerfile for ${name}: ${context_rel}/${dockerfile_rel}"
+      echo "[hint] update generated artifacts before publishing ${STATE_ID}"
+      exit 1
+    }
+  done < <(jq -c '.images[]' "${build_plan}")
+}
+
 remove_snapshot_transient_artifacts
 assert_snapshot_size_guardrails
+validate_snapshot_build_plan_contexts
+
+if [[ "${PUBLISH_VALIDATE_SNAPSHOT_ONLY}" == "1" ]]; then
+  echo "[done] snapshot validation fixture passed for ${STATE_ID}"
+  exit 0
+fi
 
 SOURCE_COMMIT="$(git -C "${ROOT}" rev-parse HEAD)"
 SOURCE_BRANCH="$(git -C "${ROOT}" branch --show-current)"

--- a/pipeline/speckit/validate-root-spec-kit-gates.sh
+++ b/pipeline/speckit/validate-root-spec-kit-gates.sh
@@ -95,6 +95,7 @@ fi
 bash "${REPO_ROOT}/pipeline/validate-state-doc-consistency.sh"
 bash "${REPO_ROOT}/pipeline/smoke-dependency-version-targets.sh"
 bash "${REPO_ROOT}/pipeline/validate-generated-state-lineage-invariants.sh" --policy-only
+bash "${REPO_ROOT}/scripts/test-publish-generated-state-branch.sh"
 bash "${REPO_ROOT}/pipeline/validate-sail-pin-contract.sh"
 
 echo "[ok] root Spec Kit quality gates passed (feature=${FEATURE_ID}, branch=${branch_name})"

--- a/scripts/test-generated-ci-assets.sh
+++ b/scripts/test-generated-ci-assets.sh
@@ -167,6 +167,43 @@ if rg -qi 'token|password' "${TARGET_ROOT}/runtime/deploy/aws-ec2-compose/deploy
   exit 1
 fi
 
+echo "[check] state 012 preserves local api-explorer without publishing it"
+rm -rf "${TARGET_ROOT}"
+mkdir -p \
+  "${TARGET_ROOT}/api-explorer" \
+  "${TARGET_ROOT}/ingress" \
+  "${TARGET_ROOT}/scripts"
+touch \
+  "${TARGET_ROOT}/api-explorer/Dockerfile" \
+  "${TARGET_ROOT}/ingress/Dockerfile.compose"
+cat > "${TARGET_ROOT}/scripts/start-state-012-platform-convergence-c3-generated.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+TRADERX_USE_PUBLISHED_IMAGES="${TRADERX_USE_PUBLISHED_IMAGES:-0}"
+TRADERX_PUBLISHED_NAMESPACE="${TRADERX_PUBLISHED_NAMESPACE:-}"
+TRADERX_PUBLISHED_TAG="${TRADERX_PUBLISHED_TAG:-latest}"
+
+echo "published image mode: ${TRADERX_USE_PUBLISHED_IMAGES} ${TRADERX_PUBLISHED_NAMESPACE} ${TRADERX_PUBLISHED_TAG}"
+EOF
+
+bash "${ROOT}/pipeline/install-generated-ci-assets.sh" 012-platform-convergence-c3 "${TARGET_ROOT}"
+
+grep -q 'directory: ingress' "${TARGET_ROOT}/.github/workflows/build-and-publish.yml" || {
+  echo "[fail] state 012 should publish retained ingress container image"
+  exit 1
+}
+
+if grep -q 'directory: api-explorer' "${TARGET_ROOT}/.github/workflows/build-and-publish.yml"; then
+  echo "[fail] api-explorer should remain a local runtime build context, not a published image"
+  exit 1
+fi
+
+grep -q 'ingress=ghcr.io/finos/traderx-c3/ingress:latest' "${TARGET_ROOT}/runtime/ghcr/012-platform-convergence-c3/images.lock" || {
+  echo "[fail] state 012 GHCR image map should include publishable ingress image"
+  exit 1
+}
+
 echo "[check] generated-state contract validation guards order-matcher schema"
 mkdir -p "${TARGET_ROOT}/order-matcher" "${TARGET_ROOT}/database" "${TARGET_ROOT}/ci"
 cat > "${TARGET_ROOT}/ci/state-metadata.json" <<'EOF'

--- a/scripts/test-publish-generated-state-branch.sh
+++ b/scripts/test-publish-generated-state-branch.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d /tmp/traderx-publish-state.XXXXXX)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+STATE_ID="012-platform-convergence-c3"
+
+make_state_012_fixture() {
+  local fixture_root="$1"
+  local context_rel="${2:-api-explorer}"
+  local dockerfile_rel="${3:-Dockerfile}"
+
+  rm -rf "${fixture_root}"
+  mkdir -p \
+    "${fixture_root}/.github" \
+    "${fixture_root}/account-service" \
+    "${fixture_root}/api-explorer" \
+    "${fixture_root}/database" \
+    "${fixture_root}/ingress" \
+    "${fixture_root}/kubernetes-runtime" \
+    "${fixture_root}/order-matcher" \
+    "${fixture_root}/people-service" \
+    "${fixture_root}/position-service" \
+    "${fixture_root}/price-publisher" \
+    "${fixture_root}/reference-data" \
+    "${fixture_root}/runtime" \
+    "${fixture_root}/tilt-kubernetes-dev-loop" \
+    "${fixture_root}/trade-processor" \
+    "${fixture_root}/trade-service" \
+    "${fixture_root}/web-front-end" \
+    "${fixture_root}/will-be-pruned"
+
+  touch "${fixture_root}/api-explorer/Dockerfile"
+  cat > "${fixture_root}/kubernetes-runtime/build-plan.json" <<EOF
+{
+  "images": [
+    {
+      "name": "api-explorer",
+      "image": "traderx-api-explorer:local",
+      "context": "${context_rel}",
+      "dockerfile": "${dockerfile_rel}"
+    }
+  ]
+}
+EOF
+}
+
+run_publish_fixture() {
+  local fixture_root="$1"
+  TRADERX_PUBLISH_SNAPSHOT_FIXTURE_ROOT="${fixture_root}" \
+  TRADERX_PUBLISH_VALIDATE_SNAPSHOT_ONLY=1 \
+    bash "${ROOT}/pipeline/publish-generated-state-branch.sh" "${STATE_ID}"
+}
+
+expect_publish_fixture_failure() {
+  local fixture_root="$1"
+  local expected_message="$2"
+  local log_file="${TMP_DIR}/failure.log"
+
+  set +e
+  run_publish_fixture "${fixture_root}" >"${log_file}" 2>&1
+  local exit_code=$?
+  set -e
+
+  if [[ "${exit_code}" -eq 0 ]]; then
+    echo "[fail] expected publisher fixture validation to fail"
+    cat "${log_file}"
+    exit 1
+  fi
+
+  grep -q "${expected_message}" "${log_file}" || {
+    echo "[fail] expected failure output to contain: ${expected_message}"
+    cat "${log_file}"
+    exit 1
+  }
+}
+
+echo "[check] publisher keeps api-explorer build context through state pruning"
+valid_fixture="${TMP_DIR}/valid"
+make_state_012_fixture "${valid_fixture}"
+run_publish_fixture "${valid_fixture}" >/dev/null
+
+echo "[check] publisher rejects missing build-plan context"
+missing_context_fixture="${TMP_DIR}/missing-context"
+make_state_012_fixture "${missing_context_fixture}" "missing-context" "Dockerfile"
+expect_publish_fixture_failure "${missing_context_fixture}" "references missing context"
+
+echo "[check] publisher rejects missing build-plan dockerfile"
+missing_dockerfile_fixture="${TMP_DIR}/missing-dockerfile"
+make_state_012_fixture "${missing_dockerfile_fixture}" "api-explorer" "Missing.Dockerfile"
+expect_publish_fixture_failure "${missing_dockerfile_fixture}" "references missing dockerfile"
+
+echo "[check] publisher rejects build-plan image entries missing required keys"
+missing_key_fixture="${TMP_DIR}/missing-key"
+make_state_012_fixture "${missing_key_fixture}"
+cat > "${missing_key_fixture}/kubernetes-runtime/build-plan.json" <<'EOF'
+{
+  "images": [
+    {
+      "name": "api-explorer",
+      "image": "traderx-api-explorer:local",
+      "dockerfile": "Dockerfile"
+    }
+  ]
+}
+EOF
+expect_publish_fixture_failure "${missing_key_fixture}" "kubernetes build plan must contain"
+
+echo "[check] publisher rejects malformed kubernetes build plan"
+malformed_fixture="${TMP_DIR}/malformed"
+make_state_012_fixture "${malformed_fixture}"
+printf '{bad json' > "${malformed_fixture}/kubernetes-runtime/build-plan.json"
+expect_publish_fixture_failure "${malformed_fixture}" "kubernetes build plan must contain"
+
+echo "[done] generated-state publisher snapshot checks passed"


### PR DESCRIPTION
## Summary
- Preserve the generated top-level `api-explorer/` build context in Kubernetes generated-state snapshots (`010`-`014`).
- Add a publisher validation guard that fails before publishing if `kubernetes-runtime/build-plan.json` references a missing context or Dockerfile.
- Allow `api-explorer/` in generated CI asset root policy while keeping it out of the container publish matrix, with a state-012 regression test.

Refs #456.

Note: this fixes the generator/publisher path. After merge, the affected generated-state branches still need to be regenerated/republished so `code/generated-state-012-platform-convergence-c3` receives the preserved `api-explorer/` context.

## Validation
- `bash scripts/test-generated-ci-assets.sh`
- `tools/validate-frontmatter.sh`
- `bash pipeline/speckit/validate-root-spec-kit-gates.sh`
- `bash pipeline/speckit/validate-speckit-readiness.sh`
- `bash pipeline/verify-spec-coverage.sh`
- `git diff --check`